### PR TITLE
Map only if necessary

### DIFF
--- a/docs/changelog/1899.md
+++ b/docs/changelog/1899.md
@@ -1,0 +1,2 @@
+- Fixed write-data samples being generated for substeps even in case they are never exchanged.
+- Fixed remapping of a time windows initial data sample in implicit coupling schemes.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -9,9 +9,9 @@
 #include <sstream>
 #include <utility>
 
-#include "BaseCouplingScheme.hpp"
 #include "acceleration/Acceleration.hpp"
 #include "com/SerializedStamples.hpp"
+#include "cplscheme/BaseCouplingScheme.hpp"
 #include "cplscheme/Constants.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "cplscheme/CouplingScheme.hpp"
@@ -854,6 +854,33 @@ void BaseCouplingScheme::receiveConvergence(const m2n::PtrM2N &m2n)
 double BaseCouplingScheme::getWindowEndTime() const
 {
   return _timeWindowStartTime + getTimeWindowSize();
+}
+
+bool BaseCouplingScheme::requiresSubsteps() const
+{
+  // Global toggle if a single send data uses substeps
+  for (auto cpldata : _allData | boost::adaptors::map_values) {
+    if (cpldata->getDirection() == CouplingData::Direction::Send && cpldata->exchangeSubsteps()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ImplicitData BaseCouplingScheme::implicitDataToReceive() const
+{
+  // This implementation covers everything except SerialImplicit
+  if (!isImplicitCouplingScheme()) {
+    return {};
+  }
+
+  ImplicitData idata;
+  for (auto cpldata : _allData | boost::adaptors::map_values) {
+    if (cpldata->getDirection() == CouplingData::Direction::Receive) {
+      idata.add(cpldata->getDataID(), false);
+    }
+  }
+  return idata;
 }
 
 } // namespace precice::cplscheme

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -396,6 +396,12 @@ protected:
    */
   bool reachedEndOfTimeWindow() const;
 
+  /// @copydoc cplscheme::CouplingScheme::requiresSubsteps()
+  bool requiresSubsteps() const override final;
+
+  /// @copydoc cplscheme::CouplingScheme::implicitDataToReceive()
+  ImplicitData implicitDataToReceive() const override;
+
 private:
   /// Coupling mode used by coupling scheme.
   CouplingMode _couplingMode = Undefined;

--- a/src/cplscheme/BiCouplingScheme.cpp
+++ b/src/cplscheme/BiCouplingScheme.cpp
@@ -109,6 +109,11 @@ DataMap &BiCouplingScheme::getReceiveData()
   return _receiveData;
 }
 
+const DataMap &BiCouplingScheme::getReceiveData() const
+{
+  return _receiveData;
+}
+
 CouplingData *BiCouplingScheme::getSendData(
     DataID dataID)
 {

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -76,6 +76,9 @@ protected:
   /// Returns all data to be received.
   DataMap &getReceiveData();
 
+  /// Returns all data to be received.
+  const DataMap &getReceiveData() const;
+
   /// Sets the values
   CouplingData *getSendData(DataID dataID);
 

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -394,4 +394,22 @@ bool CompositionalCouplingScheme::hasConverged() const
   return _implicitScheme->hasConverged();
 }
 
+bool CompositionalCouplingScheme::requiresSubsteps() const
+{
+  for (auto scheme : allSchemes()) {
+    if (scheme->requiresSubsteps()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ImplicitData CompositionalCouplingScheme::implicitDataToReceive() const
+{
+  if (_implicitScheme) {
+    return _implicitScheme->implicitDataToReceive();
+  }
+  return {};
+}
+
 } // namespace precice::cplscheme

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -204,6 +204,12 @@ public:
   /// True if the implicit scheme has converged or no implicit scheme is defined
   bool hasConverged() const final;
 
+  /// @copydoc cplscheme::CouplingScheme::requiresSubsteps()
+  bool requiresSubsteps() const override final;
+
+  /// @copydoc cplscheme::CouplingScheme::implicitDataToReceive()
+  ImplicitData implicitDataToReceive() const override final;
+
 private:
   mutable logging::Logger _log{"cplscheme::CompositionalCouplingScheme"};
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "com/SharedPointer.hpp"
+#include "cplscheme/ImplicitData.hpp"
 #include "precice/impl/Types.hpp"
 
 namespace precice {
@@ -226,6 +227,12 @@ public:
 
   /// Returns false if the scheme is implicit and hasn't converged
   virtual bool hasConverged() const = 0;
+
+  /// Returns true if any send data of the scheme requires substeps
+  virtual bool requiresSubsteps() const = 0;
+
+  /// Returns a vector of implicit data to receive in the next advance
+  virtual ImplicitData implicitDataToReceive() const = 0;
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/ImplicitData.cpp
+++ b/src/cplscheme/ImplicitData.cpp
@@ -1,0 +1,23 @@
+#include "cplscheme/ImplicitData.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice::cplscheme {
+
+void ImplicitData::add(DataID did, bool toKeep)
+{
+  PRECICE_ASSERT(entries.count(did) == 0);
+  entries[did] = toKeep;
+}
+
+bool ImplicitData::contains(DataID did) const
+{
+  return entries.count(did) > 0;
+}
+
+bool ImplicitData::toKeep(DataID did) const
+{
+  PRECICE_ASSERT(contains(did));
+  return entries.at(did);
+}
+
+} // namespace precice::cplscheme

--- a/src/cplscheme/ImplicitData.hpp
+++ b/src/cplscheme/ImplicitData.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <map>
+
+#include "precice/impl/Types.hpp"
+
+namespace precice::cplscheme {
+
+struct ImplicitData {
+  void add(DataID did, bool toKeep);
+
+  bool contains(DataID did) const;
+  bool toKeep(DataID did) const;
+
+  std::map<DataID, bool> entries;
+};
+
+} // namespace precice::cplscheme

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -1,15 +1,16 @@
-#include "SerialCouplingScheme.hpp"
+#include <boost/range/adaptor/map.hpp>
 #include <cmath>
 #include <memory>
 #include <ostream>
 #include <utility>
-
 #include <vector>
+
 #include "acceleration/Acceleration.hpp"
 #include "acceleration/SharedPointer.hpp"
 #include "cplscheme/BaseCouplingScheme.hpp"
 #include "cplscheme/BiCouplingScheme.hpp"
 #include "cplscheme/CouplingScheme.hpp"
+#include "cplscheme/SerialCouplingScheme.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/M2N.hpp"
 #include "math/differences.hpp"
@@ -201,6 +202,21 @@ DataMap &SerialCouplingScheme::getAccelerationData()
 {
   // SerialCouplingSchemes applies acceleration to send data
   return getSendData();
+}
+
+ImplicitData SerialCouplingScheme::implicitDataToReceive() const
+{
+  if (!isImplicitCouplingScheme()) {
+    return {};
+  }
+
+  const auto isSecond = !doesFirstStep();
+
+  ImplicitData idata;
+  for (auto cpldata : getReceiveData() | boost::adaptors::map_values) {
+    idata.add(cpldata->getDataID(), isSecond);
+  }
+  return idata;
 }
 
 } // namespace precice::cplscheme

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -62,6 +62,8 @@ public:
       constants::TimesteppingMethod dtMethod,
       CouplingMode                  cplMode);
 
+  ImplicitData implicitDataToReceive() const override final;
+
 private:
   logging::Logger _log{"cplschemes::SerialCouplingSchemes"};
 

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -799,6 +799,16 @@ PtrCouplingScheme CouplingSchemeConfiguration::createSerialExplicitCouplingSchem
       _config.participants[0], _config.participants[1]);
   SerialCouplingScheme *scheme = new SerialCouplingScheme(_config.maxTime, _config.maxTimeWindows, _config.timeWindowSize, _config.participants[0], _config.participants[1], accessor, m2n, _config.dtMethod, BaseCouplingScheme::Explicit);
 
