### PR TITLE
Fix EventRegistry stopping backend without starting it.

### DIFF
--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -69,6 +69,9 @@ void EventRegistry::initialize(std::string_view applicationName, int rank, int s
 
   _initialized = true;
   _finalized   = false;
+  if (_isBackendRunning) {
+    stopBackend();
+  }
 }
 
 void EventRegistry::setWriteQueueMax(std::size_t size)
@@ -107,6 +110,9 @@ void EventRegistry::startBackend()
     PRECICE_DEBUG("Profiling is turned off. Backend will not start.");
     return;
   }
+
+  PRECICE_ASSERT(!_isBackendRunning);
+
   // Create the directory if necessary
   bool isLocal = _directory.empty() || _directory == ".";
   if (!isLocal) {
@@ -146,11 +152,12 @@ void EventRegistry::startBackend()
              timepoint_to_string(_initTime),
              toString(_mode));
   _output.flush();
+  _isBackendRunning = true;
 }
 
 void EventRegistry::stopBackend()
 {
-  if (_mode == Mode::Off) {
+  if (_mode == Mode::Off || !_isBackendRunning) {
     return;
   }
   // create end of global event
@@ -161,12 +168,15 @@ void EventRegistry::stopBackend()
   _output << "]}";
   _output.close();
   _nameDict.clear();
+
+  _isBackendRunning = false;
 }
 
 void EventRegistry::finalize()
 {
-  if (_finalized)
+  if (_finalized || !_initialized) {
     return;
+  }
 
   stopBackend();
 

--- a/src/profiling/EventUtils.hpp
+++ b/src/profiling/EventUtils.hpp
@@ -168,6 +168,8 @@ private:
 
   bool _finalized = false;
 
+  bool _isBackendRunning = false;
+
   /// The initial time clock, used to take runtime measurements.
   Event::Clock::time_point _initClock;
 


### PR DESCRIPTION
## Main changes of this PR

This PR fixes the management of the back-end of the EventRegistry.

If an error occurs during configuration, then the registry was finalized before the back-end was started, resulting in a `std::bad_optional_access` exception.

## Motivation and additional information

Closes #1896
Superseeds #1898

Special thanks to @davidscn for finding the origin of the problem.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
