### PR TITLE
Simplify splitComm using MPI_Comm_Split

### DIFF
--- a/src/testing/TestContext.hpp
+++ b/src/testing/TestContext.hpp
@@ -316,10 +316,11 @@ private:
   }
   /// @}
 
-  /** set the context from a Participants and a given rank
+  /** set the context from a Participants and the current com
    * Both uniquely identify a context.
+   * @see Par::current()
    */
-  void setContextFrom(const ParticipantState &p, Rank rank);
+  void setContextFrom(const ParticipantState &p);
 
   /// @{
   /// @name Initialization

--- a/src/utils/Parallel.cpp
+++ b/src/utils/Parallel.cpp
@@ -24,7 +24,6 @@ Parallel::InitializationState Parallel::_initState = Parallel::InitializationSta
 
 Parallel::CommState::CommState(Parallel::CommState &&other) noexcept
 {
-  groups     = std::move(other.groups);
   comm       = other.comm;
   other.comm = MPI_COMM_NULL;
   _owning    = other._owning;
@@ -33,7 +32,6 @@ Parallel::CommState::CommState(Parallel::CommState &&other) noexcept
 
 Parallel::CommState &Parallel::CommState::operator=(Parallel::CommState &&other) noexcept
 {
-  groups     = std::move(other.groups);
   comm       = other.comm;
   other.comm = MPI_COMM_NULL;
   _owning    = other._owning;
@@ -271,114 +269,21 @@ void Parallel::finalizeTestingMPI()
 
 // State altering
 
-void Parallel::splitCommunicator(const std::string &groupName)
+void Parallel::splitCommunicator(std::optional<int> group)
 {
 #ifndef PRECICE_NO_MPI
-  PRECICE_TRACE(groupName);
+  PRECICE_TRACE(group.value_or(-1));
 
-  // Exchange group information
-  PRECICE_DEBUG("Exchange group information");
-  //_accessorGroups.clear(); // Makes reinitialization possible
+  // Passing the same key maintains rank order
+  constexpr int keepTheSameOrder{0};
 
-  CommStatePtr baseState  = current();
-  MPI_Comm     globalComm = baseState->comm;
-  int          rank       = baseState->rank();
-  int          size       = baseState->size();
+  MPI_Comm newComm = MPI_COMM_NULL;
+  // Passing MPI_UNDEFINED as group results in MPI_COMM_NULL
+  auto err = MPI_Comm_split(current()->comm, group.value_or(MPI_UNDEFINED), keepTheSameOrder, &newComm);
+  PRECICE_ASSERT(err == MPI_SUCCESS, "MPI_Comm_split failed!", group.has_value(), group.value_or(-1));
 
-  PRECICE_ASSERT(size > 1, "Splitting a communicator or size 1 is not possible!");
-
-  std::vector<AccessorGroup>  accessorGroups;
-  com::MPIDirectCommunication com;
-
-  if (rank == 0) { // Primary rank
-    // Step 1 receive groupNames from Salves and setup accessorGroups
-    std::map<std::string, int> groupMap; // map from names to group ID
-    groupMap[groupName] = 0;
-    AccessorGroup newGroup;
-    newGroup.id         = 0;
-    newGroup.size       = 1;
-    newGroup.leaderRank = 0;
-    newGroup.name       = groupName;
-    accessorGroups.push_back(newGroup);
-    for (int i = 1; i < size; i++) {
-      std::string name;
-      com.receive(name, i); // Receive group name from all ranks
-      if (groupMap.find(name) == groupMap.end()) {
-        groupMap[name] = static_cast<int>(accessorGroups.size());
-        AccessorGroup newGroup;
-        newGroup.id         = static_cast<int>(accessorGroups.size());
-        newGroup.size       = 1;
-        newGroup.leaderRank = i;
-        newGroup.name       = name;
-        accessorGroups.push_back(newGroup);
-      } else {
-        accessorGroups[groupMap[name]].size++;
-      }
-    }
-    // Step 2 send groupCount to Primary rank
-    auto groupCount = static_cast<int>(accessorGroups.size());
-    MPI_Bcast(&groupCount, 1, MPI_INT, 0, globalComm);
-    PRECICE_ASSERT(groupCount > 1, "Calling split with a single group is not permitted!");
-
-    // Step 3 send AccessorGroups to SecondaryRanks
-    for (const AccessorGroup &group : accessorGroups) {
-      // @TODO can we use broadcast as the primary rank sends this to everyone else?
-      for (int i = 1; i < size; i++) {
-        com.send(group.name, i);
-        com.send(group.leaderRank, i);
-        com.send(group.id, i);
-        com.send(group.size, i);
-      }
-    }
-  } else { // rank != 0
-    // Step 1 send groupName to Primary rank
-    com.send(groupName, 0);
-    // Step 2 receive groupCount from Primary rank
-    int groupCount = -1;
-    MPI_Bcast(&groupCount, 1, MPI_INT, 0, globalComm);
-    PRECICE_ASSERT(groupCount > 1, "Calling split with a single group is not permitted!");
-
-    // Step 3 receive AccessorGroups from Primary rank
-    for (int i = 0; i < groupCount; i++) {
-      AccessorGroup newGroup;
-      com.receive(newGroup.name, 0);
-      com.receive(newGroup.leaderRank, 0);
-      com.receive(newGroup.id, 0);
-      com.receive(newGroup.size, 0);
-      accessorGroups.emplace_back(std::move(newGroup));
-    }
-  }
-
-  // Step 4 split into groups
-  PRECICE_DEBUG("Split groups");
-  auto thisGroup = std::find_if(accessorGroups.begin(), accessorGroups.end(), [groupName](const AccessorGroup &group) { return group.name == groupName; });
-  PRECICE_ASSERT(thisGroup != accessorGroups.end(), "This requested groupName is not in accessorGroups!", groupName);
-
-  CommStatePtr newState;
-  const bool   restrictToSelf = std::all_of(accessorGroups.begin(), accessorGroups.end(), [](const AccessorGroup &group) { return group.size == 1; });
-  if (restrictToSelf) {
-    PRECICE_DEBUG("Split to Comm Self");
-    newState = CommState::self();
-  } else {
-    PRECICE_DEBUG("Split to new Communicator");
-    // Create a new communicator that contains only ranks of my group
-    MPI_Comm newComm = MPI_COMM_NULL;
-    MPI_Comm_split(globalComm, thisGroup->id, rank, &newComm);
-    // Assemble and set new state
-    newState = CommState::fromComm(newComm);
-  }
-
-#ifndef NDEBUG
-  PRECICE_DEBUG("Detected {} groups", accessorGroups.size());
-  for (const AccessorGroup &group : accessorGroups) {
-    PRECICE_DEBUG("Group {}: name = {}, leaderRank = {}, size = {}",
-                  group.id, group.name, group.leaderRank, group.size);
-  }
-#endif // NDEBUG
-
-  newState->groups = std::move(accessorGroups);
-  pushState(newState);
-
+  // Assemble and set new state
+  pushState(CommState::fromComm(newComm));
 #endif // not PRECICE_NO_MPI
 }
 
@@ -400,82 +305,6 @@ int Parallel::getProcessRank()
   }
 #endif // not PRECICE_NO_MPI
   return 0;
-}
-
-void Parallel::restrictCommunicator(int newSize)
-{
-  PRECICE_TRACE(newSize);
-  PRECICE_ASSERT(newSize > 0, "Cannot restrict a communicator to nothing!");
-
-#ifndef PRECICE_NO_MPI
-  auto       baseState = current();
-  const auto size      = baseState->size();
-  const auto rank      = baseState->rank();
-
-  PRECICE_ASSERT(newSize <= size, "Requested more ranks than the Communicator can provide!");
-
-  // A single rank can use MPI_COMM_SELF, nothing else required
-  if (newSize == 1) {
-    // @todo verify if the barrier is required
-    // PRECICE_DEBUG("Barrier");
-    // MPI_Barrier(_globalCommunicator);
-    if (rank == 0) {
-      PRECICE_DEBUG("Restricted to COMM_SELF");
-      pushState(CommState::self());
-      return;
-    } else {
-      PRECICE_DEBUG("This rank remains unused after the restriction.");
-      pushState(CommState::null());
-      return;
-    }
-  }
-
-  // If the requested size is the same as the capacity, then simply duplicate the comm
-  if (newSize == size) {
-    PRECICE_DEBUG("Restriction to capacity: duplicating Comm");
-    MPI_Comm copiedComm;
-    MPI_Comm_dup(baseState->comm, &copiedComm);
-    pushState(CommState::fromComm(copiedComm));
-    return;
-  }
-
-  // Create group, containing all processes of communicator
-  MPI_Group currentGroup;
-  MPI_Comm_group(baseState->comm, &currentGroup);
-
-  // Prepare a ranks vector with 0,1,2,...,newSize-1
-  std::vector<int> ranks(newSize);
-  std::iota(ranks.begin(), ranks.end(), 0);
-
-  // Create subgroup, containing processes contained in ranks
-  PRECICE_DEBUG("Create restricted group");
-  MPI_Group restrictedGroup;
-  MPI_Group_incl(currentGroup, static_cast<int>(ranks.size()), ranks.data(), &restrictedGroup);
-
-  // @todo check if it has to go back down to the other group free
-  MPI_Group_free(&currentGroup);
-
-  {
-    int restrictedGroupSize = 0;
-    MPI_Group_size(restrictedGroup, &restrictedGroupSize);
-    PRECICE_ASSERT(restrictedGroupSize == newSize, "Group size differs: restriction failed!");
-  }
-
-  // Create communicator, containing process of restrictedGroup
-  PRECICE_DEBUG("Create restricted comm using group");
-
-  //  MPI_Comm restrictedCommunicator;
-  MPI_Comm restrictedCommunicator = MPI_COMM_NULL;
-  MPI_Comm_create(baseState->comm, restrictedGroup, &restrictedCommunicator);
-
-  // @todo check if the we need a barrier here
-  // PRECICE_DEBUG("Barrier");
-  // MPI_Barrier(_globalCommunicator);
-  PRECICE_DEBUG("Free restricted group");
-  MPI_Group_free(&restrictedGroup);
-
-  pushState(CommState::fromComm(restrictedCommunicator));
-#endif // not PRECICE_NO_MPI
 }
 
 std::ostream &operator<<(std::ostream &out, const Parallel::CommState &value)