+  for (const auto &exchange : _config.exchanges) {
+    if ((exchange.from == _config.participants[1]) && exchange.exchangeSubsteps) {
+      PRECICE_WARN(
+          "You enabled exchanging substeps in the serial-explicit coupling between the second participant \"{}\" and first participant \"{}\". "
+          "This is inefficient as these substeps will never be used.",
+          exchange.from, exchange.to);
+      break;
+    }
+  }
+
   addDataToBeExchanged(*scheme, accessor);
 
   return PtrCouplingScheme(scheme);
@@ -811,6 +821,16 @@ PtrCouplingScheme CouplingSchemeConfiguration::createParallelExplicitCouplingSch
   m2n::PtrM2N m2n = _m2nConfig->getM2N(
       _config.participants[0], _config.participants[1]);
   ParallelCouplingScheme *scheme = new ParallelCouplingScheme(_config.maxTime, _config.maxTimeWindows, _config.timeWindowSize, _config.participants[0], _config.participants[1], accessor, m2n, _config.dtMethod, BaseCouplingScheme::Explicit);
+
+  for (const auto &exchange : _config.exchanges) {
+    if (exchange.exchangeSubsteps) {
+      PRECICE_WARN(
+          "You enabled exchanging substeps in the parallel-explicit coupling between \"{}\" and \"{}\". "
+          "This is inefficient as these substeps will never be used.",
+          exchange.from, exchange.to);
+      break;
+    }
+  }
 
   addDataToBeExchanged(*scheme, accessor);
 

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -216,6 +216,16 @@ public:
 
   bool hasConverged() const override;
 
+  bool requiresSubsteps() const override final
+  {
+    return true;
+  }
+
+  ImplicitData implicitDataToReceive() const override final
+  {
+    return {};
+  }
+
 private:
   mutable logging::Logger _log{"cplscheme::tests::DummyCouplingScheme"};
 

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -78,9 +78,13 @@ public:
   bool hasGradient() const;
 
   /**
-   * @brief Perform the mapping for all mapping contexts and the corresponding data context (from and to data)
+   * @brief Perform the mapping for mapping contexts and the corresponding data context (from and to data)
+   *
+   * @param[in] after only map samples after this optional time
+   *
+   * @return the number of performed mappings
    */
