### PR TITLE
Add --list_units to testprecice

### DIFF
--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -29,6 +29,41 @@ int countEnabledTests()
   return tcc.p_count;
 }
 
+class test_case_printer : public boost::unit_test::test_tree_visitor {
+private:
+  std::vector<std::string> prefix;
+
+  bool test_suite_start(boost::unit_test::test_suite const &ts) override
+  {
+    if (ts.p_type_name == "suite") {
+      prefix.push_back(ts.p_name);
+    }
+    return test_tree_visitor::visit((boost::unit_test::test_unit const &) ts);
+  }
+
+  void test_suite_finish(boost::unit_test::test_suite const &ts) override
+  {
+    if (ts.p_type_name == "suite") {
+      prefix.pop_back();
+    }
+  }
+
+  void visit(boost::unit_test::test_case const &tc) override
+  {
+    for (const auto &p : prefix) {
+      std::cout << p << '/';
+    }
+    std::cout << tc.p_name << '\n';
+  }
+};
+
+void printTestList()
+{
+  using namespace boost::unit_test;
+  test_case_printer tcp;
+  traverse_test_tree(framework::master_test_suite(), tcp, true);
+}
+
 void setupTolerance()
 {
   static constexpr double tolerance = 1e-9;
@@ -58,10 +93,21 @@ int main(int argc, char *argv[])
   const auto size = utils::Parallel::current()->size();
   logging::setMPIRank(rank);
 
+  // Handle custom printing
+  if (argc == 2 && std::string(argv[1]) == "--list_units") {
+    if (rank == 0) {
+      printTestList();
+    }
+    utils::Parallel::finalizeTestingMPI();
+    return 0;
+  }
+
+  // Handle not enough MPI ranks
   if (size < 4 && argc < 2) {
     if (rank == 0) {
       std::cerr << "ERROR: The tests require at least 4 MPI processes. Please use \"mpirun -np 4 ./testprecice\" or \"ctest\" to run the full testsuite. \n";
     }
+    utils::Parallel::finalizeTestingMPI();
     return 2;
   }
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds a custom `--list_units` argument to `testprecice`.

It lists all tests in the form accepted by the `--run-test`/`-t` flag of `testprecice`.

## Motivation and additional information

This allows to use the output a bit easier in tools. `--list_content` is not suitable for that as it is an indented format, requiring further processing.

In the long term, this allows us to register each test individually to CTest.

Example to run all tests in parallel in isolated directories with an output overview log in `tests.log`:

```
./testprecice --list_units | parallel --group --joblog tests.log "mkdir -p 'run/{#}' && mpirun -wdir 'run/{#}' -n 4 ../../testprecice -t {}"
```

You can use a custom filter before parallel using a tool like grep:

```
./testprecice --list_units | grep "SerialImplicit" | parallel --group --joblog tests.log "mkdir -p 'run/{#}' && mpirun -wdir 'run/{#}' -n 4 ../../testprecice -t {}"
```

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