--- a/src/utils/Parallel.hpp
+++ b/src/utils/Parallel.hpp
@@ -30,14 +30,6 @@ public:
 #define MPI_COMM_NULL nullptr
 #endif
 
-  /// Used to sort and order all coupling participants.
-  struct AccessorGroup {
-    std::string name;
-    int         id;
-    int         leaderRank;
-    int         size;
-  };
-
   struct CommState;
 
   using CommStatePtr = std::shared_ptr<CommState>;
@@ -47,10 +39,6 @@ public:
    * It also owns the CommState it originated from (parent) via shared ownership.
    */
   struct CommState {
-
-    /// The different groups that were used to split the communicator
-    std::vector<AccessorGroup> groups;
-
     /// The native communicator that represents this state
     Communicator comm = MPI_COMM_NULL;
 
@@ -188,18 +176,7 @@ public:
    *
    * @param[in] groupName MPI group in which the calling process will be put in
    */
-  static void splitCommunicator(const std::string &groupName);
-
-  /// Creates a restricted communicator
-  /**
-   * Set the new, restricted communicator on all ranks that are contained in
-   * that new communicator. Sets the communicator of the other ranks to MPI_COMM_NULL.
-   *
-   * @param[in] newSize How many ranks to restrict the Communicator to
-   *
-   * @postcondition current()->size() == newSize || current()->isNull()
-   */
-  static void restrictCommunicator(int newSize);
+  static void splitCommunicator(std::optional<int> group = std::nullopt);
 
   /** Resets the commState to World
    *

--- a/src/utils/tests/ParallelTest.cpp
+++ b/src/utils/tests/ParallelTest.cpp
@@ -16,52 +16,6 @@ BOOST_AUTO_TEST_SUITE(Parallel)
 
 #ifndef PRECICE_NO_MPI
 
-BOOST_AUTO_TEST_CASE(RestrictCommTest)
-{
-  PRECICE_TEST(4_ranks);
-  using Par = utils::Parallel;
-
-  auto baseComm = Par::current();
-  Par::restrictCommunicator(3);
-  auto restComm = Par::current();
-  BOOST_TEST(restComm);
-  BOOST_TEST(restComm->parent == baseComm);
-
-  if (context.rank == 3) {
-    BOOST_TEST(restComm->isNull());
-  } else {
-    BOOST_TEST(!restComm->isNull());
-    BOOST_TEST(restComm->size() == 3);
-    BOOST_TEST(restComm->rank() <= 2);
-  }
-}
-
-BOOST_AUTO_TEST_CASE(SplitCommTest)
-{
-  PRECICE_TEST(3_ranks);
-  using Par = utils::Parallel;
-
-  std::string name{"Group"};
-  name.append(context.rank == 2 ? "Two" : "One");
-  auto baseComm = Par::current();
-  Par::splitCommunicator(name);
-  auto splitComm = Par::current();
-  BOOST_TEST(splitComm->parent == baseComm);
-
-  BOOST_TEST(!splitComm->isNull());
-
-  const auto &groups = splitComm->groups;
-  BOOST_TEST(groups.size() == 2);
-  BOOST_TEST(groups.at(0).id == 0);
-  BOOST_TEST(groups.at(1).id == 1);
-  BOOST_TEST(groups.at(0).name == std::string("GroupOne"));
-  BOOST_TEST(groups.at(1).name == std::string("GroupTwo"));
-  BOOST_TEST(groups.at(0).leaderRank == 0);
-  BOOST_TEST(groups.at(1).leaderRank == 2);
-  BOOST_TEST(groups.at(0).size == 2);
-  BOOST_TEST(groups.at(1).size == 1);
-}
-
 BOOST_AUTO_TEST_CASE(Primary1SecondaryTest)
 {
   PRECICE_TEST(""_on(2_ranks).setupIntraComm());


### PR DESCRIPTION
## Main changes of this PR

Replaces the cumbersome functionality in `utils::Parallel` to split the communicator into multiple groups with a single call to `MPI_Comm_Split`.

## Motivation and additional information

MPI_Comm_Split provides all guarantees which we rely on:
* Groups need to be numbered and become colors
* Rank orders are preserved if no key is given
* Passing MPI_Undefined as a color returns MPI_COMM_NULL

Hence, this one function replaces the complete setup. All we need is to assign number to participants and associate ranks with participants.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
