### PR TITLE
Geometric multiscale: Use size_t for all indices

### DIFF
--- a/src/mapping/AxialGeoMultiscaleMapping.cpp
+++ b/src/mapping/AxialGeoMultiscaleMapping.cpp
@@ -126,7 +126,7 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
     size_t const outSize = output()->vertices().size();
 
     for (size_t i = 0; i < outSize; i++) {
-      PRECICE_ASSERT(static_cast<size_t>((i * outDataDimensions) + effectiveCoordinate) < outputValues.size(), ((i * outDataDimensions) + effectiveCoordinate), outputValues.size());
+      PRECICE_ASSERT(static_cast<size_t>((i * outDataDimensions) + effectiveCoordinate) < static_cast<size_t>(outputValues.size()), ((i * outDataDimensions) + effectiveCoordinate), outputValues.size());
       // When adding support for 2D, remember that this should be 1.5 * inputValues(effectiveCoordinate) * (1 - (_vertexDistances[i] * _vertexDistances[i]));
       outputValues((i * outDataDimensions) + effectiveCoordinate) = 2 * inputValues(effectiveCoordinate) * (1 - (_vertexDistances[i] * _vertexDistances[i]));
     }
@@ -140,7 +140,7 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
     outputValues(effectiveCoordinate) = 0;
     size_t const inSize               = input()->vertices().size();
     for (size_t i = 0; i < inSize; i++) {
-      PRECICE_ASSERT(static_cast<size_t>((i * inDataDimensions) + effectiveCoordinate) < inputValues.size(), ((i * inDataDimensions) + effectiveCoordinate), inputValues.size())
+      PRECICE_ASSERT(static_cast<size_t>((i * inDataDimensions) + effectiveCoordinate) < static_cast<size_t>(inputValues.size()), ((i * inDataDimensions) + effectiveCoordinate), inputValues.size())
       outputValues(effectiveCoordinate) += inputValues((i * inDataDimensions) + effectiveCoordinate);
     }
     outputValues(effectiveCoordinate) = outputValues(effectiveCoordinate) / inSize;

--- a/src/mapping/AxialGeoMultiscaleMapping.cpp
+++ b/src/mapping/AxialGeoMultiscaleMapping.cpp
@@ -126,7 +126,7 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
     size_t const outSize = output()->vertices().size();
 
     for (size_t i = 0; i < outSize; i++) {
-      PRECICE_ASSERT(static_cast<int>((i * outDataDimensions) + effectiveCoordinate) < outputValues.size(), ((i * outDataDimensions) + effectiveCoordinate), outputValues.size());
+      PRECICE_ASSERT(static_cast<size_t>((i * outDataDimensions) + effectiveCoordinate) < outputValues.size(), ((i * outDataDimensions) + effectiveCoordinate), outputValues.size());
       // When adding support for 2D, remember that this should be 1.5 * inputValues(effectiveCoordinate) * (1 - (_vertexDistances[i] * _vertexDistances[i]));
       outputValues((i * outDataDimensions) + effectiveCoordinate) = 2 * inputValues(effectiveCoordinate) * (1 - (_vertexDistances[i] * _vertexDistances[i]));
     }
@@ -140,7 +140,7 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
     outputValues(effectiveCoordinate) = 0;
     size_t const inSize               = input()->vertices().size();
     for (size_t i = 0; i < inSize; i++) {
-      PRECICE_ASSERT(static_cast<int>((i * inDataDimensions) + effectiveCoordinate) < inputValues.size(), ((i * inDataDimensions) + effectiveCoordinate), inputValues.size())
+      PRECICE_ASSERT(static_cast<size_t>((i * inDataDimensions) + effectiveCoordinate) < inputValues.size(), ((i * inDataDimensions) + effectiveCoordinate), inputValues.size())
       outputValues(effectiveCoordinate) += inputValues((i * inDataDimensions) + effectiveCoordinate);
     }
     outputValues(effectiveCoordinate) = outputValues(effectiveCoordinate) / inSize;

