### PR TITLE
Prevent Floating-point exception during scaling

### DIFF
--- a/docs/changelog/1910.md
+++ b/docs/changelog/1910.md
@@ -1,0 +1,1 @@
+- Fixed preconditioners dividing by zero in case of coupling data always being zero and not changing over time.

--- a/src/acceleration/impl/ResidualPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualPreconditioner.cpp
@@ -1,6 +1,7 @@
 #include "acceleration/impl/ResidualPreconditioner.hpp"
 #include <cstddef>
 #include <vector>
+#include "math/differences.hpp"
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
@@ -26,14 +27,21 @@ void ResidualPreconditioner::_update_(bool                   timeWindowComplete,
       }
       norms[k] = utils::IntraComm::l2norm(part);
       offset += _subVectorSizes[k];
-      PRECICE_ASSERT(norms[k] > 0.0);
     }
 
     offset = 0;
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-        _weights[i + offset]    = 1.0 / norms[k];
-        _invWeights[i + offset] = norms[k];
+      if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
+        PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
+                     "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+                     "check if the coupling data values of one solver is zero in the first iteration. "
+                     "The preconditioner scaling factors were not applied for this iteration.");
+      } else {
+        for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+          PRECICE_ASSERT(norms[k] > 0.0);
+          _weights[i + offset]    = 1.0 / norms[k];
+          _invWeights[i + offset] = norms[k];
+        }
       }
       offset += _subVectorSizes[k];
     }

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -53,7 +53,9 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
     }
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      _residualSum[k] += norms[k] / sum;
+      if (sum > math::NUMERICAL_ZERO_DIFFERENCE)
+        _residualSum[k] += norms[k] / sum;
+
       if (math::equals(_residualSum[k], 0.0)) {
         PRECICE_WARN("A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = {}). "
                      "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "

--- a/src/acceleration/impl/ValuePreconditioner.cpp
+++ b/src/acceleration/impl/ValuePreconditioner.cpp
@@ -1,6 +1,7 @@
 #include "acceleration/impl/ValuePreconditioner.hpp"
 #include <cstddef>
 #include <vector>
+#include "math/differences.hpp"
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
@@ -28,14 +29,21 @@ void ValuePreconditioner::_update_(bool                   timeWindowComplete,
       }
       norms[k] = utils::IntraComm::l2norm(part);
       offset += _subVectorSizes[k];
-      PRECICE_ASSERT(norms[k] > 0.0);
     }
 
     offset = 0;
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-        _weights[i + offset]    = 1.0 / norms[k];
-        _invWeights[i + offset] = norms[k];
+      if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
+        PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
+                     "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+                     "check if the coupling data values of one solver is zero in the first iteration. "
+                     "The preconditioner scaling factors were not applied for this iteration.");
+      } else {
+        for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+          PRECICE_ASSERT(norms[k] > 0.0);
+          _weights[i + offset]    = 1.0 / norms[k];
+          _invWeights[i + offset] = norms[k];
+        }
       }
       offset += _subVectorSizes[k];
     }


### PR DESCRIPTION
## Main changes of this PR

Prevents division by zero in case the coupling data is always zero or doesn't change over time.

## Motivation and additional information

Related to #1558
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->
