### PR TITLE
Fix missing bindings include in build pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,11 +685,16 @@ else()
 endif()
 
 # Configure the pkg-config file for the binary directory
+set(_precice_bindings "")
+if (PRECICE_BINDINGS_C)
+  set(_precice_bindings "-I${PROJECT_SOURCE_DIR}/extras/bindings/c/include")
+endif()
 configure_file(
   "${PROJECT_SOURCE_DIR}/cmake/binary.pc.in"
   "libprecice.pc"
   @ONLY
   )
+unset(_precice_bindings)
 
 # Configure the pkg-config file for the installation
 configure_file(

--- a/cmake/binary.pc.in
+++ b/cmake/binary.pc.in
@@ -3,4 +3,4 @@ Description: preCICE coupling library from binary dir
 Version: @preCICE_VERSION@
 URL: https://www.precice.org
 Libs: -L@PROJECT_BINARY_DIR@ -lprecice
-Cflags: -I@PROJECT_SOURCE_DIR@/src -I@PROJECT_BINARY_DIR@/src
+Cflags: -I@PROJECT_SOURCE_DIR@/src -I@PROJECT_BINARY_DIR@/src @_precice_bindings@

--- a/docs/changelog/1931.md
+++ b/docs/changelog/1931.md
@@ -1,0 +1,1 @@
+- Fixed missing include path for C-bindings when using preCICE via pkg-config directly from the build directory.


### PR DESCRIPTION
## Main changes of this PR

This PR adds the missing include directory of C bindings to the pkg-config file **in the build directory**.

You can now build C solvers using pkg-config from the build directory without installing precice first.

## Motivation and additional information

Consistency

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