--- a/src/mapping/RadialGeoMultiscaleMapping.cpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.cpp
@@ -96,7 +96,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
       }
       axisMidpoints(outSize - 1) = std::numeric_limits<double>::max(); // large number, such that vertices after the last midpoint are still assigned
 
-      std::vector<int> counters(outSize); // counts number of vertices in between midpoints for averaging
+      std::vector<size_t> counters(outSize); // counts number of vertices in between midpoints for averaging
 
       // Identify which vertex (index) of the 3D mesh corresponds to which vertex (index) of the 1D meesh
       _vertexIndicesCollect.clear();

--- a/src/mapping/RadialGeoMultiscaleMapping.cpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.cpp
@@ -62,10 +62,10 @@ void RadialGeoMultiscaleMapping::computeMapping()
       _vertexIndicesSpread.clear();
       _vertexIndicesSpread.reserve(output()->vertices().size());
       for (size_t i = 0; i < outSize; i++) {
-        auto vertexCoord = output()->vertices()[i].rawCoords()[effectiveCoordinate];
-        int  index       = 0;
+        auto   vertexCoord = output()->vertices()[i].rawCoords()[effectiveCoordinate];
+        size_t index       = 0;
         while (vertexCoord > axisMidpoints(index)) {
-          PRECICE_ASSERT(index + 1 < static_cast<int>(inSize));
+          PRECICE_ASSERT(index + 1 < inSize);
           ++index;
         }
         _vertexIndicesSpread.push_back(index);
@@ -102,10 +102,10 @@ void RadialGeoMultiscaleMapping::computeMapping()
       _vertexIndicesCollect.clear();
       _vertexIndicesCollect.reserve(input()->vertices().size());
       for (size_t i = 0; i < inSize; i++) {
-        auto vertexCoords = input()->vertices()[i].rawCoords()[effectiveCoordinate];
-        int  index        = 0;
+        auto   vertexCoords = input()->vertices()[i].rawCoords()[effectiveCoordinate];
+        size_t index        = 0;
         while (vertexCoords > axisMidpoints(index)) {
-          PRECICE_ASSERT(index + 1 < static_cast<int>(outSize));
+          PRECICE_ASSERT(index + 1 < outSize);
           ++index;
         }
         _vertexIndicesCollect.push_back(index);

--- a/src/mapping/RadialGeoMultiscaleMapping.hpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.hpp
@@ -65,11 +65,11 @@ private:
   MultiscaleAxis _axis;
 
   /// computed vertex indices to map data from input vertices to output vertices and vice versa
-  std::vector<int> _vertexIndicesSpread;
-  std::vector<int> _vertexIndicesCollect;
+  std::vector<size_t> _vertexIndicesSpread;
+  std::vector<size_t> _vertexIndicesCollect;
 
   /// counts number of vertices between midpoints for averaging
-  std::vector<int> _vertexCounter;
+  std::vector<size_t> _vertexCounter;
 };
 
 } // namespace mapping


### PR DESCRIPTION
## Main changes of this PR

Uses `size_t` for some stray index vectors that were previously declared as `int`.

## Motivation and additional information

Fixes (hopefully) this code scanning alert: https://github.com/precice/precice/security/code-scanning/9 and therefore should be part of v3.0.0.

I am not sure how to check without merging to develop or pushing my branch here and triggering CodeQL, but this multiplication:

```c++
inputValues(_vertexIndicesSpread[i] * inDataDimensions)
```

is now happening between a `size_t` and an `int`, so there should be an implicit conversion to `size_t` ([CodeQL documentation](https://codeql.github.com/codeql-query-help/cpp/cpp-integer-multiplication-cast-to-long/)). The dimensions is currently defined everywhere as an `int`, I would not change or discuss that as part of this PR.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> N/A
* I added a test to cover the proposed changes in our test suite. -> N/A (already caught by a linter)
* For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> N/A
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Do you understand the code changes?
* [ ] Do you see any other places where we should apply the same change?
* [ ] Do we have any reason to keep the `int` in any of these places?

