### PR TITLE
Clean-up tagging for kernel methods

### DIFF
--- a/docs/changelog/1912.md
+++ b/docs/changelog/1912.md
@@ -1,0 +1,2 @@
+- Fixed parallel repartitioning for PU-RBF to be more accurate.
+- Speed-up parallel repartitioning for global RBF mappings.

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -326,9 +326,11 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
 
   // Get the local bounding boxes
   auto localBB = outMesh->getBoundingBox();
-  // could run into issues if the output mesh is only a single mesh
-  // vertex in the outpur mesh
-  PRECICE_ASSERT(!localBB.empty());
+  // we cannot check for empty'ness here, as a single output mesh vertex
+  // would lead to a 0D box with zero volume (considered empty). Thus, we
+  // simply check here for default'ness, which is equivalent to outMesh->empty()
+  // further above
+  PRECICE_ASSERT(!localBB.isDefault());
 
   if (_clusterRadius == 0)
     _clusterRadius = impl::estimateClusterRadius(_verticesPerCluster, filterMesh, localBB);

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -306,47 +306,36 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
   if (outMesh->empty())
     return; // Ranks not at the interface should never hold interface vertices
 
-  // Note that we don't use the corresponding bounding box functions from
-  // precice::mesh (e.g. ::getBoundingBox), as the stored bounding box might
-  // have the wrong size (e.g. direct access)
-  precice::mesh::BoundingBox bb = filterMesh->index().getRtreeBounds();
+  // The geometric filter of the repartitioning is always disabled for the PU-RBF.
+  // The main rationale: if we use only a fraction of the mesh then we might end up
+  // with too few vertices per rank and we cannot prevent too few vertices from being
+  // tagged, if we have filtered too much vertices beforehand. When using the filtering,
+  // the user could increase the safety-factor or disable the filtering, but that's
+  // a bit hard to understand for users. When no geometric filter is applid,
+  // vertices().size() is here the same as getGlobalNumberOfVertices. Hence, it is much
+  // safer to make use of the unfiltered mesh for the parallel tagging.
+  //
+  // Drawback: the "estimateClusterRadius" below makes use of the mesh R* index tree, and
+  // constructing the tree on the (unfiltered) global mesh is computationally expensive (O( N logN)).
+  // We could pre-filter the global mesh to a local fraction (using our own geometric filtering,
+  // maybe with an increased safety margin or even an iterative increase of the safety margin),
+  // but then there is again the question on how to do this in a safe way, without risking
+  // failures depending on the partitioning. So we stick here to the computationally more
+  // demanding, but safer version.
+  // See also https://github.com/precice/precice/pull/1912#issuecomment-2551143620
 
-#ifndef NDEBUG
-  // Safety check
-  precice::mesh::BoundingBox bb_check(filterMesh->getDimensions());
-  for (const mesh::Vertex &vertex : filterMesh->vertices()) {
-    bb_check.expandBy(vertex);
-  }
-  PRECICE_ASSERT(bb_check == bb);
-#endif
-  // @TODO: This is assert and the function might run into problems if we have only a single.
-  // vertex in the received mesh
-  // However, with the current BB implementation, the expandBy function will just do nothing.
-  PRECICE_ASSERT(!bb.empty());
-  // This function behaves differently when disabling the geometric filtering
-  // without filter, we look at the complete mesh, whereas otherwise, we look at
-  // a fraction of the mesh and we might end up with too few vertices per rank
-  // We cannot prevent too few vertices from being tagged, if we have filtered too much
-  // vertices, but the user could increase the safety-factor or disable the filtering.
-  // When no geometric filter is applid, vertices().size() is here the same as
-  // getGlobalNumberOfVertices
-  if (filterMesh->nVertices() < _verticesPerCluster &&
-      filterMesh->nVertices() < static_cast<std::size_t>(filterMesh->getGlobalNumberOfVertices())) {
-    PRECICE_WARN("The repartitioning of the received mesh \"{}\" resulted in {} vertices on this "
-                 "rank, which is less than the desired number of vertices per cluster configured "
-                 "in the partition of unity mapping ({}). Consider increasing the safety-factor "
-                 "or switching off the geometric filter (<receive-mesh: ... geometric-filter=\"no-filter\" .../>)",
-                 filterMesh->getName(), filterMesh->nVertices(), _verticesPerCluster);
-  }
+  // Get the local bounding boxes
+  auto localBB = outMesh->getBoundingBox();
+  // could run into issues if the output mesh is only a single mesh
+  // vertex in the outpur mesh
+  PRECICE_ASSERT(!localBB.empty());
 
   if (_clusterRadius == 0)