-  void mapData();
+  int mapData(std::optional<double> after = std::nullopt);
 
   /**
    * @brief Adds a MappingContext and the MeshContext required by the mapping to the corresponding DataContext data structures.

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -31,14 +31,6 @@ struct MappingContext {
   {
     mapping->getInputMesh()->data(dataName)->requireDataGradient();
   }
-
-  /// Allows to clear data storage before mapping is performed
-  void clearToDataStorage()
-  {
-    if (toData->timeStepsStorage().nTimes() > 0) {
-      toData->timeStepsStorage().clear(); // requires clear, not trim, because otherwise data from the beginning of the window is kept across windows (toData that is no coupling data is never moved)
-    }
-  }
 };
 
 } // namespace impl

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -376,6 +376,7 @@ void ParticipantImpl::advance(
   // Update the coupling scheme time state. Necessary to get correct remainder.
   const bool   isAtWindowEnd = _couplingScheme->addComputedTime(computedTimeStepSize);
   const double timeSteppedTo = _couplingScheme->getTime();
+  const auto   dataToReceive = _couplingScheme->implicitDataToReceive();
 
   handleDataBeforeAdvance(isAtWindowEnd, timeSteppedTo);
 
@@ -385,9 +386,12 @@ void ParticipantImpl::advance(
   const double timeAfterAdvance   = _couplingScheme->getTime();
   const bool   timeWindowComplete = _couplingScheme->isTimeWindowComplete();
 
-  handleDataAfterAdvance(isAtWindowEnd, timeWindowComplete, timeSteppedTo, timeAfterAdvance);
+  handleDataAfterAdvance(isAtWindowEnd, timeWindowComplete, timeSteppedTo, timeAfterAdvance, dataToReceive);
 
   PRECICE_INFO(_couplingScheme->printCouplingState());
+
+  PRECICE_DEBUG("Mapped {} samples in write mappings and {} samples in read mappings",
+                _executedWriteMappings, _executedReadMappings);
 
   _meshLock.lockAll();
 
@@ -398,37 +402,48 @@ void ParticipantImpl::advance(
 
 void ParticipantImpl::handleDataBeforeAdvance(bool reachedTimeWindowEnd, double timeSteppedTo)
 {
-  samplizeWriteData(timeSteppedTo);
+  if (reachedTimeWindowEnd || _couplingScheme->requiresSubsteps()) {
+    samplizeWriteData(timeSteppedTo);
+  }
+  resetWrittenData();
+
+  // Reset mapping counters here to cover subcycling
+  _executedReadMappings  = 0;
+  _executedWriteMappings = 0;
 
   if (reachedTimeWindowEnd) {
-    mapWrittenData();
+    mapWrittenData(_couplingScheme->getTimeWindowStart());
     performDataActions({action::Action::WRITE_MAPPING_POST});
   }
 }
 
-void ParticipantImpl::handleDataAfterAdvance(bool reachedTimeWindowEnd, bool isTimeWindowComplete, double timeSteppedTo, double timeAfterAdvance)
+void ParticipantImpl::handleDataAfterAdvance(bool reachedTimeWindowEnd, bool isTimeWindowComplete, double timeSteppedTo, double timeAfterAdvance, const cplscheme::ImplicitData &receivedData)
 {
   if (!reachedTimeWindowEnd) {
     // We are subcycling
     return;
   }
 
-  if (reachedTimeWindowEnd) {
-    mapReadData();
-    // FIXME: the actions timing for read mappings doesn't make sense after
-    performDataActions({action::Action::READ_MAPPING_POST});
-  }
-
-  handleExports();
-
   if (isTimeWindowComplete) {
     // Move to next time window
     PRECICE_ASSERT(math::greaterEquals(timeAfterAdvance, timeSteppedTo), "We must have stayed or moved forwards in time (min-time-step-size).");
 
     // As we move forward, there may now be old samples lying around
-    // We know that timeAfterAdvance is the start time of the time window
-    trimOldDataBefore(timeAfterAdvance);
+    trimOldDataBefore(_couplingScheme->getTimeWindowStart());
+  } else {
+    // We are iterating
+    PRECICE_ASSERT(math::greater(timeSteppedTo, timeAfterAdvance), "We must have moved back in time!");
 
+    trimSendDataAfter(timeAfterAdvance);
+  }
+
+  if (reachedTimeWindowEnd) {
+    trimReadMappedData(timeAfterAdvance, isTimeWindowComplete, receivedData);
+    mapReadData();
+    performDataActions({action::Action::READ_MAPPING_POST});
+  }
+
+  if (isTimeWindowComplete) {
     // Reset initial guesses for iterative mappings
     for (auto &context : _accessor->readDataContexts()) {
       context.resetInitialGuesses();
@@ -436,13 +451,9 @@ void ParticipantImpl::handleDataAfterAdvance(bool reachedTimeWindowEnd, bool isT
     for (auto &context : _accessor->writeDataContexts()) {
       context.resetInitialGuesses();
     }
-    return;
   }
 
-  // We are iterating
-  PRECICE_ASSERT(math::greater(timeSteppedTo, timeAfterAdvance), "We must have moved back in time!");
-
-  trimSendDataAfter(timeAfterAdvance);
+  handleExports();
 }
 
 void ParticipantImpl::samplizeWriteData(double time)
@@ -451,7 +462,6 @@ void ParticipantImpl::samplizeWriteData(double time)
   for (auto &context : _accessor->writeDataContexts()) {
     context.storeBufferedData(time);
   }
-  resetWrittenData();
 }
 
 void ParticipantImpl::trimOldDataBefore(double time)
@@ -1385,14 +1395,31 @@ void ParticipantImpl::computeMappings(std::vector<MappingContext> &contexts, con
   }
 }
 
-void ParticipantImpl::mapWrittenData()
+void ParticipantImpl::mapWrittenData(std::optional<double> after)
 {
   PRECICE_TRACE();
   computeMappings(_accessor->writeMappingContexts(), "write");
   for (auto &context : _accessor->writeDataContexts()) {
     if (context.hasMapping()) {
       PRECICE_DEBUG("Map write data \"{}\" from mesh \"{}\"", context.getDataName(), context.getMeshName());
-      context.mapData();
+      _executedWriteMappings += context.mapData(after);
+    }
+  }
+}
+
+void ParticipantImpl::trimReadMappedData(double startOfTimeWindow, bool isTimeWindowComplete, const cplscheme::ImplicitData &fromData)
+{
+  PRECICE_TRACE();
+  for (auto &context : _accessor->readDataContexts()) {
+    if (context.hasMapping()) {
+      if (isTimeWindowComplete) {
+        // For serial implicit second, we need to discard everything before startOfTimeWindow to preserve the time window start
+        // For serial implicit first, we need to discard everything as everything is new
+        // For parallel implicit, we need to discard everything as everything is new
+        context.clearToDataFor(fromData);
+      } else {
+        context.trimToDataAfterFor(fromData, startOfTimeWindow);
+      }
     }
   }
 }
@@ -1404,7 +1431,8 @@ void ParticipantImpl::mapReadData()
   for (auto &context : _accessor->readDataContexts()) {
     if (context.hasMapping()) {
       PRECICE_DEBUG("Map read data \"{}\" to mesh \"{}\"", context.getDataName(), context.getMeshName());
-      context.mapData();
+      // We always ensure that all read data was mapped
+      _executedReadMappings += context.mapData();
     }
   }
 }
@@ -1534,6 +1562,14 @@ const mesh::Mesh &ParticipantImpl::mesh(const std::string &meshName) const
 {
   PRECICE_TRACE(meshName);
   return *_accessor->usedMeshContext(meshName).mesh;
+}
+
+ParticipantImpl::MappedSamples ParticipantImpl::mappedSamples() const
+{
+  MappedSamples res;
+  res.read  = _executedReadMappings;
+  res.write = _executedWriteMappings;
+  return res;
 }
 
 } // namespace precice::impl

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -267,6 +267,13 @@ public:
   /// @todo try to remove or make private. See https://github.com/precice/precice/issues/1269
   const mesh::Mesh &mesh(const std::string &meshName) const;
 
+  struct MappedSamples {
+    int write, read;
+  };
+
+  /// Returns the amount of mapped read and write samples in the last call to advance.
+  MappedSamples mappedSamples() const;
+
   /// Disable copy construction
   ParticipantImpl(ParticipantImpl const &) = delete;
 
@@ -327,6 +334,12 @@ private:
   /// Counts calls to advance for plotting.
   long int _numberAdvanceCalls = 0;
 
+  /// Counts the amount of samples mapped in write mappings executed in the latest advance
+  int _executedWriteMappings = 0;
+
+  /// Counts the amount of samples mapped in read mappings executed in the latest advance
+  int _executedReadMappings = 0;
+
   /**
    * @brief Configures the coupling interface from the given xml file.
    *
@@ -363,11 +376,18 @@ private:
   /// Helper for mapWrittenData and mapReadData
   void computeMappings(std::vector<MappingContext> &contexts, const std::string &mappingType);
 
-  /// Computes, performs, and resets all suitable write mappings.
-  void mapWrittenData();
+  /// Computes, and performs suitable write mappings either entirely or after given time
+  void mapWrittenData(std::optional<double> after = std::nullopt);
 
-  /// Computes, performs, and resets all suitable read mappings.
+  // Computes, and performs read mappings
   void mapReadData();
+
+  /**
+   * @brief Removes samples in mapped to data connected to received data via a mapping.
+   *
+   * This prevents old samples from blocking remappings.
+   */
+  void trimReadMappedData(double timeAfterAdvance, bool isTimeWindowComplete, const cplscheme::ImplicitData &fromData);
 
   /**
    * @brief Performs all data actions with given timing.
@@ -410,7 +430,7 @@ private:
   void handleDataBeforeAdvance(bool reachedTimeWindowEnd, double timeSteppedTo);
 
   /// Completes everything data-related after advancing the coupling scheme
-  void handleDataAfterAdvance(bool reachedTimeWindowEnd, bool isTimeWindowComplete, double timeSteppedTo, double timeAfterAdvance);
+  void handleDataAfterAdvance(bool reachedTimeWindowEnd, bool isTimeWindowComplete, double timeSteppedTo, double timeAfterAdvance, const cplscheme::ImplicitData &receivedData);
 
   /// Creates a Stample at the given time for each write Data and zeros the buffers
   void samplizeWriteData(double time);

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -38,4 +38,31 @@ int ReadDataContext::getWaveformDegree() const
   return _providedData->getWaveformDegree();
 }
 
+void ReadDataContext::clearToDataFor(const cplscheme::ImplicitData &from)
+{
+  PRECICE_TRACE(getMeshName(), getDataName());
+  PRECICE_ASSERT(hasMapping());
+  for (auto &context : _mappingContexts) {
+    auto id = context.fromData->getID();
+    if (from.contains(id)) {
+      if (from.toKeep(id)) {
+        context.toData->timeStepsStorage().clearExceptLast();
+      } else {
+        context.toData->timeStepsStorage().clear();
+      }
+    }
+  }
+}
+
+void ReadDataContext::trimToDataAfterFor(const cplscheme::ImplicitData &from, double t)
+{
+  PRECICE_TRACE(getMeshName(), getDataName(), t);
+  PRECICE_ASSERT(hasMapping());
+  for (auto &context : _mappingContexts) {
+    if (from.contains(context.fromData->getID())) {
+      context.toData->timeStepsStorage().trimAfter(t);
+    }
+  }
+}
+
 } // namespace precice::impl

--- a/src/precice/impl/ReadDataContext.hpp
+++ b/src/precice/impl/ReadDataContext.hpp
@@ -3,6 +3,7 @@
 #include <Eigen/Core>
 
 #include "DataContext.hpp"
+#include "cplscheme/ImplicitData.hpp"
 #include "logging/Logger.hpp"
 
 namespace precice {
@@ -62,6 +63,18 @@ public:
   /// Move constructor, use the implicitly declared.
   ReadDataContext(ReadDataContext &&) = default;
   ReadDataContext &operator=(ReadDataContext &&) = default;
+
+  /**
+   * @brief Removes all toData samples from mappings
+   */
+  void clearToDataFor(const cplscheme::ImplicitData &from);
+
+  /**
+   * @brief Trims all toData of associated mappings after the given t
+   *
+   * @param[in] t the time after which to trim data
+   */
+  void trimToDataAfterFor(const cplscheme::ImplicitData &from, double t);
 
 private:
   static logging::Logger _log;

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -101,6 +101,8 @@ target_sources(preciceCore
     src/cplscheme/CouplingData.hpp
     src/cplscheme/CouplingScheme.cpp
     src/cplscheme/CouplingScheme.hpp
+    src/cplscheme/ImplicitData.cpp
+    src/cplscheme/ImplicitData.hpp
     src/cplscheme/MultiCouplingScheme.cpp
     src/cplscheme/MultiCouplingScheme.hpp
     src/cplscheme/ParallelCouplingScheme.cpp

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -116,6 +116,17 @@ void Storage::clear()
   _bspline.reset();
 }
 
