### PR TITLE
Fix time accumulation and max time

### DIFF
--- a/docs/changelog/1933.md
+++ b/docs/changelog/1933.md
@@ -1,0 +1,1 @@
+- Changed internal time handling to a Kahan accumulator, preventing issues combining `max-time` with small a `time-windows-size`.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -490,7 +490,13 @@ double BaseCouplingScheme::getNextTimeStepMaxSize() const
   }
 
   if (hasTimeWindowSize()) {
-    return getWindowStartTime() + _timeWindowSize - _time;
+    double maxDt = getWindowStartTime() + _timeWindowSize - _time;
+    if (math::equals(_maxTime, UNDEFINED_MAX_TIME)) {
+      return maxDt;
+    } else {
+      double leftover = _maxTime - _time;
+      return std::min(maxDt, leftover);
+    }
   } else {
     if (math::equals(_maxTime, UNDEFINED_MAX_TIME)) {
       return std::numeric_limits<double>::max();

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -2,11 +2,15 @@
 
 #include <Eigen/Core>
 #include <algorithm>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+#include <boost/accumulators/statistics/sum_kahan.hpp>
 #include <map>
 #include <memory>
 #include <set>
 #include <string>
 #include <vector>
+
 #include "Constants.hpp"
 #include "CouplingData.hpp"
 #include "CouplingScheme.hpp"
@@ -19,7 +23,6 @@
 #include "m2n/M2N.hpp"
 #include "m2n/SharedPointer.hpp"
 #include "mesh/SharedPointer.hpp"
-#include "utils/assertion.hpp"
 
 namespace precice {
 namespace io {
@@ -411,8 +414,10 @@ private:
   /// Maximum time being computed. End of simulation is reached, if getTime() == _maxTime
   double _maxTime;
 
+  using KahanAccumulator = boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::sum_kahan>>;
+
   /// time of beginning of the current time window
-  double _timeWindowStartTime = 0;
+  KahanAccumulator _timeWindowStartTime;
 
   /// Number of time windows that have to be computed. End of simulation is reached, if _timeWindows == _maxTimeWindows
   int _maxTimeWindows;
@@ -584,6 +589,11 @@ private:
    * @return the end of the time window, defined as timeWindowStart + timeWindowSize
    */
   double getWindowEndTime() const;
+
+  /**
+   * @return the start of the time window
+   */
+  double getWindowStartTime() const;
 };
 } // namespace cplscheme
 } // namespace precice


### PR DESCRIPTION
## Main changes of this PR

This PR 
- replaces the time window start with a Kahan aggregator
- constrains the max dt by max-time

## Motivation and additional information

time-window-size = 0.01 and max-time = 5 leads to 501 time windows due to rounding errors.
This should solve the problem.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