-    _clusterRadius = impl::estimateClusterRadius(_verticesPerCluster, filterMesh, bb);
+    _clusterRadius = impl::estimateClusterRadius(_verticesPerCluster, filterMesh, localBB);
 
   PRECICE_DEBUG("Cluster radius estimate: {}", _clusterRadius);
   PRECICE_ASSERT(_clusterRadius > 0);
 
-  // Get the local bounding boxes
-  auto localBB = outMesh->getBoundingBox();
   // Now we extend the bounding box by the radius
   localBB.expandBy(2 * _clusterRadius);
 

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -138,13 +138,18 @@ void RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
     return; // Ranks not at the interface should never hold interface vertices
 
   // Tags all vertices that are inside otherMesh's bounding box, enlarged by the support radius
-
   if (_basisFunction.hasCompactSupport()) {
     auto bb = otherMesh->getBoundingBox();
     bb.expandBy(_basisFunction.getSupportRadius());
 
-    auto vertices = filterMesh->index().getVerticesInsideBox(bb);
-    std::for_each(vertices.begin(), vertices.end(), [&filterMesh](size_t v) { filterMesh->vertex(v).tag(); });
+    // We don't make use of the index tree here, because constructing the index tree on the
+    // (unfiltered) mesh is expensive
+    auto &vertices = filterMesh->vertices();
+    std::for_each(vertices.begin(), vertices.end(), [&bb](auto &v) {
+      if (bb.contains(v)) {
+        v.tag();
+      }
+    });
   } else {
     filterMesh->tagAll();
   }

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -686,12 +686,11 @@ void MappingConfiguration::finishRBFConfiguration()
   PRECICE_ASSERT(_executorConfig);
   ConfiguredMapping &mapping = _mappings.back();
 
-  // We need to disable the geometric filter in case we have global RBF mappings with a global support
-  // We instantiate here a dummy functionVariant to query the information about the compact support directly from the basis function
+  // We disable the geometric filter in case we have global RBF mappings, as the default safety factor is not reliable enough to provide a robust
+  // safety margin such that the mapping is still correct. For PUM, we still perform the filtering, as it accelerates the tagging and leads to
+  // more accurate settings of the cluster radius
   PRECICE_ASSERT(mapping.requiresBasisFunction);