+void Storage::clearExceptLast()
+{
+  if (_stampleStorage.empty()) {
+    return;
+  }
+  _stampleStorage.erase(_stampleStorage.begin(), --_stampleStorage.end());
+
+  // The spline has to be recomputed, since the underlying data has changed
+  _bspline.reset();
+}
+
 void Storage::trimBefore(double time)
 {
   auto beforeTime = [time](const auto &s) { return math::smaller(s.timestamp, time); };

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -122,6 +122,8 @@ public:
    */
   void clear();
 
+  void clearExceptLast();
+
   void trimBefore(double time);
 
   void trimAfter(double time);

--- a/tests/serial/map-if-necessary/three-solvers/helper.hpp
+++ b/tests/serial/map-if-necessary/three-solvers/helper.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <vector>
+
+#include "precice/impl/ParticipantImpl.hpp"
+#include "testing/Testing.hpp"
+
+// Coupling is A - C - B, which can be MultiCoupling or Compositional. A-C may be explicitly coupled.
+// A and B always go first.
+// A never sends substeps, B always sends substeps except in Multi Coupling, which should be reflected in the read mappings of C.
+// The tests choose various scenarios for C to send and receive substeps. Some with subteps, some without and some with mixed usage.
+// Checkpoints are ignored for the sake of simplicity and time window sizes are considered to be equal
+
+inline void runMultipleSolversMappingCount(precice::testing::TestContext &context, std::vector<int> readMappings, std::vector<int> writeMappings)
+{
+  BOOST_REQUIRE(readMappings.size() == writeMappings.size());
+  BOOST_REQUIRE(readMappings.size() > 1);
+
+  precice::Participant participant(context.name, context.config(), context.rank, context.size);
+
+  std::vector<double>            coords{0, 0, 1, 1};
+  std::vector<precice::VertexID> vertexIDs(2);
+  std::string                    meshName = "Mesh" + context.name;
+  participant.setMeshVertices(meshName, coords, vertexIDs);
+
+  participant.initialize();
+
+  participant.requiresWritingCheckpoint();
+
+  // A and B are fully steered by the configuration
+  if (!context.isNamed("C")) {
+    // Standard coupling loop always doing a 0.5 step followed by the rest of the timewindow
+    while (participant.isCouplingOngoing()) {
+      participant.advance(0.5);
+      BOOST_REQUIRE(participant.isCouplingOngoing());
+      participant.advance(participant.getMaxTimeStepSize());
+
+      participant.requiresReadingCheckpoint();
+      participant.requiresWritingCheckpoint();
+    }
+    return;
+  }
+
+  // Logic of solver C
+
+  size_t timeWindow = 0;
+  while (participant.isCouplingOngoing()) {
+    BOOST_TEST_CONTEXT("TW = " << timeWindow)
+    {
+      BOOST_REQUIRE(timeWindow < readMappings.size());
+      // First substep
+      participant.advance(0.5);
+      BOOST_REQUIRE(participant.isCouplingOngoing());
+
+      BOOST_TEST_CONTEXT("No mapping to be executed when subcycling")
+      {
+        auto mappedSubstep = precice::testing::WhiteboxAccessor::impl(participant).mappedSamples();
+        BOOST_TEST(mappedSubstep.write == 0);
+        BOOST_TEST(mappedSubstep.read == 0);
+      }
+
+      // Second substep
+      participant.advance(participant.getMaxTimeStepSize());
+
+      // Ignore convergence
+      participant.requiresReadingCheckpoint();
+      participant.requiresWritingCheckpoint();
+
+      // Check mappings
+      auto mappedTimeWindow = precice::testing::WhiteboxAccessor::impl(participant).mappedSamples();
+      BOOST_REQUIRE(timeWindow < writeMappings.size());
+      BOOST_TEST(mappedTimeWindow.write == writeMappings.at(timeWindow));
+      BOOST_TEST(mappedTimeWindow.read == readMappings.at(timeWindow));
+      ++timeWindow;
+    }
+  }
+  BOOST_TEST(timeWindow == readMappings.size());
+}

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/Multi.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/Multi.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(Multi)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{2, 2, 2, 2, 2, 2};
+  std::vector<int> writeMappings{4, 4, 4, 4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/Multi.xml
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/Multi.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:multi>
+    <participant name="A" />
+    <participant name="B" />
+    <participant name="C" control="true" />
+    <max-iterations value="2" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelExplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelExplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelExplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{2, 2, 2};
+  std::vector<int> writeMappings{4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelExplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelExplicit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelImplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelImplicit.cpp
@@ -1,0 +1,34 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelImplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{3, 1, 3, 1, 3, 1};
+  // When the coupling scheme A - B moves on to the next time window, C discards samples in the send data
+  // namely MeshA:DataC.
+  // While the itererative scheme is iterating, it still has this beginning timestamp and will be mapped in the writeMapping
+  std::vector<int> writeMappings{4, 4, 4, 4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelImplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelImplicit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialExplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialExplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialExplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{3, 3, 0};
+  std::vector<int> writeMappings{4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialExplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialExplicit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-explicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialImplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialImplicit.cpp
@@ -1,0 +1,42 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialImplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+  // new data from A = new end
+  // iterating B = new mid + new end
+  // new tw B = new start + mid + end
+  std::vector<int> readMappings{
+      // initialize is not checked (should be start + mid + end from B and start + end from A (tw0))
+      3, // iterating B + new data from A (tw1)
+      2, // next tw: end from B
+      3, // iterating B + final data from A (tw2)
+      2, // next tw: end from B
+      2, // iterating B
+      0  // nothing from B (second)
+  };
+  // always maps mid + end per data
+  std::vector<int> writeMappings{4, 4, 4, 4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialImplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialImplicit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-implicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/Multi.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/Multi.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(Multi)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  // 3: new start + mid + end samples
+  // 2: multi & parallel implicit only exchange end samples on convergence
+  std::vector<int> readMappings{3, 2, 3, 2, 3, 2};
+  std::vector<int> writeMappings{4, 4, 4, 4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/Multi.xml
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/Multi.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:multi>
+    <participant name="A" />
+    <participant name="B" />
+    <participant name="C" control="true" />
+    <max-iterations value="2" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelExplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelExplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelExplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{2, 2, 2};
+  std::vector<int> writeMappings{4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelExplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelExplicit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="true" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelImplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelImplicit.cpp
@@ -1,0 +1,38 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelImplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{
+      3, // iterating: end from A + mid and end from B
+      1, // new start from B
+      3, // iterating: end from A + mid and end from B
+      1, // new start from B
+      3, // iterating: last end from A + mid and end from B
+      1  // last end from B
+  };
+  std::vector<int> writeMappings{4, 4, 4, 4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelImplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelImplicit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="true" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialExplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialExplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialExplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{3, 3, 0};
+  std::vector<int> writeMappings{4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialExplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialExplicit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="true" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-explicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialImplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialImplicit.cpp
@@ -1,0 +1,39 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialImplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{
+      // initialize not checked (tw0 of A)
+      3, // iterating: end from A (tw1) and mid + end from B
+      2, // mid + end from B
+      3, // iterating: final end from A (tw2) and mid + end from B
+      2, // mid + end from B
+      2, // iterating: mid + end from B
+      0  // nothing from B (second)
+  };
+  std::vector<int> writeMappings{4, 4, 4, 4, 4, 4};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialImplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/with-substeps/SerialImplicit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="true" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-implicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="true" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/Multi.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/Multi.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(Multi)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{3, 2, 3, 2, 3, 2};
+  std::vector<int> writeMappings{2, 2, 2, 2, 2, 2};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/Multi.xml
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/Multi.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:multi>
+    <participant name="A" />
+    <participant name="B" />
+    <participant name="C" control="true" />
+    <max-iterations value="2" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="false" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelExplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelExplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelExplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{2, 2, 2};
+  std::vector<int> writeMappings{2, 2, 2};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelExplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelExplicit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelImplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelImplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelImplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{3, 1, 3, 1, 3, 1};
+  std::vector<int> writeMappings{2, 2, 2, 2, 2, 2};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelImplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelImplicit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="false" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialExplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialExplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialExplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{3, 3, 0};
+  std::vector<int> writeMappings{2, 2, 2};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialExplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialExplicit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-explicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialImplicit.cpp
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialImplicit.cpp
@@ -1,0 +1,39 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(ThreeSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialImplicit)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank), "C"_on(1_rank));
+
+  std::vector<int> readMappings{
+      // initialized not checked (tw0 of A)
+      3, // iterate: end of A (tw1) and mid + end of B
+      2, // new mid + end of B
+      3, // iterate: final end of A (tw2) and mid + end of B
+      2, // new mid + end of B
+      2, // iterate: new mid + end of B
+      0  // nothing from B (second)
+  };
+  std::vector<int> writeMappings{2, 2, 2, 2, 2, 2};
+
+  runMultipleSolversMappingCount(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialImplicit.xml
+++ b/tests/serial/map-if-necessary/three-solvers/without-substeps/SerialImplicit.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataA" />
+  <data:vector name="DataB" />
+  <data:vector name="DataC" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataA" />
+    <use-data name="DataB" />
+    <use-data name="DataC" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MeshA" />
+    <read-data name="DataC" mesh="MeshA" />
+    <write-data name="DataA" mesh="MeshA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MeshB" />
+    <read-data name="DataC" mesh="MeshB" />
+    <write-data name="DataB" mesh="MeshB" />
+  </participant>
+
+  <participant name="C">
+    <provide-mesh name="MeshC" />
+    <receive-mesh name="MeshA" from="A" />
+    <receive-mesh name="MeshB" from="B" />
+    <read-data name="DataA" mesh="MeshC" />
+    <read-data name="DataB" mesh="MeshC" />
+    <write-data name="DataC" mesh="MeshC" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshB" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="A" connector="C" />
+  <m2n:sockets acceptor="B" connector="C" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="A" second="C" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataA" mesh="MeshA" from="A" to="C" substeps="false" />
+    <exchange data="DataC" mesh="MeshA" from="C" to="A" substeps="false" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-implicit>
+    <participants first="B" second="C" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataB" mesh="MeshB" from="B" to="C" substeps="true" />
+    <exchange data="DataC" mesh="MeshB" from="C" to="B" substeps="false" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/helper.hpp
+++ b/tests/serial/map-if-necessary/two-solvers/helper.hpp
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <vector>
+
+#include "precice/impl/ParticipantImpl.hpp"
+#include "testing/Testing.hpp"
+
+// Coupling is One - Two.
+// One is always going second and Two is always going first.
+// Both always make a substep.
+// The tests choose various scenarios for One to send and receive substeps. Some with subteps, some without and some with mixed usage.
+// Checkpoints are ignored for the sake of simplicity and time window sizes are considered to be equal
+
+inline void runTwoSolversMappingCount(precice::testing::TestContext &context, std::vector<int> readMappings, std::vector<int> writeMappings, bool implicit)
+{
+  BOOST_REQUIRE(readMappings.size() == writeMappings.size());
+  BOOST_REQUIRE(readMappings.size() > 1);
+
+  precice::Participant participant(context.name, context.config(), context.rank, context.size);
+
+  std::vector<double>            coords{0, 0, 1, 1};
+  std::vector<precice::VertexID> vertexIDs(2);
+  std::string                    meshName = "Mesh" + context.name;
+  participant.setMeshVertices(meshName, coords, vertexIDs);
+
+  participant.initialize();
+
+  BOOST_TEST(participant.requiresWritingCheckpoint() == implicit);
+
+  size_t timeWindow = 0;
+  while (participant.isCouplingOngoing()) {
+    BOOST_TEST_CONTEXT("TW = " << timeWindow)
+    {
+      BOOST_REQUIRE(timeWindow < readMappings.size());
+      // First substep
+      participant.advance(0.5);
+      BOOST_REQUIRE(participant.isCouplingOngoing());
+
+      BOOST_TEST_CONTEXT("No mapping to be executed when subcycling")
+      {
+        auto mappedSubstep = precice::testing::WhiteboxAccessor::impl(participant).mappedSamples();
+        BOOST_TEST(mappedSubstep.write == 0);
+        BOOST_TEST(mappedSubstep.read == 0);
+      }
+
+      // Second substep
+      participant.advance(participant.getMaxTimeStepSize());
+
+      // Check convergence
+      if (implicit) {
+        bool lastAdvance = timeWindow == writeMappings.size() - 1;
+        if (lastAdvance) {
+          BOOST_TEST(!participant.requiresReadingCheckpoint());
+          BOOST_TEST(!participant.requiresWritingCheckpoint());
+        } else {
+          bool converged = timeWindow % 2 == 1;
+          BOOST_TEST(participant.requiresReadingCheckpoint() != converged);
+          BOOST_TEST(participant.requiresWritingCheckpoint() == converged);
+        }
+      } else {
+        BOOST_TEST(!participant.requiresReadingCheckpoint());
+        BOOST_TEST(!participant.requiresWritingCheckpoint());
+      }
+
+      // Check mappings
+      auto mappedTimeWindow = precice::testing::WhiteboxAccessor::impl(participant).mappedSamples();
+
+      if (context.isNamed("One")) {
+        BOOST_REQUIRE(timeWindow < writeMappings.size());
+        BOOST_TEST(mappedTimeWindow.write == writeMappings.at(timeWindow));
+        BOOST_TEST(mappedTimeWindow.read == readMappings.at(timeWindow));
+      } else {
+        // Solver Two has no mappings
+        BOOST_TEST(mappedTimeWindow.write == 0);
+        BOOST_TEST(mappedTimeWindow.read == 0);
+      }
+      ++timeWindow;
+    }
+  }
+
+  BOOST_REQUIRE(!participant.isCouplingOngoing());
+}
+
+inline void runTwoSolversMappingCountExplicit(precice::testing::TestContext &context, std::vector<int> readMappings, std::vector<int> writeMappings)
+{
+  runTwoSolversMappingCount(context, readMappings, writeMappings, false);
+}
+
+inline void runTwoSolversMappingCountImplicit(precice::testing::TestContext &context, std::vector<int> readMappings, std::vector<int> writeMappings)
+{
+  runTwoSolversMappingCount(context, readMappings, writeMappings, true);
+}

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelExplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelExplicit.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelExplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // We receive the new start sample
+  std::vector<int> readMappings{1, 1, 1};
+  // We write the two samples from the two time steps
+  std::vector<int> writeMappings{2, 2, 2};
+
+  runTwoSolversMappingCountExplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelExplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelExplicit.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelImplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelImplicit.cpp
@@ -1,0 +1,31 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelImplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  std::vector<int> readMappings{1, 1, 1, 1, 1, 1};
+  std::vector<int> writeMappings{2, 2, 2, 2, 2, 2};
+
+  runTwoSolversMappingCountImplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelImplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelImplicit.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialExplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialExplicit.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialExplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // We receive the new start sample
+  std::vector<int> readMappings{1, 1, 0};
+  // We write the two samples from the two time steps
+  std::vector<int> writeMappings{2, 2, 2};
+
+  runTwoSolversMappingCountExplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialExplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialExplicit.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialImplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialImplicit.cpp
@@ -1,0 +1,34 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(MixedSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialImplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // iterating: new end of same timestep
+  // converged: new end of next timestep
+  std::vector<int> readMappings{1, 1, 1, 1, 1, 0};
+  // 2: we map the samples from the two time steps
+  std::vector<int> writeMappings{2, 2, 2, 2, 2, 2};
+
+  runTwoSolversMappingCountImplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MixedSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialImplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialImplicit.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelExplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelExplicit.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelExplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // We receive the new start sample
+  std::vector<int> readMappings{1, 1, 1};
+  // We write the two samples from the two time steps
+  std::vector<int> writeMappings{2, 2, 2};
+
+  runTwoSolversMappingCountExplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelExplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelExplicit.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="true" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelImplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelImplicit.cpp
@@ -1,0 +1,34 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelImplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // 2: we fail to converge and receive new samples for the substep and end of the time window
+  // 0: we succeed to converge and keep the sample of the end of the time window
+  std::vector<int> readMappings{2, 1, 2, 1, 2, 1};
+  // 2: we map the samples from the two time steps
+  std::vector<int> writeMappings{2, 2, 2, 2, 2, 2};
+
+  runTwoSolversMappingCountImplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelImplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelImplicit.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="true" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialExplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialExplicit.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialExplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // We receive the new substep and end sample
+  std::vector<int> readMappings{2, 2, 0};
+  // We write the two samples from the two time steps
+  std::vector<int> writeMappings{2, 2, 2};
+
+  runTwoSolversMappingCountExplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialExplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialExplicit.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="true" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialImplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialImplicit.cpp
@@ -1,0 +1,34 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialImplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // 2: iterating: new mid + end
+  // 3: new time window: new mid + end
+  std::vector<int> readMappings{2, 2, 2, 2, 2, 0};
+  // 2: we map the samples from the two time steps
+  std::vector<int> writeMappings{2, 2, 2, 2, 2, 2};
+
+  runTwoSolversMappingCountImplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialImplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/with-substeps/SerialImplicit.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="true" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="true" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelExplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelExplicit.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelExplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // We receive the new start sample
+  std::vector<int> readMappings{1, 1, 1};
+  // We write the sample from the end of the time window
+  std::vector<int> writeMappings{1, 1, 1};
+
+  runTwoSolversMappingCountExplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelExplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelExplicit.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="false" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelImplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelImplicit.cpp
@@ -1,0 +1,34 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(ParallelImplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // 1: we fail to converge and receive a new sample for the end of the time window
+  // 0: we succeed to converge and keep the sample of the end of the time window
+  std::vector<int> readMappings{1, 1, 1, 1, 1, 1};
+  // 1: we only map the samples from end of the time window
+  std::vector<int> writeMappings{1, 1, 1, 1, 1, 1};
+
+  runTwoSolversMappingCountImplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelImplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelImplicit.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="false" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialExplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialExplicit.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialExplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // We receive the new start sample
+  std::vector<int> readMappings{1, 1, 0};
+  // We write the sample from the end of the time window
+  std::vector<int> writeMappings{1, 1, 1};
+
+  runTwoSolversMappingCountExplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialExplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialExplicit.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="false" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialImplicit.cpp
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialImplicit.cpp
@@ -1,0 +1,34 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapIfNecessary)
+BOOST_AUTO_TEST_SUITE(TwoSolvers)
+BOOST_AUTO_TEST_SUITE(WithoutSubsteps)
+
+BOOST_AUTO_TEST_CASE(SerialImplicit)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  // 1: new end only (iterating)
+  // 2: new end
+  std::vector<int> readMappings{1, 1, 1, 1, 1, 0};
+  // 1: we only map the sample from the end of the time window
+  std::vector<int> writeMappings{1, 1, 1, 1, 1, 1};
+
+  runTwoSolversMappingCountImplicit(context, readMappings, writeMappings);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // WithoutSubsteps
+BOOST_AUTO_TEST_SUITE_END() // TwoSolvers
+BOOST_AUTO_TEST_SUITE_END() // MapIfNecessary
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialImplicit.xml
+++ b/tests/serial/map-if-necessary/two-solvers/without-substeps/SerialImplicit.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="DataOne" />
+  <data:vector name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="Two" second="One" />
+    <max-time-windows value="3" />
+    <max-iterations value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="One" to="Two" substeps="false" />
+    <exchange data="DataTwo" mesh="MeshTwo" from="Two" to="One" substeps="false" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -137,6 +137,35 @@ target_sources(testprecice
     tests/serial/lifecycle/reconstruction/ConstructOnly.cpp
     tests/serial/lifecycle/reconstruction/Full.cpp
     tests/serial/lifecycle/reconstruction/ImplicitFinalize.cpp
+    tests/serial/map-if-necessary/three-solvers/helper.hpp
+    tests/serial/map-if-necessary/three-solvers/mixed-substeps/Multi.cpp
+    tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelExplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/mixed-substeps/ParallelImplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialExplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/mixed-substeps/SerialImplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/with-substeps/Multi.cpp
+    tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelExplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/with-substeps/ParallelImplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/with-substeps/SerialExplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/with-substeps/SerialImplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/without-substeps/Multi.cpp
+    tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelExplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/without-substeps/ParallelImplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/without-substeps/SerialExplicit.cpp
+    tests/serial/map-if-necessary/three-solvers/without-substeps/SerialImplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/helper.hpp
+    tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelExplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/mixed-substeps/ParallelImplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialExplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/mixed-substeps/SerialImplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelExplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/with-substeps/ParallelImplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/with-substeps/SerialExplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/with-substeps/SerialImplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelExplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelImplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/without-substeps/SerialExplicit.cpp
+    tests/serial/map-if-necessary/two-solvers/without-substeps/SerialImplicit.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR changes mappings to only map stamples that are missing.

This comes with some significant implications:

* preCICE will **never** map a sample multiple times
* all mappings are now steered by clearing timestorages
* Actions will not work with mixed-time-window sizes as samples can persist multiple read/write mappings (unchecked)
* write-data samples will not be generated when subcycling is turned off for all exchanges. **enabling substeps on a single exchange enables samples from subcycling for the participant, which leads to the evaluation of all write mappings** 

Before we merge this PR, I would prefer to get this tested using a few tutorials under real conditions.

**Open questions:**

* Did I overlook a cleaning schenario?
* Do the exports still work?
* Does acceleration still work? 

## Motivation and additional information

Closes #1707

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Can you imagine any situations in which this could backfire?
* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
