### PR TITLE
Tidy the API documentation

### DIFF
--- a/docs/documents/000_main.dox
+++ b/docs/documents/000_main.dox
@@ -9,7 +9,7 @@ Refer to \ref precice::tooling for the tooling API.
 
 The API of further native bindings can be found here:
 
-- \ref preciceC.h "precicec" for the C bindings.
+- \ref preciceC.h "preciceC" for the C bindings.
 - \ref preciceFortran.hpp "preciceFortran" for the Fortran bindings.
 
 # For Library Developers

--- a/docs/documents/span.dox
+++ b/docs/documents/span.dox
@@ -10,7 +10,7 @@
  * A simple mental model is an object that holds a pointer and size, so it knows how many elements it is allowed to access after the initial pointer.
  * You can imagine a `span<double>` to look like this:
  *
- * @code cpp
+ * @code{cpp}
  * class span {
  *   double* begin;
  *   size_t size;
@@ -19,7 +19,7 @@
  *
  * This type can also be read-only aka `const`. You can imagine a `span<const double>` to look like this:
  *
- * @code cpp
+ * @code{cpp}
  * class span {
  *   double const* begin;
  *   size_t size;

--- a/docs/documents/span.dox
+++ b/docs/documents/span.dox
@@ -2,9 +2,36 @@
  *
  * @copyright Copyright Tristan Brindle 2018.
  *
- * @brief A C++ 11 implementation of the non-owning C++20 std::span type.
+ * @brief A C++ 11 implementation of the non-owning C++20 \ref std::span type.
  *
- * A span represents a non-owning view into a contiguous block of memory of a known size.
+ * A \ref span represents a non-owning view into a contiguous block of memory of a known size.
+ * This view can be mutable or const, depending on the type.
  *
- * This version contains an additional constructor for `const char *`-style C strings, allowing the span to mimic C++17 std::string_view.
+ * A simple mental model is an object that holds a pointer and size, so it knows how many elements it is allowed to access after the initial pointer.
+ * You can imagine a `span<double>` to look like this:
+ *
+ * @code cpp
+ * class span {
+ *   double* begin;
+ *   size_t size;
+ * }
+ * @endcode
+ *
+ * This type can also be read-only aka `const`. You can imagine a `span<const double>` to look like this:
+ *
+ * @code cpp
+ * class span {
+ *   double const* begin;
+ *   size_t size;
+ * }
+ * @endcode
+ *
+ * It can be constructed from:
+ * - A pointer and size
+ * - A pointer to first element and pointer to one past the last element
+ * - A C-style array `char[10]`
+ * - A C++ STL arrays `std::array<char,10>`
+ * - A contiguous range with size `end(R) - begin(R)`, such as a `std::vector`
+ *
+ * @note This version contains an additional constructor for `const char *`-style C strings, allowing the span to mimic C++17 \ref std::string_view.
  */

--- a/extras/bindings/c/include/precice/preciceC.h
+++ b/extras/bindings/c/include/precice/preciceC.h
@@ -162,13 +162,13 @@ PRECICE_API void precicec_setMeshVertices(
     int *         ids);
 
 /**
- * @brief Sets mesh edge from vertex IDs, returns edge ID.
+ * @brief Sets mesh edge from vertex IDs
  *
  * @param[in] meshName the name of the mesh to add the edge to
  * @param[in] firstVertexID ID of the first vertex of the edge
  * @param[in] secondVertexID ID of the second vertex of the edge
  *
- * @return the ID of the edge
+ * @pre ids were added to the mesh with the name \p meshName
  */
 PRECICE_API void precicec_setMeshEdge(
     const char *meshName,
@@ -182,7 +182,7 @@ PRECICE_API void precicec_setMeshEdge(
  * @param[in] size the amount of edges to set
  * @param[in] ids an array containing 2*size vertex IDs
  *
- * @pre ids were added to the mesh with the ID meshID
+ * @pre ids were added to the mesh with the name \p meshName
  */
 PRECICE_API void precicec_setMeshEdges(
     const char *meshName,
@@ -205,7 +205,7 @@ PRECICE_API void precicec_setMeshTriangle(
  * @param[in] size the amount of triangles to set
  * @param[in] ids an array containing 3*size vertex IDs
  *
- * @pre vertices in \p ids were added to the mesh with the ID meshID
+ * @pre vertices in \p ids were added to the mesh with the name \p meshName
  */
 PRECICE_API void precicec_setMeshTriangles(
     const char *meshName,
@@ -235,7 +235,7 @@ PRECICE_API void precicec_setMeshQuad(
  * @param[in] size the amount of quads to set
  * @param[in] ids an array containing 4*size vertex IDs
  *
- * @pre vertices in \ids were added to the mesh with the ID meshID
+ * @pre vertices in \ids were added to the mesh with the name \p meshName
  */
 PRECICE_API void precicec_setMeshQuads(
     const char *meshName,
@@ -265,7 +265,7 @@ PRECICE_API void precicec_setMeshTetrahedron(
  * @param[in] size the amount of tetrahedra to set
  * @param[in] ids an array containing 4*size vertex IDs
  *
- * @pre vertices in ids were added to the mesh with the ID meshID
+ * @pre vertices in ids were added to the mesh with the name \p meshName
  */
 PRECICE_API void precicec_setMeshTetrahedra(
     const char *meshName,

--- a/extras/bindings/c/include/precice/preciceC.h
+++ b/extras/bindings/c/include/precice/preciceC.h
@@ -8,8 +8,12 @@ extern "C" {
 #endif
 
 /**
+ * @file
  * @brief C language bindings to main Application Programming Interface of preCICE
  *
+ * The C bindings are thin wrappers around the C++ API.
+ *
+ * Refer to \ref precice::Participant for detailed documentation.
  */
 
 ///@name Construction and Configuration
@@ -77,6 +81,17 @@ PRECICE_API void precicec_finalize();
 
 ///@}
 
+///@name Implicit coupling
+///@{
+
+/// @copydoc precice::Participant::requiresWritingCheckpoint()
+PRECICE_API int precicec_requiresWritingCheckpoint();
+
+/// @copydoc precice::Participant::requiresReadingCheckpoint()
+PRECICE_API int precicec_requiresReadingCheckpoint();
+
+///@}
+
 ///@name Status Queries
 ///@{
 
@@ -103,18 +118,6 @@ PRECICE_API double precicec_getMaxTimeStepSize();
 
 ///@}
 
-///@name Action Methods
-///@{
-
-/// @copydoc precice::Participant::requiresInitialData()
-PRECICE_API int precicec_requiresInitialData();
-
-/// @copydoc precice::Participant::requiresWritingCheckpoint()
-PRECICE_API int precicec_requiresWritingCheckpoint();
-
-/// @copydoc precice::Participant::requiresReadingCheckpoint()
-PRECICE_API int precicec_requiresReadingCheckpoint();
-
 ///@name Mesh Access
 ///@anchor precice-mesh-access
 ///@{
@@ -126,12 +129,12 @@ PRECICE_API int precicec_requiresMeshConnectivityFor(const char *meshName);
  * @brief Creates a mesh vertex
  *
  * @param[in] meshName the name of the mesh to add the vertex to.
- * @param[in] position a pointer to the coordinates of the vertex.
+ * @param[in] coordinates a pointer to the coordinates of the vertex.
  * @returns the id of the created vertex
  */
 PRECICE_API int precicec_setMeshVertex(
     const char *  meshName,
-    const double *position);
+    const double *coordinates);
 
 /**
  * @brief Returns the number of vertices of a mesh.
@@ -146,7 +149,7 @@ PRECICE_API int precicec_getMeshVertexSize(const char *meshName);
  *
  * @param[in] meshName the name of the mesh to add the vertices to.
  * @param[in] size Number of vertices to create
- * @param[in] positions a pointer to the coordinates of the vertices
+ * @param[in] coordinates a pointer to the coordinates of the vertices
  *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
  *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
  *
@@ -155,7 +158,7 @@ PRECICE_API int precicec_getMeshVertexSize(const char *meshName);
 PRECICE_API void precicec_setMeshVertices(
     const char *  meshName,
     int           size,
-    const double *positions,
+    const double *coordinates,
     int *         ids);
 
 /**
@@ -177,14 +180,14 @@ PRECICE_API void precicec_setMeshEdge(
  *
  * @param[in] meshName the name of the mesh to add the edges to
  * @param[in] size the amount of edges to set
- * @param[in] vertices an array containing 2*size vertex IDs
+ * @param[in] ids an array containing 2*size vertex IDs
  *
- * @pre vertices were added to the mesh with the ID meshID
+ * @pre ids were added to the mesh with the ID meshID
  */
 PRECICE_API void precicec_setMeshEdges(
     const char *meshName,
     int         size,
-    const int * vertices);
+    const int * ids);
 
 /**
  * @brief Sets a triangle from vertex IDs. Creates missing edges.
@@ -200,14 +203,14 @@ PRECICE_API void precicec_setMeshTriangle(
  *
  * @param[in] meshName the name of the mesh to add the triangles to
  * @param[in] size the amount of triangles to set
- * @param[in] vertices an array containing 3*size vertex IDs
+ * @param[in] ids an array containing 3*size vertex IDs
  *
- * @pre vertices were added to the mesh with the ID meshID
+ * @pre vertices in \p ids were added to the mesh with the ID meshID
  */
 PRECICE_API void precicec_setMeshTriangles(
     const char *meshName,
     int         size,
-    const int * vertices);
+    const int * ids);
 
 /**
  * @brief Sets surface mesh quadrangle from vertex IDs.
@@ -230,14 +233,14 @@ PRECICE_API void precicec_setMeshQuad(
  *
  * @param[in] meshName the name of the mesh to add the quad to
  * @param[in] size the amount of quads to set
- * @param[in] vertices an array containing 4*size vertex IDs
+ * @param[in] ids an array containing 4*size vertex IDs
  *
- * @pre vertices were added to the mesh with the ID meshID
+ * @pre vertices in \ids were added to the mesh with the ID meshID
  */
 PRECICE_API void precicec_setMeshQuads(
     const char *meshName,
     int         size,
-    const int * vertices);
+    const int * ids);
 
 /**
  * @brief Sets mesh tetrahedron from vertex IDs.
@@ -260,35 +263,22 @@ PRECICE_API void precicec_setMeshTetrahedron(
  *
  * @param[in] meshName the name of the mesh to add the tetrahedra to
  * @param[in] size the amount of tetrahedra to set
- * @param[in] vertices an array containing 4*size vertex IDs
+ * @param[in] ids an array containing 4*size vertex IDs
  *
- * @pre vertices were added to the mesh with the ID meshID
+ * @pre vertices in ids were added to the mesh with the ID meshID
  */
 PRECICE_API void precicec_setMeshTetrahedra(
     const char *meshName,
     int         size,
-    const int * vertices);
-
-/**
- * @brief See precice::Participant::setMeshAccessRegion().
- */
-PRECICE_API void precicec_setMeshAccessRegion(
-    const char *  meshName,
-    const double *boundingBox);
-
-/**
- * @brief See precice::Participant::getMeshVertexIDsAndCoordinates().
- */
-PRECICE_API void precicec_getMeshVertexIDsAndCoordinates(
-    const char *meshName,
-    const int   size,
-    int *       ids,
-    double *    coordinates);
+    const int * ids);
 
 ///@}
 
 ///@name Data Access
 ///@{
+
+/// @copydoc precice::Participant::requiresInitialData()
+PRECICE_API int precicec_requiresInitialData();
 
 /**
  * @brief Writes vector data values given as block.
@@ -335,20 +325,30 @@ PRECICE_API void precicec_readData(
     double      relativeReadTime,
     double *    values);
 
+///@}
+
+///@name Direct mesh access
+///@{
+
 /**
- * @brief Returns information on the version of preCICE.
- *
- * Returns a semicolon-separated C-string containing:
- *
- * 1) the version of preCICE
- * 2) the revision information of preCICE
- * 3) the configuration of preCICE including MPI, PETSC, PYTHON
+ * @brief See precice::Participant::setMeshAccessRegion().
  */
-PRECICE_API const char *precicec_getVersionInformation();
+PRECICE_API void precicec_setMeshAccessRegion(
+    const char *  meshName,
+    const double *boundingBox);
+
+/**
+ * @brief See precice::Participant::getMeshVertexIDsAndCoordinates().
+ */
+PRECICE_API void precicec_getMeshVertexIDsAndCoordinates(
+    const char *meshName,
+    const int   size,
+    int *       ids,
+    double *    coordinates);
 
 ///@}
 
-/** @name Experimental Data Access
+/** @name Experimental Gradient Data
  * These API functions are \b experimental and may change in future versions.
  */
 ///@{
@@ -366,6 +366,17 @@ PRECICE_API void precicec_writeGradientData(
     const double *gradients);
 
 ///@}
+
+/**
+ * @brief Returns information on the version of preCICE.
+ *
+ * Returns a semicolon-separated C-string containing:
+ *
+ * 1) the version of preCICE
+ * 2) the revision information of preCICE
+ * 3) the configuration of preCICE including MPI, PETSC, PYTHON
+ */
+PRECICE_API const char *precicec_getVersionInformation();
 
 #ifdef __cplusplus
 }

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -4,7 +4,7 @@
 
 /** @file
  * This file contains a Fortran 77 compatible interface written in C/C++.
- *
+ * The Fortran bindings are thin wrappers around the C++ API.
  *
  * Every method has a Fortran syntax equivalent in the method comment, and a
  * listing for input and output variables. A variable can be input and output
@@ -14,6 +14,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+///@name Construction and Configuration
+///@{
 
 /**
  * Fortran syntax:
@@ -36,6 +39,11 @@ PRECICE_API void precicef_create_(
     const int * solverProcessSize,
     int         participantNameLength,
     int         configFileNameLength);
+
+///@}
+
+/// @name Steering Methods
+///@{
 
 /**
  * Fortran syntax:
@@ -69,6 +77,42 @@ PRECICE_API void precicef_advance_(const double *timeStepSize);
  *
  */
 PRECICE_API void precicef_finalize_();
+
+///@}
+
+///@name Implicit coupling
+///@{
+
+/**
+ * Fortran syntax:
+ * precicef_requires_reading_checkpoint_(
+ *   INTEGER   isRequired )
+ *
+ * IN:  -
+ * OUT: isRequired(1:true, 0:false)
+ *
+ * @copydoc precice::Participant::requiresReadingCheckpoint()
+ */
+PRECICE_API void precicef_requires_reading_checkpoint_(
+    int *isRequired);
+
+/**
+ * Fortran syntax:
+ * precicef_requires_writing_checkpoint_(
+ *   INTEGER   isRequired )
+ *
+ * IN:  -
+ * OUT: isRequired(1:true, 0:false)
+ *
+ * @copydoc precice::Participant::requiresWritingCheckpoint()
+ */
+PRECICE_API void precicef_requires_writing_checkpoint_(
+    int *isRequired);
+
+///@}
+
+///@name Status Queries
+///@{
 
 /**
  * Fortran syntax:
@@ -143,44 +187,11 @@ PRECICE_API void precicef_is_time_window_complete_(int *isComplete);
  */
 PRECICE_API void precicef_get_max_time_step_size_(double *maxTimeStepSize);
 
-/**
- * Fortran syntax:
- * precicef_requires_initial_data_(
- *   INTEGER   isRequired )
- *
- * IN:  -
- * OUT: isRequired(1:true, 0:false)
- *
- * @copydoc precice::Participant::requiresInitialData()
- */
-PRECICE_API void precicef_requires_initial_data_(
-    int *isRequired);
+///@}
 
-/**
- * Fortran syntax:
- * precicef_requires_reading_checkpoint_(
- *   INTEGER   isRequired )
- *
- * IN:  -
- * OUT: isRequired(1:true, 0:false)
- *
- * @copydoc precice::Participant::requiresReadingCheckpoint()
- */
-PRECICE_API void precicef_requires_reading_checkpoint_(
-    int *isRequired);
-
-/**
- * Fortran syntax:
- * precicef_requires_writing_checkpoint_(
- *   INTEGER   isRequired )
- *
- * IN:  -
- * OUT: isRequired(1:true, 0:false)
- *
- * @copydoc precice::Participant::requiresWritingCheckpoint()
- */
-PRECICE_API void precicef_requires_writing_checkpoint_(
-    int *isRequired);
+///@name Mesh Access
+///@anchor precice-mesh-access
+///@{
 
 /**
  * Fortran syntax:
@@ -202,19 +213,19 @@ PRECICE_API void precicef_requires_mesh_connectivity_for_(
  * Fortran syntax:
  * precicef_set_vertex(
  *   CHARACTER        meshName(*),
- *   DOUBLE PRECISION position(dim),
- *   INTEGER          vertexID )
+ *   DOUBLE PRECISION coordinates(dim),
+ *   INTEGER          id )
  *
- * IN:  mesh, position, meshNameLength
- * OUT: vertexID
+ * IN:  mesh, coordinates, meshNameLength
+ * OUT: id
  *
  * @copydoc precice::Participant::setMeshVertex()
  *
  */
 PRECICE_API void precicef_set_vertex_(
     const char *  meshName,
-    const double *position,
-    int *         vertexID,
+    const double *coordinates,
+    int *         id,
     int           meshNameLength);
 
 /**
@@ -239,11 +250,11 @@ PRECICE_API void precicef_get_mesh_vertex_size_(
  * precicef_set_vertices(
  *   CHARACTER        meshName(*),
  *   INTEGER          size,
- *   DOUBLE PRECISION positions(dim*size),
- *   INTEGER          positionIDs(size) )
+ *   DOUBLE PRECISION coordinates(dim*size),
+ *   INTEGER          ids(size) )
  *
- * IN:  mesh, size, positions, meshNameLength
- * OUT: positionIDs
+ * IN:  mesh, size, coordinates, meshNameLength
+ * OUT: ids
  *
  * @copydoc precice::Participant::setMeshVertices()
  *
@@ -251,8 +262,8 @@ PRECICE_API void precicef_get_mesh_vertex_size_(
 PRECICE_API void precicef_set_vertices_(
     const char *meshName,
     const int * size,
-    double *    positions,
-    int *       positionIDs,
+    double *    coordinates,
+    int *       ids,
     int         meshNameLength);
 
 /**
@@ -279,9 +290,9 @@ PRECICE_API void precicef_set_edge_(
  * precicef_set_mesh_edges_(
  *   CHARACTER meshName(*),
  *   INTEGER size,
- *   INTEGER vertices(size*2) )
+ *   INTEGER ids(size*2) )
  *
- * IN:  mesh, size, vertices, meshNameLength
+ * IN:  mesh, size, ids, meshNameLength
  * OUT: -
  *
  * @copydoc precice::Participant::setMeshEdges()
@@ -290,7 +301,7 @@ PRECICE_API void precicef_set_edge_(
 PRECICE_API void precicef_set_mesh_edges_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength);
 
 /**
@@ -319,9 +330,9 @@ PRECICE_API void precicef_set_triangle_(
  * precicef_set_mesh_triangles_(
  *   CHARACTER meshName(*),
  *   INTEGER size,
- *   INTEGER vertices(size*3) )
+ *   INTEGER ids(size*3) )
  *
- * IN:  mesh, size, vertices, meshNameLength
+ * IN:  mesh, size, ids, meshNameLength
  * OUT: -
  *
  * @copydoc precice::Participant::setMeshTriangles()
@@ -330,7 +341,7 @@ PRECICE_API void precicef_set_triangle_(
 PRECICE_API void precicef_set_mesh_edges_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength);
 
 /**
@@ -361,9 +372,9 @@ PRECICE_API void precicef_set_quad_(
  * precicef_set_mesh_quads(
  *   CHARACTER meshName(*),
  *   INTEGER size,
- *   INTEGER vertices(size*4) )
+ *   INTEGER ids(size*4) )
  *
- * IN:  mesh, size, vertices, meshNameLength
+ * IN:  mesh, size, ids, meshNameLength
  * OUT: -
  *
  * @copydoc precice::Participant::setMeshQuads()
@@ -372,7 +383,7 @@ PRECICE_API void precicef_set_quad_(
 PRECICE_API void precicef_set_mesh_quads_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength);
 
 /**
@@ -403,9 +414,9 @@ PRECICE_API void precicef_set_tetrahedron(
  * precicef_set_mesh_tetrahedra_(
  *   CHARACTER meshName(*),
  *   INTEGER size,
- *   INTEGER vertices(size*4) )
+ *   INTEGER ids(size*4) )
  *
- * IN:  mesh, size, vertices, meshNameLength
+ * IN:  mesh, size, ids, meshNameLength
  * OUT: -
  *
  * @copydoc precice::Participant::setMeshTetrahedra()
@@ -414,8 +425,81 @@ PRECICE_API void precicef_set_tetrahedron(
 PRECICE_API void precicef_set_mesh_tetrahedra_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength);
+
+///@}
+
+///@name Data Access
+///@{
+
+/**
+ * Fortran syntax:
+ * precicef_requires_initial_data_(
+ *   INTEGER   isRequired )
+ *
+ * IN:  -
+ * OUT: isRequired(1:true, 0:false)
+ *
+ * @copydoc precice::Participant::requiresInitialData()
+ */
+PRECICE_API void precicef_requires_initial_data_(
+    int *isRequired);
+
+/**
+ * Fortran syntax:
+ * precicef_write_data(
+ *   CHARACTER meshName(*),
+ *   CHARACTER dataName(*),
+ *   INTEGER size,
+ *   INTEGER ids,
+ *   DOUBLE PRECISION values(dim*size) )
+ *
+ * IN:  mesh, data, size, ids, values, meshNameLength, dataNameLength
+ * OUT: -
+ *
+ * @copydoc precice::Participant::writeData
+ *
+ */
+PRECICE_API void precicef_write_data_(
+    const char *meshName,
+    const char *dataName,
+    const int * size,
+    int *       ids,
+    double *    values,
+    int         meshNameLength,
+    int         dataNameLength);
+
+/**
+ * Fortran syntax:
+ * precicef_read_data(
+ *   CHARACTER meshName(*),
+ *   CHARACTER dataName(*),
+ *   INTEGER size,
+ *   INTEGER ids,
+ *   DOUBLE PRECISION relativeReadTime,
+ *   DOUBLE PRECISION values(dim*size) )
+ *
+ * IN:  mesh, data, size, ids, meshNameLength, dataNameLength
+ * OUT: values
+ *
+ * @copydoc precice::Participant::readData
+ *
+ */
+PRECICE_API void precicef_read_data_(
+    const char *  meshName,
+    const char *  dataName,
+    const int *   size,
+    int *         ids,
+    const double *relativeReadTime,
+    double *      values,
+    int           meshNameLength,
+    int           dataNameLength);
+
+///@}
+
+///@name Direct mesh access
+///@{
 
 /**
  * Fortran syntax:
@@ -453,61 +537,9 @@ PRECICE_API void precicef_get_mesh_vertex_ids_and_coordinates_(
     double *    coordinates,
     int         meshNameLength);
 
-/**
- * Fortran syntax:
- * precicef_write_data(
- *   CHARACTER meshName(*),
- *   CHARACTER dataName(*),
- *   INTEGER size,
- *   INTEGER valueIndices,
- *   DOUBLE PRECISION values(dim*size) )
- *
- * IN:  mesh, data, size, valueIndices, values, meshNameLength, dataNameLength
- * OUT: -
- *
- * @copydoc precice::Participant::writeData
- *
- */
-PRECICE_API void precicef_write_data_(
-    const char *meshName,
-    const char *dataName,
-    const int * size,
-    int *       valueIndices,
-    double *    values,
-    int         meshNameLength,
-    int         dataNameLength);
+///@}
 
-/**
- * Fortran syntax:
- * precicef_read_data(
- *   CHARACTER meshName(*),
- *   CHARACTER dataName(*),
- *   INTEGER size,
- *   INTEGER valueIndices,
- *   DOUBLE PRECISION relativeReadTime,
- *   DOUBLE PRECISION values(dim*size) )
- *
- * IN:  mesh, data, size, valueIndices, meshNameLength, dataNameLength
- * OUT: values
- *
- * @copydoc precice::Participant::readData
- *
- */
-PRECICE_API void precicef_read_data_(
-    const char *  meshName,
-    const char *  dataName,
-    const int *   size,
-    int *         valueIndices,
-    const double *relativeReadTime,
-    double *      values,
-    int           meshNameLength,
-    int           dataNameLength);
-
-PRECICE_API void precicef_get_version_information_(
-    char *versionInfo,
-    int   lengthVersionInfo);
-
-/** @name Experimental Data Access
+/** @name Experimental Gradient Data
  * These API functions are \b experimental and may change in future versions.
  */
 ///@{
@@ -536,10 +568,10 @@ PRECICE_API void precicef_requires_gradient_data_for_(
  *   CHARACTER meshName(*),
  *   CHARACTER dataName(*),
  *   INTEGER size,
- *   INTEGER valueIndices,
+ *   INTEGER ids,
  *   DOUBLE PRECISION gradients )
  *
- * IN:  mesh, data, size, valueIndices, gradients, meshNameLength, dataNameLength
+ * IN:  mesh, data, size, ids, gradients, meshNameLength, dataNameLength
  * OUT: -
  *
  * @copydoc precice::Participant::writeGradientData
@@ -548,12 +580,16 @@ PRECICE_API void precicef_write_gradient_data_(
     const char *  meshName,
     const char *  dataName,
     const int *   size,
-    const int *   valueIndices,
+    const int *   ids,
     const double *gradients,
     int           meshNameLength,
     int           dataNameLength);
 
 ///@}
+
+PRECICE_API void precicef_get_version_information_(
+    char *versionInfo,
+    int   lengthVersionInfo);
 
 #ifdef __cplusplus
 }

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -180,14 +180,14 @@ void precicef_get_mesh_vertex_size_(
 void precicef_set_vertices_(
     const char *meshName,
     const int * size,
-    double *    positions,
-    int *       positionIDs,
+    double *    coordinates,
+    int *       ids,
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto sv           = precice::impl::strippedStringView(meshName, meshNameLength);
   auto positionSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * *size);
-  impl->setMeshVertices(sv, {positions, positionSize}, {positionIDs, static_cast<unsigned long>(*size)});
+  impl->setMeshVertices(sv, {coordinates, positionSize}, {ids, static_cast<unsigned long>(*size)});
 }
 
 void precicef_set_edge_(
@@ -203,12 +203,12 @@ void precicef_set_edge_(
 void precicef_set_mesh_edges_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  auto verticesSize = static_cast<unsigned long>(*size) * 2;
-  impl->setMeshEdges(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
+  auto idsSize = static_cast<unsigned long>(*size) * 2;
+  impl->setMeshEdges(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
 }
 
 void precicef_set_triangle_(
@@ -225,12 +225,12 @@ void precicef_set_triangle_(
 void precicef_set_mesh_triangles_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  auto verticesSize = static_cast<unsigned long>(*size) * 3;
-  impl->setMeshTriangles(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
+  auto idsSize = static_cast<unsigned long>(*size) * 3;
+  impl->setMeshTriangles(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
 }
 
 void precicef_set_quad_(
@@ -248,12 +248,12 @@ void precicef_set_quad_(
 void precicef_set_mesh_quads_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  auto verticesSize = static_cast<unsigned long>(*size) * 4;
-  impl->setMeshQuads(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
+  auto idsSize = static_cast<unsigned long>(*size) * 4;
+  impl->setMeshQuads(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
 }
 
 void precicef_set_tetrahedron(
@@ -271,19 +271,19 @@ void precicef_set_tetrahedron(
 void precicef_set_mesh_tetrahedra_(
     const char *meshName,
     const int * size,
-    const int * vertices,
+    const int * ids,
     int         meshNameLength)
 {
   PRECICE_CHECK(impl != nullptr, errormsg);
-  auto verticesSize = static_cast<unsigned long>(*size) * 4;
-  impl->setMeshTetrahedra(precice::impl::strippedStringView(meshName, meshNameLength), {vertices, verticesSize});
+  auto idsSize = static_cast<unsigned long>(*size) * 4;
+  impl->setMeshTetrahedra(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
 }
 
 void precicef_write_data_(
     const char *meshName,
     const char *dataName,
     const int * size,
-    int *       valueIndices,
+    int *       ids,
     double *    values,
     int         meshNameLength,
     int         dataNameLength)
@@ -294,7 +294,7 @@ void precicef_write_data_(
   auto dataSize         = *size * impl->getDataDimensions(strippedMeshName, strippedDataName);
   impl->writeData(strippedMeshName,
                   strippedDataName,
-                  {valueIndices, static_cast<unsigned long>(*size)},
+                  {ids, static_cast<unsigned long>(*size)},
                   {values, static_cast<unsigned long>(dataSize)});
 }
 
@@ -302,7 +302,7 @@ void precicef_read_data_(
     const char *  meshName,
     const char *  dataName,
     const int *   size,
-    int *         valueIndices,
+    int *         ids,
     const double *relativeReadTime,
     double *      values,
     int           meshNameLength,
@@ -315,7 +315,7 @@ void precicef_read_data_(
   impl->readData(
       strippedMeshName,
       strippedDataName,
-      {valueIndices, static_cast<unsigned long>(*size)},
+      {ids, static_cast<unsigned long>(*size)},
       *relativeReadTime,
       {values, static_cast<unsigned long>(dataSize)});
 }
@@ -365,7 +365,7 @@ void precicef_write_gradient_data_(
     const char *  meshName,
     const char *  dataName,
     const int *   size,
-    const int *   valueIndices,
+    const int *   ids,
     const double *gradients,
     int           meshNameLength,
     int           dataNameLength)
@@ -378,7 +378,7 @@ void precicef_write_gradient_data_(
 
   impl->writeGradientData(strippedMeshName,
                           strippedDataName,
-                          {valueIndices, static_cast<unsigned long>(*size)},
+                          {ids, static_cast<unsigned long>(*size)},
                           {gradients, static_cast<unsigned long>(gradientSize)});
 }
 
@@ -393,7 +393,7 @@ void precicef_set_mesh_access_region_(
   impl->setMeshAccessRegion(sv, {boundingBox, bbSize});
 }
 
-void precicef_get_mesh_vertices_and_ids_(
+void precicef_get_mesh_vertex_ids_and_coordinates_(
     const char *meshName,
     const int   size,
     int *       ids,

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -133,10 +133,10 @@ void Participant::setMeshVertices(
 
 void Participant::setMeshEdge(
     ::precice::string_view meshName,
-    VertexID               firstVertexID,
-    VertexID               secondVertexID)
+    VertexID               first,
+    VertexID               second)
 {
-  _impl->setMeshEdge(toSV(meshName), firstVertexID, secondVertexID);
+  _impl->setMeshEdge(toSV(meshName), first, second);
 }
 
 void Participant::setMeshEdges(
@@ -148,11 +148,11 @@ void Participant::setMeshEdges(
 
 void Participant::setMeshTriangle(
     ::precice::string_view meshName,
-    VertexID               firstVertexID,
-    VertexID               secondVertexID,
-    VertexID               thirdVertexID)
+    VertexID               first,
+    VertexID               second,
+    VertexID               third)
 {
-  _impl->setMeshTriangle(toSV(meshName), firstVertexID, secondVertexID, thirdVertexID);
+  _impl->setMeshTriangle(toSV(meshName), first, second, third);
 }
 
 void Participant::setMeshTriangles(
@@ -164,13 +164,12 @@ void Participant::setMeshTriangles(
 
 void Participant::setMeshQuad(
     ::precice::string_view meshName,
-    VertexID               firstVertexID,
-    VertexID               secondVertexID,
-    VertexID               thirdVertexID,
-    VertexID               fourthVertexID)
+    VertexID               first,
+    VertexID               second,
+    VertexID               third,
+    VertexID               fourth)
 {
-  _impl->setMeshQuad(toSV(meshName), firstVertexID, secondVertexID, thirdVertexID,
-                     fourthVertexID);
+  _impl->setMeshQuad(toSV(meshName), first, second, third, fourth);
 }
 
 void Participant::setMeshQuads(
@@ -182,13 +181,12 @@ void Participant::setMeshQuads(
 
 void Participant::setMeshTetrahedron(
     ::precice::string_view meshName,
-    VertexID               firstVertexID,
-    VertexID               secondVertexID,
-    VertexID               thirdVertexID,
-    VertexID               fourthVertexID)
+    VertexID               first,
+    VertexID               second,
+    VertexID               third,
+    VertexID               fourth)
 {
-  _impl->setMeshTetrahedron(toSV(meshName), firstVertexID, secondVertexID, thirdVertexID,
-                            fourthVertexID);
+  _impl->setMeshTetrahedron(toSV(meshName), first, second, third, fourth);
 }
 
 void Participant::setMeshTetrahedra(

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -119,9 +119,9 @@ bool Participant::requiresGradientDataFor(::precice::string_view meshName,
 
 int Participant::setMeshVertex(
     ::precice::string_view        meshName,
-    ::precice::span<const double> position)
+    ::precice::span<const double> coordinates)
 {
-  return _impl->setMeshVertex(toSV(meshName), position);
+  return _impl->setMeshVertex(toSV(meshName), coordinates);
 }
 
 int Participant::getMeshVertexSize(
@@ -132,10 +132,10 @@ int Participant::getMeshVertexSize(
 
 void Participant::setMeshVertices(
     ::precice::string_view        meshName,
-    ::precice::span<const double> positions,
+    ::precice::span<const double> coordinates,
     ::precice::span<VertexID>     ids)
 {
-  _impl->setMeshVertices(toSV(meshName), positions, ids);
+  _impl->setMeshVertices(toSV(meshName), coordinates, ids);
 }
 
 void Participant::setMeshEdge(
@@ -148,9 +148,9 @@ void Participant::setMeshEdge(
 
 void Participant::setMeshEdges(
     ::precice::string_view          meshName,
-    ::precice::span<const VertexID> vertices)
+    ::precice::span<const VertexID> ids)
 {
-  _impl->setMeshEdges(toSV(meshName), vertices);
+  _impl->setMeshEdges(toSV(meshName), ids);
 }
 
 void Participant::setMeshTriangle(
@@ -164,9 +164,9 @@ void Participant::setMeshTriangle(
 
 void Participant::setMeshTriangles(
     ::precice::string_view          meshName,
-    ::precice::span<const VertexID> vertices)
+    ::precice::span<const VertexID> ids)
 {
-  _impl->setMeshTriangles(toSV(meshName), vertices);
+  _impl->setMeshTriangles(toSV(meshName), ids);
 }
 
 void Participant::setMeshQuad(
@@ -182,9 +182,9 @@ void Participant::setMeshQuad(
 
 void Participant::setMeshQuads(
     ::precice::string_view          meshName,
-    ::precice::span<const VertexID> vertices)
+    ::precice::span<const VertexID> ids)
 {
-  _impl->setMeshQuads(toSV(meshName), vertices);
+  _impl->setMeshQuads(toSV(meshName), ids);
 }
 
 void Participant::setMeshTetrahedron(
@@ -200,28 +200,28 @@ void Participant::setMeshTetrahedron(
 
 void Participant::setMeshTetrahedra(
     ::precice::string_view          meshName,
-    ::precice::span<const VertexID> vertices)
+    ::precice::span<const VertexID> ids)
 {
-  _impl->setMeshTetrahedra(toSV(meshName), vertices);
+  _impl->setMeshTetrahedra(toSV(meshName), ids);
 }
 
 void Participant::writeData(
     ::precice::string_view          meshName,
     ::precice::string_view          dataName,
-    ::precice::span<const VertexID> vertices,
+    ::precice::span<const VertexID> ids,
     ::precice::span<const double>   values)
 {
-  _impl->writeData(toSV(meshName), toSV(dataName), vertices, values);
+  _impl->writeData(toSV(meshName), toSV(dataName), ids, values);
 }
 
 void Participant::readData(
     ::precice::string_view          meshName,
     ::precice::string_view          dataName,
-    ::precice::span<const VertexID> vertices,
+    ::precice::span<const VertexID> ids,
     double                          relativeReadTime,
     ::precice::span<double>         values) const
 {
-  _impl->readData(toSV(meshName), toSV(dataName), vertices, relativeReadTime, values);
+  _impl->readData(toSV(meshName), toSV(dataName), ids, relativeReadTime, values);
 }
 
 void Participant::setMeshAccessRegion(::precice::string_view        meshName,
@@ -240,10 +240,10 @@ void Participant::getMeshVertexIDsAndCoordinates(::precice::string_view    meshN
 void Participant::writeGradientData(
     ::precice::string_view          meshName,
     ::precice::string_view          dataName,
-    ::precice::span<const VertexID> vertices,
+    ::precice::span<const VertexID> ids,
     ::precice::span<const double>   gradients)
 {
-  _impl->writeGradientData(toSV(meshName), toSV(dataName), vertices, gradients);
+  _impl->writeGradientData(toSV(meshName), toSV(dataName), ids, gradients);
 }
 
 } // namespace precice

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -110,7 +110,7 @@ bool Participant::requiresGradientDataFor(::precice::string_view meshName,
   return _impl->requiresGradientDataFor(toSV(meshName), toSV(dataName));
 }
 
-int Participant::setMeshVertex(
+VertexID Participant::setMeshVertex(
     ::precice::string_view        meshName,
     ::precice::span<const double> coordinates)
 {
@@ -133,8 +133,8 @@ void Participant::setMeshVertices(
 
 void Participant::setMeshEdge(
     ::precice::string_view meshName,
-    int                    firstVertexID,
-    int                    secondVertexID)
+    VertexID               firstVertexID,
+    VertexID               secondVertexID)
 {
   _impl->setMeshEdge(toSV(meshName), firstVertexID, secondVertexID);
 }
@@ -148,9 +148,9 @@ void Participant::setMeshEdges(
 
 void Participant::setMeshTriangle(
     ::precice::string_view meshName,
-    int                    firstVertexID,
-    int                    secondVertexID,
-    int                    thirdVertexID)
+    VertexID               firstVertexID,
+    VertexID               secondVertexID,
+    VertexID               thirdVertexID)
 {
   _impl->setMeshTriangle(toSV(meshName), firstVertexID, secondVertexID, thirdVertexID);
 }
@@ -164,10 +164,10 @@ void Participant::setMeshTriangles(
 
 void Participant::setMeshQuad(
     ::precice::string_view meshName,
-    int                    firstVertexID,
-    int                    secondVertexID,
-    int                    thirdVertexID,
-    int                    fourthVertexID)
+    VertexID               firstVertexID,
+    VertexID               secondVertexID,
+    VertexID               thirdVertexID,
+    VertexID               fourthVertexID)
 {
   _impl->setMeshQuad(toSV(meshName), firstVertexID, secondVertexID, thirdVertexID,
                      fourthVertexID);
@@ -182,10 +182,10 @@ void Participant::setMeshQuads(
 
 void Participant::setMeshTetrahedron(
     ::precice::string_view meshName,
-    int                    firstVertexID,
-    int                    secondVertexID,
-    int                    thirdVertexID,
-    int                    fourthVertexID)
+    VertexID               firstVertexID,
+    VertexID               secondVertexID,
+    VertexID               thirdVertexID,
+    VertexID               fourthVertexID)
 {
   _impl->setMeshTetrahedron(toSV(meshName), firstVertexID, secondVertexID, thirdVertexID,
                             fourthVertexID);

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -110,13 +110,6 @@ bool Participant::requiresGradientDataFor(::precice::string_view meshName,
   return _impl->requiresGradientDataFor(toSV(meshName), toSV(dataName));
 }
 
-// void Participant:: resetMesh
-//(
-//   ::precice::string_view meshName )
-//{
-//   _impl->resetMesh(toSV(meshName)ID);
-// }
-
 int Participant::setMeshVertex(
     ::precice::string_view        meshName,
     ::precice::span<const double> coordinates)

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -548,7 +548,7 @@ public:
    *
    * @see getMeshDimensions()
    */
-  int setMeshVertex(
+  VertexID setMeshVertex(
       ::precice::string_view        meshName,
       ::precice::span<const double> position);
 
@@ -600,8 +600,8 @@ public:
    */
   void setMeshEdge(
       ::precice::string_view meshName,
-      int                    firstVertexID,
-      int                    secondVertexID);
+      VertexID               firstVertexID,
+      VertexID               secondVertexID);
 
   /**
    * @brief Sets multiple mesh edges from vertex IDs
@@ -642,9 +642,9 @@ public:
    */
   void setMeshTriangle(
       ::precice::string_view meshName,
-      int                    firstVertexID,
-      int                    secondVertexID,
-      int                    thirdVertexID);
+      VertexID               firstVertexID,
+      VertexID               secondVertexID,
+      VertexID               thirdVertexID);
 
   /**
    * @brief Sets multiple mesh triangles from vertex IDs
@@ -687,10 +687,10 @@ public:
    */
   void setMeshQuad(
       ::precice::string_view meshName,
-      int                    firstVertexID,
-      int                    secondVertexID,
-      int                    thirdVertexID,
-      int                    fourthVertexID);
+      VertexID               firstVertexID,
+      VertexID               secondVertexID,
+      VertexID               thirdVertexID,
+      VertexID               fourthVertexID);
 
   /**
    * @brief Sets multiple mesh quads from vertex IDs
@@ -732,10 +732,10 @@ public:
    */
   void setMeshTetrahedron(
       ::precice::string_view meshName,
-      int                    firstVertexID,
-      int                    secondVertexID,
-      int                    thirdVertexID,
-      int                    fourthVertexID);
+      VertexID               firstVertexID,
+      VertexID               secondVertexID,
+      VertexID               thirdVertexID,
+      VertexID               fourthVertexID);
 
   /**
    * @brief Sets multiple mesh tetrahedra from vertex IDs

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -531,20 +531,20 @@ public:
    * @brief Creates multiple mesh vertices
    *
    * @param[in] meshName the name of the mesh to add the vertices to.
-   * @param[in] positions a span to the coordinates of the vertices
+   * @param[in] coordinates a span to the coordinates of the vertices
    *            The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
    *            The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
    *
    * @param[out] ids The ids of the created vertices
    *
    * @pre initialize() has not yet been called
-   * @pre position.size() == getMeshDimensions(meshName) * ids.size()
+   * @pre \p coordinates.size() == getMeshDimensions(meshName) * ids.size()
    *
    * @see getDimensions()
    */
   void setMeshVertices(
       ::precice::string_view        meshName,
-      ::precice::span<const double> positions,
+      ::precice::span<const double> coordinates,
       ::precice::span<VertexID>     ids);
 
   /**
@@ -575,16 +575,16 @@ public:
    * @note The order of vertices per edge does not matter.
    *
    * @param[in] meshName the name of the mesh to add the edges to
-   * @param[in] vertices an array containing 2*size vertex IDs
+   * @param[in] ids an array containing 2*size vertex IDs
    *
-   * @pre vertices were added to the mesh with the name meshName
-   * @pre vertices.size() is multiple of 2
+   * @pre vertices in \p ids were added to the mesh with the name meshName
+   * @pre \p ids.size() is multiple of 2
    *
    * @see requiresMeshConnectivityFor()
    */
   void setMeshEdges(
       ::precice::string_view          meshName,
-      ::precice::span<const VertexID> vertices);
+      ::precice::span<const VertexID> ids);
 
   /**
    * @brief Sets mesh triangle from vertex IDs.
@@ -618,16 +618,16 @@ public:
    * @note The order of vertices per triangle does not matter.
    *
    * @param[in] meshName name of the mesh to add the triangles to
-   * @param[in] vertices an array containing 3*size vertex IDs
+   * @param[in] ids an array containing 3*size vertex IDs
    *
-   * @pre vertices were added to the mesh with the name meshName
-   * @pre vertices.size() is multiple of 3
+   * @pre vertices in \p ids were added to the mesh with the name meshName
+   * @pre \p ids.size() is multiple of 3
    *
    * @see requiresMeshConnectivityFor()
    */
   void setMeshTriangles(
       ::precice::string_view          meshName,
-      ::precice::span<const VertexID> vertices);
+      ::precice::span<const VertexID> ids);
 
   /**
    * @brief Sets a planar surface mesh quadrangle from vertex IDs.
@@ -666,16 +666,16 @@ public:
    * @warning The order of vertices per quad does not matter, however, only planar quads are allowed.
    *
    * @param[in] meshName name of the mesh to add the quad to
-   * @param[in] vertices an array containing 4*size vertex IDs
+   * @param[in] ids an array containing 4*size vertex IDs
    *
-   * @pre vertices were added to the mesh with the name meshName
-   * @pre vertices.size() is multiple of 4
+   * @pre vertices in \p ids were added to the mesh with the name meshName
+   * @pre \p ids.size() is multiple of 4
    *
    * @see requiresMeshConnectivityFor()
    */
   void setMeshQuads(
       ::precice::string_view          meshName,
-      ::precice::span<const VertexID> vertices);
+      ::precice::span<const VertexID> ids);
 
   /**
    * @brief Set tetrahedron in 3D mesh from vertex ID
@@ -709,16 +709,16 @@ public:
    * @note The order of vertices per tetrahedron does not matter.
    *
    * @param[in] meshName name of the mesh to add the tetrahedra to
-   * @param[in] vertices an array containing 4*size vertex IDs
+   * @param[in] ids an array containing 4*size vertex IDs
    *
-   * @pre vertices were added to the mesh with the name meshName
-   * @pre vertices.size() is multiple of 4
+   * @pre vertices in \p ids were added to the mesh with the name meshName
+   * @pre ids.size() is multiple of 4
    *
    * @see requiresMeshConnectivityFor()
    */
   void setMeshTetrahedra(
       ::precice::string_view          meshName,
-      ::precice::span<const VertexID> vertices);
+      ::precice::span<const VertexID> ids);
 
   ///@}
 
@@ -768,11 +768,11 @@ public:
    *
    * @param[in] meshName the name of mesh that hold the data.
    * @param[in] dataName the name of the data to write to.
-   * @param[in] vertices the vertex ids of the vertices to write data to.
+   * @param[in] ids the vertex ids of the vertices to write data to.
    * @param[in] values the values to write to preCICE.
    *
-   * @pre every VertexID in vertices is a return value of setMeshVertex or setMeshVertices
-   * @pre values.size() == getDataDimensions(meshName, dataName) * vertices.size()
+   * @pre every VertexID in \p ids is a return value of setMeshVertex or setMeshVertices
+   * @pre values.size() == getDataDimensions(meshName, dataName) * ids.size()
    *
    * @see Participant::setMeshVertex()
    * @see Participant::setMeshVertices()
@@ -781,7 +781,7 @@ public:
   void writeData(
       ::precice::string_view          meshName,
       ::precice::string_view          dataName,
-      ::precice::span<const VertexID> vertices,
+      ::precice::span<const VertexID> ids,
       ::precice::span<const double>   values);
 
   /**
@@ -801,12 +801,12 @@ public:
    *
    * @param[in] meshName the name of mesh that hold the data.
    * @param[in] dataName the name of the data to read from.
-   * @param[in] vertices the vertex ids of the vertices to read data from.
+   * @param[in] ids the vertex ids of the vertices to read data from.
    * @param[in] relativeReadTime Point in time where data is read relative to the beginning of the current time step.
    * @param[out] values the destination memory to read the data from.
    *
-   * @pre every VertexID in vertices is a return value of setMeshVertex or setMeshVertices
-   * @pre values.size() == getDataDimensions(meshName, dataName) * vertices.size()
+   * @pre every VertexID in ids is a return value of setMeshVertex or setMeshVertices
+   * @pre values.size() == getDataDimensions(meshName, dataName) * ids.size()
    *
    * @post values contain the read data as specified in the above format.
    *
@@ -817,7 +817,7 @@ public:
   void readData(
       ::precice::string_view          meshName,
       ::precice::string_view          dataName,
-      ::precice::span<const VertexID> vertices,
+      ::precice::span<const VertexID> ids,
       double                          relativeReadTime,
       ::precice::span<double>         values) const;
 
@@ -974,12 +974,12 @@ public:
    *
    * @param[in] meshName the name of mesh that hold the data.
    * @param[in] dataName the name of the data to write to.
-   * @param[in] vertices the vertex ids of the vertices to write gradient data to.
+   * @param[in] ids the vertex ids of the vertices to write gradient data to.
    * @param[in] gradients the linearised gradient data to write to preCICE.
    *
    * @pre Data has attribute hasGradient = true
    * @pre every VertexID in vertices is a return value of setMeshVertex or setMeshVertices
-   * @pre gradients.size() == vertices.size() * getMeshDimensions(meshName) * getDataDimensions(meshName, dataName)
+   * @pre gradients.size() == ids.size() * getMeshDimensions(meshName) * getDataDimensions(meshName, dataName)
    *
    * @see Participant::setMeshVertex()
    * @see Participant::setMeshVertices()
@@ -990,7 +990,7 @@ public:
   void writeGradientData(
       ::precice::string_view          meshName,
       ::precice::string_view          dataName,
-      ::precice::span<const VertexID> vertices,
+      ::precice::span<const VertexID> ids,
       ::precice::span<const double>   gradients);
 
   ///@}

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -248,7 +248,7 @@ public:
    * @pre initialize() has been called successfully.
    * @pre The solver has computed one time step.
    * @pre The solver has written all coupling data.
-   * @pre isCouplngOngoing() returns true.
+   * @pre isCouplingOngoing() returns true.
    * @pre finalize() has not yet been called.
    *
    * @post Coupling data values specified in the configuration are exchanged.

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -604,7 +604,7 @@ public:
       int                    secondVertexID);
 
   /**
-   * @brief Sets multiple mesh edge from vertex IDs
+   * @brief Sets multiple mesh edges from vertex IDs
    *
    * vertices contain pairs of vertex indices for each edge to define.
    * The format follows: e1a, e1b, e2a, e2b, ...
@@ -612,8 +612,8 @@ public:
    *
    * @note The order of vertices per edge does not matter.
    *
-   * @param[in] meshName the name of the mesh to add the edges to
-   * @param[in] ids an array containing 2*size vertex IDs
+   * @param[in] meshName the name of the mesh to add the n edges to
+   * @param[in] ids an array containing 2n vertex IDs for n edges
    *
    * @pre vertices in \p ids were added to the mesh with the name meshName
    * @pre \p ids.size() is multiple of 2
@@ -655,8 +655,8 @@ public:
    *
    * @note The order of vertices per triangle does not matter.
    *
-   * @param[in] meshName name of the mesh to add the triangles to
-   * @param[in] ids an array containing 3*size vertex IDs
+   * @param[in] meshName name of the mesh to add the n triangles to
+   * @param[in] ids an array containing 3n vertex IDs for n triangles
    *
    * @pre vertices in \p ids were added to the mesh with the name meshName
    * @pre \p ids.size() is multiple of 3
@@ -703,8 +703,8 @@ public:
    *
    * @warning The order of vertices per quad does not matter, however, only planar quads are allowed.
    *
-   * @param[in] meshName name of the mesh to add the quad to
-   * @param[in] ids an array containing 4*size vertex IDs
+   * @param[in] meshName name of the mesh to add the n quads to
+   * @param[in] ids an array containing 4n vertex IDs for n quads
    *
    * @pre vertices in \p ids were added to the mesh with the name meshName
    * @pre \p ids.size() is multiple of 4
@@ -746,8 +746,8 @@ public:
    *
    * @note The order of vertices per tetrahedron does not matter.
    *
-   * @param[in] meshName name of the mesh to add the tetrahedra to
-   * @param[in] ids an array containing 4*size vertex IDs
+   * @param[in] meshName name of the mesh to add the n tetrahedra to
+   * @param[in] ids an array containing 4n vertex IDs for n tetrahedra
    *
    * @pre vertices in \p ids were added to the mesh with the name meshName
    * @pre ids.size() is multiple of 4

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -55,20 +55,8 @@ namespace precice {
  * // one of
  * const char*      meshName = "MyMesh";
  * std::string      meshName = "MyMesh";
- * std::string_view meshName = "MyMesh";
  * // followed by
  * getMeshDimensions(meshName);
- * @endcode
- *
- * For more complex settings, you can pass pointer + size:
- *
- * @code{.cpp}
- * const char* meshName     = ...;
- * int         meshNameSize = ...;
- * // followed by either directly constructing
- * getMeshDimensions(::precice::string_view{meshName, meshNameSize});
- * // or without naming the type
- * getMeshDimensions({meshName, meshNameSize});
  * @endcode
  *
  */

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -22,7 +22,56 @@ struct WhiteboxAccessor;
 
 namespace precice {
 
-/// convenience type for compatibility
+/** @brief forwards-compatible typedef for C++17 \ref std::string_view.
+ *
+ * The \ref string_view is a read-only view into sequence of characters.
+ *
+ * A good mental model for this type is a struct containing a pointer and a size like the following:
+ *
+ * @code cpp
+ * struct string_view {
+ *   const char* first;
+ *   size_t size;
+ * };
+ * @endcode
+ *
+ * It can be constructed from:
+ * - a pointer to a NULL-terminated C-string
+ * - a pointer and a size
+ * - a pointer to the first and one past the last element
+ * - \ref std::string can directly convert itself to \ref std::string_view.
+ *
+ * In practise, using a function such as \ref Participant::getMeshDimensions() that expects a string_view looks like this:
+ *
+ * You can directly pass the string literal:
+ *
+ * @code{.cpp}
+ * getMeshDimensions("MyMesh");
+ * @endcode
+ *
+ * Or you can pass something string-like:
+ *
+ * @code{.cpp}
+ * // one of
+ * const char*      meshName = "MyMesh";
+ * std::string      meshName = "MyMesh";
+ * std::string_view meshName = "MyMesh";
+ * // followed by
+ * getMeshDimensions(meshName);
+ * @endcode
+ *
+ * For more complex settings, you can pass pointer + size:
+ *
+ * @code{.cpp}
+ * const char* meshName     = ...;
+ * int         meshNameSize = ...;
+ * // followed by either directly constructing
+ * getMeshDimensions(::precice::string_view{meshName, meshNameSize});
+ * // or without naming the type
+ * getMeshDimensions({meshName, meshNameSize});
+ * @endcode
+ *
+ */
 using string_view = ::precice::span<const char>;
 
 /**

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -28,7 +28,7 @@ namespace precice {
  *
  * A good mental model for this type is a struct containing a pointer and a size like the following:
  *
- * @code cpp
+ * @code{cpp}
  * struct string_view {
  *   const char* first;
  *   size_t size;

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -524,17 +524,6 @@ public:
    *@{
    */
 
-  /*
-   * @brief Resets mesh with given ID.
-   *
-   * @experimental
-   *
-   * Has to be called, every time the positions for data to be mapped
-   * changes. Only has an effect, if the mapping used is non-stationary and
-   * non-incremental.
-   */
-  //  void resetMesh ( ::precice::string_view meshName );
-
   /**
    * @brief Checks if the given mesh requires connectivity.
    *

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -582,15 +582,15 @@ public:
    * @note The order of vertices does not matter.
    *
    * @param[in] meshName name of the mesh to add the edge to
-   * @param[in] firstVertexID ID of the first vertex of the edge
-   * @param[in] secondVertexID ID of the second vertex of the edge
+   * @param[in] first ID of the first vertex of the edge
+   * @param[in] second ID of the second vertex of the edge
    *
-   * @pre vertices with firstVertexID and secondVertexID were added to the mesh with the name meshName
+   * @pre vertices with IDs first and second were added to the mesh with the name meshName
    */
   void setMeshEdge(
       ::precice::string_view meshName,
-      VertexID               firstVertexID,
-      VertexID               secondVertexID);
+      VertexID               first,
+      VertexID               second);
 
   /**
    * @brief Sets multiple mesh edges from vertex IDs
@@ -621,19 +621,19 @@ public:
    * @note The order of vertices does not matter.
    *
    * @param[in] meshName name of the mesh to add the triangle to
-   * @param[in] firstVertexID ID of the first vertex of the triangle
-   * @param[in] secondVertexID ID of the second vertex of the triangle
-   * @param[in] thirdVertexID ID of the third vertex of the triangle
+   * @param[in] first ID of the first vertex of the triangle
+   * @param[in] second ID of the second vertex of the triangle
+   * @param[in] third ID of the third vertex of the triangle
    *
-   * @pre edges with firstVertexID, secondVertexID, and thirdVertexID were added to the mesh with the name meshName
+   * @pre vertices with IDs first, second, and third were added to the mesh with the name meshName
    *
    * @see requiresMeshConnectivityFor()
    */
   void setMeshTriangle(
       ::precice::string_view meshName,
-      VertexID               firstVertexID,
-      VertexID               secondVertexID,
-      VertexID               thirdVertexID);
+      VertexID               first,
+      VertexID               second,
+      VertexID               third);
 
   /**
    * @brief Sets multiple mesh triangles from vertex IDs
@@ -665,21 +665,21 @@ public:
    * @warning The order of vertices does not matter, however, only planar quads are allowed.
    *
    * @param[in] meshName name of the mesh to add the Quad to
-   * @param[in] firstVertexID ID of the first vertex of the Quad
-   * @param[in] secondVertexID ID of the second vertex of the Quad
-   * @param[in] thirdVertexID ID of the third vertex of the Quad
-   * @param[in] fourthVertexID ID of the fourth vertex of the Quad
+   * @param[in] first ID of the first vertex of the Quad
+   * @param[in] second ID of the second vertex of the Quad
+   * @param[in] third ID of the third vertex of the Quad
+   * @param[in] fourth ID of the fourth vertex of the Quad
    *
-   * @pre vertices with firstVertexID, secondVertexID, thirdVertexID, and fourthVertexID were added to the mesh with the name meshName
+   * @pre vertices with IDs first, second, third, and fourth were added to the mesh with the name meshName
    *
    * @see requiresMeshConnectivityFor()
    */
   void setMeshQuad(
       ::precice::string_view meshName,
-      VertexID               firstVertexID,
-      VertexID               secondVertexID,
-      VertexID               thirdVertexID,
-      VertexID               fourthVertexID);
+      VertexID               first,
+      VertexID               second,
+      VertexID               third,
+      VertexID               fourth);
 
   /**
    * @brief Sets multiple mesh quads from vertex IDs
@@ -710,21 +710,21 @@ public:
    * @note The order of vertices does not matter.
    *
    * @param[in] meshName name of the mesh to add the Tetrahedron to
-   * @param[in] firstVertexID ID of the first vertex of the Tetrahedron
-   * @param[in] secondVertexID ID of the second vertex of the Tetrahedron
-   * @param[in] thirdVertexID ID of the third vertex of the Tetrahedron
-   * @param[in] fourthVertexID ID of the fourth vertex of the Tetrahedron
+   * @param[in] first ID of the first vertex of the Tetrahedron
+   * @param[in] second ID of the second vertex of the Tetrahedron
+   * @param[in] third ID of the third vertex of the Tetrahedron
+   * @param[in] fourth ID of the fourth vertex of the Tetrahedron
    *
-   * @pre vertices with firstVertexID, secondVertexID, thirdVertexID, and fourthVertexID were added to the mesh with the name meshName
+   * @pre vertices with IDs first, second, third, and fourth were added to the mesh with the name meshName
    *
    * @see requiresMeshConnectivityFor()
    */
   void setMeshTetrahedron(
       ::precice::string_view meshName,
-      VertexID               firstVertexID,
-      VertexID               secondVertexID,
-      VertexID               thirdVertexID,
-      VertexID               fourthVertexID);
+      VertexID               first,
+      VertexID               second,
+      VertexID               third,
+      VertexID               fourth);
 
   /**
    * @brief Sets multiple mesh tetrahedra from vertex IDs

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -189,10 +189,11 @@ public:
    * index and size of the current process, which are equivalent to rank and size in the MPI terminology.
    *
    * If preCICE is compiled with MPI, then there are multiple ways for it to be used:
-   * 1. if the participant is configured to use an intra-comm using sockets, preCICE ignores MPI
-   * 2. if a custom communicator is provided, preCICE uses it
-   * 3. if MPI is already initialized, preCICE uses the MPI_COMM_WORLD
-   * 4. otherwise, preCICE initializes MPI itself and uses the MPI_COMM_WORLD
+   * 1. if a custom communicator is provided, preCICE uses it
+   * 2. if MPI is already initialized, preCICE uses the MPI_COMM_WORLD
+   * 3. otherwise, preCICE initializes MPI itself and uses the MPI_COMM_WORLD
+   *
+   * The MPI initialization is independent of which kind IntraCommunicator is configured.
    *
    * @{
    */

--- a/src/precice/Types.hpp
+++ b/src/precice/Types.hpp
@@ -3,7 +3,12 @@
 namespace precice {
 
 /**
- * Type used for the IDs of vertices
+ * Type used identify a vertex on a mesh.
+ *
+ * These IDs are always bound to a mesh. Using a VertexID on another mesh is not allowed and not guaranteed to result in an error.
+ * The only valid way of receiving these IDs are by using \ref setMeshVertex(), \ref setMeshVertices(), \ref getMeshVertexIDsAndCoordinates().
+ *
+ * There is no guarantee on the values of vertex IDs. **Do not** rely on them to start at zero or be continuous.
  */
 using VertexID = int;
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -641,7 +641,7 @@ void ParticipantImpl::resetMesh(
   context.mesh->clear();
 }
 
-int ParticipantImpl::setMeshVertex(
+VertexID ParticipantImpl::setMeshVertex(
     std::string_view              meshName,
     ::precice::span<const double> position)
 {
@@ -698,8 +698,8 @@ void ParticipantImpl::setMeshVertices(
 
 void ParticipantImpl::setMeshEdge(
     std::string_view meshName,
-    int              firstVertexID,
-    int              secondVertexID)
+    VertexID         firstVertexID,
+    VertexID         secondVertexID)
 {
   PRECICE_TRACE(meshName, firstVertexID, secondVertexID);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
@@ -751,9 +751,9 @@ void ParticipantImpl::setMeshEdges(
 
 void ParticipantImpl::setMeshTriangle(
     std::string_view meshName,
-    int              firstVertexID,
-    int              secondVertexID,
-    int              thirdVertexID)
+    VertexID         firstVertexID,
+    VertexID         secondVertexID,
+    VertexID         thirdVertexID)
 {
   PRECICE_TRACE(meshName, firstVertexID,
                 secondVertexID, thirdVertexID);
@@ -825,10 +825,10 @@ void ParticipantImpl::setMeshTriangles(
 
 void ParticipantImpl::setMeshQuad(
     std::string_view meshName,
-    int              firstVertexID,
-    int              secondVertexID,
-    int              thirdVertexID,
-    int              fourthVertexID)
+    VertexID         firstVertexID,
+    VertexID         secondVertexID,
+    VertexID         thirdVertexID,
+    VertexID         fourthVertexID)
 {
   PRECICE_TRACE(meshName, firstVertexID,
                 secondVertexID, thirdVertexID, fourthVertexID);
@@ -940,10 +940,10 @@ void ParticipantImpl::setMeshQuads(
 
 void ParticipantImpl::setMeshTetrahedron(
     std::string_view meshName,
-    int              firstVertexID,
-    int              secondVertexID,
-    int              thirdVertexID,
-    int              fourthVertexID)
+    VertexID         firstVertexID,
+    VertexID         secondVertexID,
+    VertexID         thirdVertexID,
+    VertexID         fourthVertexID)
 {
   PRECICE_TRACE(meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -698,19 +698,19 @@ void ParticipantImpl::setMeshVertices(
 
 void ParticipantImpl::setMeshEdge(
     std::string_view meshName,
-    VertexID         firstVertexID,
-    VertexID         secondVertexID)
+    VertexID         first,
+    VertexID         second)
 {
-  PRECICE_TRACE(meshName, firstVertexID, secondVertexID);
+  PRECICE_TRACE(meshName, first, second);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
     mesh::PtrMesh &mesh = context.mesh;
     using impl::errorInvalidVertexID;
-    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), errorInvalidVertexID(firstVertexID));
-    PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), errorInvalidVertexID(secondVertexID));
-    mesh::Vertex &v0 = mesh->vertices()[firstVertexID];
-    mesh::Vertex &v1 = mesh->vertices()[secondVertexID];
+    PRECICE_CHECK(mesh->isValidVertexID(first), errorInvalidVertexID(first));
+    PRECICE_CHECK(mesh->isValidVertexID(second), errorInvalidVertexID(second));
+    mesh::Vertex &v0 = mesh->vertices()[first];
+    mesh::Vertex &v1 = mesh->vertices()[second];
     mesh->createEdge(v0, v1);
   }
 }
@@ -751,32 +751,32 @@ void ParticipantImpl::setMeshEdges(
 
 void ParticipantImpl::setMeshTriangle(
     std::string_view meshName,
-    VertexID         firstVertexID,
-    VertexID         secondVertexID,
-    VertexID         thirdVertexID)
+    VertexID         first,
+    VertexID         second,
+    VertexID         third)
 {
-  PRECICE_TRACE(meshName, firstVertexID,
-                secondVertexID, thirdVertexID);
+  PRECICE_TRACE(meshName, first,
+                second, third);
 
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
     mesh::PtrMesh &mesh = context.mesh;
     using impl::errorInvalidVertexID;
-    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), errorInvalidVertexID(firstVertexID));
-    PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), errorInvalidVertexID(secondVertexID));
-    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID), errorInvalidVertexID(thirdVertexID));
-    PRECICE_CHECK(utils::unique_elements(utils::make_array(firstVertexID, secondVertexID, thirdVertexID)),
+    PRECICE_CHECK(mesh->isValidVertexID(first), errorInvalidVertexID(first));
+    PRECICE_CHECK(mesh->isValidVertexID(second), errorInvalidVertexID(second));
+    PRECICE_CHECK(mesh->isValidVertexID(third), errorInvalidVertexID(third));
+    PRECICE_CHECK(utils::unique_elements(utils::make_array(first, second, third)),
                   "setMeshTriangle() was called with repeated Vertex IDs ({}, {}, {}).",
-                  firstVertexID, secondVertexID, thirdVertexID);
+                  first, second, third);
     mesh::Vertex *vertices[3];
-    vertices[0] = &mesh->vertices()[firstVertexID];
-    vertices[1] = &mesh->vertices()[secondVertexID];
-    vertices[2] = &mesh->vertices()[thirdVertexID];
+    vertices[0] = &mesh->vertices()[first];
+    vertices[1] = &mesh->vertices()[second];
+    vertices[2] = &mesh->vertices()[third];
     PRECICE_CHECK(utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
                                                            vertices[1]->getCoords(), vertices[2]->getCoords())),
                   "setMeshTriangle() was called with vertices located at identical coordinates (IDs: {}, {}, {}).",
-                  firstVertexID, secondVertexID, thirdVertexID);
+                  first, second, third);
     mesh::Edge *edges[3];
     edges[0] = &mesh->createEdge(*vertices[0], *vertices[1]);
     edges[1] = &mesh->createEdge(*vertices[1], *vertices[2]);
@@ -825,13 +825,13 @@ void ParticipantImpl::setMeshTriangles(
 
 void ParticipantImpl::setMeshQuad(
     std::string_view meshName,
-    VertexID         firstVertexID,
-    VertexID         secondVertexID,
-    VertexID         thirdVertexID,
-    VertexID         fourthVertexID)
+    VertexID         first,
+    VertexID         second,
+    VertexID         third,
+    VertexID         fourth)
 {
-  PRECICE_TRACE(meshName, firstVertexID,
-                secondVertexID, thirdVertexID, fourthVertexID);
+  PRECICE_TRACE(meshName, first,
+                second, third, fourth);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshQuad is only possible for 3D meshes."
@@ -840,12 +840,12 @@ void ParticipantImpl::setMeshQuad(
     PRECICE_ASSERT(context.mesh);
     mesh::Mesh &mesh = *(context.mesh);
     using impl::errorInvalidVertexID;
-    PRECICE_CHECK(mesh.isValidVertexID(firstVertexID), errorInvalidVertexID(firstVertexID));
-    PRECICE_CHECK(mesh.isValidVertexID(secondVertexID), errorInvalidVertexID(secondVertexID));
-    PRECICE_CHECK(mesh.isValidVertexID(thirdVertexID), errorInvalidVertexID(thirdVertexID));
-    PRECICE_CHECK(mesh.isValidVertexID(fourthVertexID), errorInvalidVertexID(fourthVertexID));
+    PRECICE_CHECK(mesh.isValidVertexID(first), errorInvalidVertexID(first));
+    PRECICE_CHECK(mesh.isValidVertexID(second), errorInvalidVertexID(second));
+    PRECICE_CHECK(mesh.isValidVertexID(third), errorInvalidVertexID(third));
+    PRECICE_CHECK(mesh.isValidVertexID(fourth), errorInvalidVertexID(fourth));
 
-    auto vertexIDs = utils::make_array(firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
+    auto vertexIDs = utils::make_array(first, second, third, fourth);
     PRECICE_CHECK(utils::unique_elements(vertexIDs), "The four vertex ID's are not unique. Please check that the vertices that form the quad are correct.");
 
     auto coords = mesh::coordsFor(mesh, vertexIDs);
@@ -940,12 +940,12 @@ void ParticipantImpl::setMeshQuads(
 
 void ParticipantImpl::setMeshTetrahedron(
     std::string_view meshName,
-    VertexID         firstVertexID,
-    VertexID         secondVertexID,
-    VertexID         thirdVertexID,
-    VertexID         fourthVertexID)
+    VertexID         first,
+    VertexID         second,
+    VertexID         third,
+    VertexID         fourth)
 {
-  PRECICE_TRACE(meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
+  PRECICE_TRACE(meshName, first, second, third, fourth);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
   PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshTetrahedron is only possible for 3D meshes."
@@ -953,14 +953,14 @@ void ParticipantImpl::setMeshTetrahedron(
   if (context.meshRequirement == mapping::Mapping::MeshRequirement::FULL) {
     mesh::PtrMesh &mesh = context.mesh;
     using impl::errorInvalidVertexID;
-    PRECICE_CHECK(mesh->isValidVertexID(firstVertexID), errorInvalidVertexID(firstVertexID));
-    PRECICE_CHECK(mesh->isValidVertexID(secondVertexID), errorInvalidVertexID(secondVertexID));
-    PRECICE_CHECK(mesh->isValidVertexID(thirdVertexID), errorInvalidVertexID(thirdVertexID));
-    PRECICE_CHECK(mesh->isValidVertexID(fourthVertexID), errorInvalidVertexID(fourthVertexID));
-    mesh::Vertex &A = mesh->vertices()[firstVertexID];
-    mesh::Vertex &B = mesh->vertices()[secondVertexID];
-    mesh::Vertex &C = mesh->vertices()[thirdVertexID];
-    mesh::Vertex &D = mesh->vertices()[fourthVertexID];
+    PRECICE_CHECK(mesh->isValidVertexID(first), errorInvalidVertexID(first));
+    PRECICE_CHECK(mesh->isValidVertexID(second), errorInvalidVertexID(second));
+    PRECICE_CHECK(mesh->isValidVertexID(third), errorInvalidVertexID(third));
+    PRECICE_CHECK(mesh->isValidVertexID(fourth), errorInvalidVertexID(fourth));
+    mesh::Vertex &A = mesh->vertices()[first];
+    mesh::Vertex &B = mesh->vertices()[second];
+    mesh::Vertex &C = mesh->vertices()[third];
+    mesh::Vertex &D = mesh->vertices()[fourth];
 
     mesh->createTetrahedron(A, B, C, D);
   }

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -170,8 +170,8 @@ public:
   /// @copydoc Participant::setMeshEdge
   void setMeshEdge(
       std::string_view meshName,
-      VertexID         firstVertexID,
-      VertexID         secondVertexID);
+      VertexID         first,
+      VertexID         second);
 
   /// @copydoc Participant::setMeshEdges
   void setMeshEdges(
@@ -181,9 +181,9 @@ public:
   /// @copydoc Participant::setMeshTriangle
   void setMeshTriangle(
       std::string_view meshName,
-      VertexID         firstVertexID,
-      VertexID         secondVertexID,
-      VertexID         thirdVertexID);
+      VertexID         first,
+      VertexID         second,
+      VertexID         third);
 
   /// @copydoc Participant::setMeshTriangles
   void setMeshTriangles(
@@ -193,10 +193,10 @@ public:
   /// @copydoc Participant::setMeshQuad
   void setMeshQuad(
       std::string_view meshName,
-      VertexID         firstVertexID,
-      VertexID         secondVertexID,
-      VertexID         thirdVertexID,
-      VertexID         fourthVertexID);
+      VertexID         first,
+      VertexID         second,
+      VertexID         third,
+      VertexID         fourth);
 
   /// @copydoc Participant::setMeshQuads
   void setMeshQuads(
@@ -206,10 +206,10 @@ public:
   /// @copydoc Participant::setMeshTetrahedron
   void setMeshTetrahedron(
       std::string_view meshName,
-      VertexID         firstVertexID,
-      VertexID         secondVertexID,
-      VertexID         thirdVertexID,
-      VertexID         fourthVertexID);
+      VertexID         first,
+      VertexID         second,
+      VertexID         third,
+      VertexID         fourth);
 
   /// @copydoc Participant::setMeshTetrahedra
   void setMeshTetrahedra(

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -154,7 +154,7 @@ public:
                                std::string_view dataName) const;
 
   /// @copydoc Participant::setMeshVertex
-  int setMeshVertex(
+  VertexID setMeshVertex(
       std::string_view              meshName,
       ::precice::span<const double> position);
 
@@ -170,8 +170,8 @@ public:
   /// @copydoc Participant::setMeshEdge
   void setMeshEdge(
       std::string_view meshName,
-      int              firstVertexID,
-      int              secondVertexID);
+      VertexID         firstVertexID,
+      VertexID         secondVertexID);
 
   /// @copydoc Participant::setMeshEdges
   void setMeshEdges(
@@ -181,9 +181,9 @@ public:
   /// @copydoc Participant::setMeshTriangle
   void setMeshTriangle(
       std::string_view meshName,
-      int              firstVertexID,
-      int              secondVertexID,
-      int              thirdVertexID);
+      VertexID         firstVertexID,
+      VertexID         secondVertexID,
+      VertexID         thirdVertexID);
 
   /// @copydoc Participant::setMeshTriangles
   void setMeshTriangles(
@@ -193,10 +193,10 @@ public:
   /// @copydoc Participant::setMeshQuad
   void setMeshQuad(
       std::string_view meshName,
-      int              firstVertexID,
-      int              secondVertexID,
-      int              thirdVertexID,
-      int              fourthVertexID);
+      VertexID         firstVertexID,
+      VertexID         secondVertexID,
+      VertexID         thirdVertexID,
+      VertexID         fourthVertexID);
 
   /// @copydoc Participant::setMeshQuads
   void setMeshQuads(
@@ -206,10 +206,10 @@ public:
   /// @copydoc Participant::setMeshTetrahedron
   void setMeshTetrahedron(
       std::string_view meshName,
-      int              firstVertexID,
-      int              secondVertexID,
-      int              thirdVertexID,
-      int              fourthVertexID);
+      VertexID         firstVertexID,
+      VertexID         secondVertexID,
+      VertexID         thirdVertexID,
+      VertexID         fourthVertexID);
 
   /// @copydoc Participant::setMeshTetrahedra
   void setMeshTetrahedra(


### PR DESCRIPTION
## Main changes of this PR

This PR aims to tidy the API documentation of Participant and add more context.

I used plantuml to generate some [activity diagrams](https://plantuml.com/activity-diagram-beta) in order to clarify the intent of how the API is supposed to be used.
Plantuml may still need to be installed in the CI of the website.

I didn't invest time into the gradient API as it is still experimental.
Mesh access remains unchanged.

## Motivation and additional information

We always say that the doxygen is for adapter developers that need to go deep.
Now it contains have more complete information.

## Screenshots of Sections in order

![image](https://github.com/precice/precice/assets/13552216/c60ede48-a9ac-429a-b716-4949d96905fc)

![image](https://github.com/precice/precice/assets/13552216/4de59b16-739b-4f13-a05e-4c6bebb6a0cd)

![image](https://github.com/precice/precice/assets/13552216/1d16b1ae-fff8-4210-b2c2-1f107a5f215a)

![image](https://github.com/precice/precice/assets/13552216/fe3c6020-2a09-4be0-bad0-79c9915d5cc5)

![image](https://github.com/precice/precice/assets/13552216/8746002d-1e21-4332-a68f-a36b95c18d25)
![image](https://github.com/precice/precice/assets/13552216/4c0aa6ed-3a15-4768-bbbb-2e76377c8fcf)

![image](https://github.com/precice/precice/assets/13552216/12ae0d8c-77b5-4f6c-b9e8-265abec25b5d)



## Author's checklist

* [x] I added plantuml to the CI in the website and check that the path is setup
* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