-  auto functionVariant          = constructRBF(_rbfConfig.basisFunction, _rbfConfig.supportRadius, _rbfConfig.shapeParameter);
-  mapping.allowsGeometricFilter = _rbfConfig.solver == RBFConfiguration::SystemSolver::PUMDirect ||
-                                  std::visit([&](auto &&func) { return func.hasCompactSupport(); }, functionVariant);
+  mapping.allowsGeometricFilter = _rbfConfig.solver == RBFConfiguration::SystemSolver::PUMDirect;
 
   // Instantiate the RBF mapping classes
   // We first categorize according to the executor

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -685,6 +685,14 @@ void MappingConfiguration::finishRBFConfiguration()
 {
   PRECICE_ASSERT(_executorConfig);
   ConfiguredMapping &mapping = _mappings.back();
+
+  // We need to disable the geometric filter in case we have global RBF mappings with a global support
+  // We instantiate here a dummy functionVariant to query the information about the compact support directly from the basis function
+  PRECICE_ASSERT(mapping.requiresBasisFunction);
+  auto functionVariant          = constructRBF(_rbfConfig.basisFunction, _rbfConfig.supportRadius, _rbfConfig.shapeParameter);
+  mapping.allowsGeometricFilter = _rbfConfig.solver == RBFConfiguration::SystemSolver::PUMDirect ||
+                                  std::visit([&](auto &&func) { return func.hasCompactSupport(); }, functionVariant);
+
   // Instantiate the RBF mapping classes
   // We first categorize according to the executor
   // 1. the CPU executor

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -686,12 +686,6 @@ void MappingConfiguration::finishRBFConfiguration()
   PRECICE_ASSERT(_executorConfig);
   ConfiguredMapping &mapping = _mappings.back();
 
-  // We disable the geometric filter in case we have global RBF mappings, as the default safety factor is not reliable enough to provide a robust
-  // safety margin such that the mapping is still correct. For PUM, we still perform the filtering, as it accelerates the tagging and leads to
-  // more accurate settings of the cluster radius
-  PRECICE_ASSERT(mapping.requiresBasisFunction);
-  mapping.allowsGeometricFilter = _rbfConfig.solver == RBFConfiguration::SystemSolver::PUMDirect;
-
   // Instantiate the RBF mapping classes
   // We first categorize according to the executor
   // 1. the CPU executor

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -30,6 +30,8 @@ public:
     mesh::PtrMesh toMesh;
     /// Direction of mapping (important to set input and output mesh).
     Direction direction;
+    /// allows to filter the mesh before the first round of tagging
+    bool allowsGeometricFilter = true;
     /// true for RBF mapping
     bool requiresBasisFunction;
     /// used the automatic rbf alias tag in order to set the mapping

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -30,8 +30,6 @@ public:
     mesh::PtrMesh toMesh;
     /// Direction of mapping (important to set input and output mesh).
     Direction direction;
-    /// allows to filter the mesh before the first round of tagging
-    bool allowsGeometricFilter = true;
     /// true for RBF mapping
     bool requiresBasisFunction;
     /// used the automatic rbf alias tag in order to set the mapping

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -227,7 +227,7 @@ inline double estimateClusterRadius(unsigned int verticesPerCluster, mesh::PtrMe
   // Step 1: Generate random samples from the input mesh
   std::vector<VertexID> randomSamples;
 
-  PRECICE_ASSERT(!bb.empty(), "Center computation won't work right now.");
+  PRECICE_ASSERT(!bb.isDefault(), "Invalid bounding box.");
   // All samples are 'moved' to the closest vertex from the input mesh in order
   // to avoid empty clusters when we have shell-like meshes (as in surface coupling)
   // The first sample: the vertex closest to the bounding box center

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -457,8 +457,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     impl::MeshContext &fromMeshContext = participant->meshContext(fromMesh);
     impl::MeshContext &toMeshContext   = participant->meshContext(toMesh);
 
-    // We disable the filtering for any kernel methods, as all of them operate on the full mesh,
-    // mostly for safety reasons
+    // We disable the geometric filter for any kernel method, as the default safety factor is not reliable enough to provide a robust
+    // safety margin such that the mapping is still correct.
     if (!confMapping.requiresBasisFunction) {
       fromMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
       toMeshContext.geoFilter   = partition::ReceivedPartition::GeometricFilter::NO_FILTER;

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -457,8 +457,9 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     impl::MeshContext &fromMeshContext = participant->meshContext(fromMesh);
     impl::MeshContext &toMeshContext   = participant->meshContext(toMesh);
 
-    // @TODO: is this still correct?
-    if (!confMapping.allowsGeometricFilter) {
+    // We disable the filtering for any kernel methods, as all of them operate on the full mesh,
+    // mostly for safety reasons
+    if (!confMapping.requiresBasisFunction) {
       fromMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
       toMeshContext.geoFilter   = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
     }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -458,7 +458,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     impl::MeshContext &toMeshContext   = participant->meshContext(toMesh);
 
     // @TODO: is this still correct?
-    if (confMapping.requiresBasisFunction) {
+    if (!confMapping.allowsGeometricFilter) {
       fromMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
       toMeshContext.geoFilter   = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
     }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -156,7 +156,8 @@ ParticipantConfiguration::ParticipantConfiguration(
                                "`on-primary-rank` is beneficial for a huge mesh and a low number of processors, but is incompatible with two-level initialization. "
                                "`on-secondary-ranks` performs better for a very high number of processors. "
                                "Both result in the same distribution if the safety-factor is sufficiently large. "
-                               "`no-filter` may be useful for very asymmetric cases and for debugging.")
+                               "`no-filter` may be useful for very asymmetric cases and for debugging. "
+                               "If a mapping based on RBFs (rbf-pum,global-rbf) is used, the filter has no influence and is always `no-filter`.")
                            .setOptions({VALUE_NO_FILTER, VALUE_FILTER_ON_PRIMARY_RANK, VALUE_FILTER_ON_SECONDARY_RANKS})
                            .setDefaultValue(VALUE_FILTER_ON_SECONDARY_RANKS);
   tagReceiveMesh.addAttribute(attrGeoFilter);
@@ -459,7 +460,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
     // We disable the geometric filter for any kernel method, as the default safety factor is not reliable enough to provide a robust
     // safety margin such that the mapping is still correct.
-    if (!confMapping.requiresBasisFunction) {
+    if (confMapping.requiresBasisFunction) {
       fromMeshContext.geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
       toMeshContext.geoFilter   = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
     }


### PR DESCRIPTION
## Main changes of this PR
Removes the automatic switch-off of geometric filters for all but global RBFs using globally supported kernel functions.

## Motivation and additional information

This seems to be an older relic in the configuration of received meshes.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
