### PR TITLE
Replace _time with Kahan aggregator

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -432,7 +432,7 @@ private:
   double _nextTimeWindowSize = UNDEFINED_TIME_WINDOW_SIZE;
 
   /// Current time
-  double _time = 0;
+  KahanAccumulator _time;
 
   /// Lower limit of iterations during one time window. Prevents convergence if _iterations < _minIterations.
   int _minIterations = -1;


### PR DESCRIPTION
## Main changes of this PR

This PR replaces `_time` with a Kahan aggregator, which significantly reduces accumulated rounding errors when dealing with many substeps.

## Motivation and additional information

Direct extension of #1933 (thanks to @davidscn).

This should be interesting for our waveformers @BenjaminRodenberg @NiklasKotarsky @NiklasVin

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
