### PR TITLE
Improve time handling

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -205,14 +205,13 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
 void BaseCouplingScheme::receiveDataForWindowEnd(const m2n::PtrM2N &m2n, const DataMap &receiveData)
 {
   // buffer current time
-  const double oldProgress = getTimeWindowProgress();
+  auto oldProgress = _timeWindowProgress;
   // set _time state to point to end of this window such that _time in receiveData is at end of window
   _timeWindowProgress(_nextTimeWindowSize);
   // receive data for end of window
   this->receiveData(m2n, receiveData);
   // reset time state;
-  _timeWindowProgress = KahanAccumulator{};
-  _timeWindowProgress(oldProgress); // This should be 0, right?
+  _timeWindowProgress = oldProgress;
 }
 
 void BaseCouplingScheme::initializeWithZeroInitialData(const DataMap &receiveData)

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -109,10 +109,12 @@ public:
   bool hasDataBeenReceived() const override final;
 
   /**
-   * @brief getter for _time
+   * @brief returns getTimeWindowStart() + getTimeWindowProgress()
    * @returns the currently computed time of the coupling scheme.
    */
   double getTime() const override final;
+
+  double getTimeWindowProgress() const;
 
   double getTimeWindowStart() const override final;
 
@@ -414,13 +416,16 @@ private:
   /// Maximum time being computed. End of simulation is reached, if getTime() == _maxTime
   double _maxTime;
 
-  using KahanAccumulator = boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::sum_kahan>>;
-
-  /// time of beginning of the current time window
-  KahanAccumulator _timeWindowStartTime;
-
   /// Number of time windows that have to be computed. End of simulation is reached, if _timeWindows == _maxTimeWindows
   int _maxTimeWindows;
+
+  using KahanAccumulator = boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::sum_kahan>>;
+
+  /// The start time of the current time window
+  KahanAccumulator _timeWindowStartTime;
+
+  /// The progress inside the current time window
+  KahanAccumulator _timeWindowProgress;
 
   /// number of completed time windows; _timeWindows <= _maxTimeWindows
   int _timeWindows = 0;
@@ -430,9 +435,6 @@ private:
 
   /// time window size of next window (acts as buffer for time windows size provided by first participant, if using first participant method)
   double _nextTimeWindowSize = UNDEFINED_TIME_WINDOW_SIZE;
-
-  /// Current time
-  KahanAccumulator _time;
 
   /// Lower limit of iterations during one time window. Prevents convergence if _iterations < _minIterations.
   int _minIterations = -1;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -119,6 +119,15 @@ public:
   double getTimeWindowStart() const override final;
 
   /**
+   * @brief returns the remaining time after the start of the current time window
+   *
+   * @return getTimeWindowStart() - _maxTime
+   *
+   * @pre _maxTime must be defined
+   */
+  double getRemainingTime() const;
+
+  /**
    * @brief getter for _timeWindows
    * @returns the number of currently computed time windows of the coupling scheme.
    */
@@ -426,6 +435,9 @@ private:
 
   /// The progress inside the current time window
   KahanAccumulator _timeWindowProgress;
+
+  /// The remaining time of the simulation. This is _maxTime - timeWindowStartTime
+  KahanAccumulator _remainingTime;
 
   /// number of completed time windows; _timeWindows <= _maxTimeWindows
   int _timeWindows = 0;

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -299,7 +299,8 @@ target_sources(testprecice
     tests/serial/whitebox/TestConfigurationComsol.cpp
     tests/serial/whitebox/TestConfigurationPeano.cpp
     tests/serial/whitebox/TestExplicitWithDataScaling.cpp
+    tests/time-handling/SimpleMaxTime.cpp
     )
 
 # Contains the list of integration test suites
-set(PRECICE_TEST_SUITES GeometricMultiscale Parallel QuasiNewton Serial)
+set(PRECICE_TEST_SUITES GeometricMultiscale Parallel QuasiNewton Serial TimeHandling)

--- a/tests/time-handling/SimpleMaxTime.cpp
+++ b/tests/time-handling/SimpleMaxTime.cpp
@@ -1,0 +1,45 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(TimeHandling)
+BOOST_AUTO_TEST_CASE(SimpleMaxTime, *boost::unit_test::tolerance(1e-18))
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+  double               coord[] = {0, 0};
+  p.setMeshVertex(context.name + "-Mesh", coord);
+  p.initialize();
+
+  const double expected = 0.01;
+
+  BOOST_TEST(p.getMaxTimeStepSize() == expected);
+  BOOST_TEST(p.isCouplingOngoing());
+  p.advance(p.getMaxTimeStepSize());
+
+  BOOST_TEST(p.getMaxTimeStepSize() == expected);
+  BOOST_TEST(p.isCouplingOngoing());
+  p.advance(p.getMaxTimeStepSize());
+
+  BOOST_REQUIRE(p.isCouplingOngoing());
+  // BUG was: return value 0.009999999999999998
+  BOOST_TEST(p.getMaxTimeStepSize() == expected);
+  p.advance(p.getMaxTimeStepSize());
+
+  BOOST_TEST(p.isCouplingOngoing());
+  // BUG was: return value 0.010000000000000002
+  BOOST_TEST(p.getMaxTimeStepSize() == expected);
+  p.advance(p.getMaxTimeStepSize());
+
+  BOOST_TEST(p.getMaxTimeStepSize() == 0.);
+  BOOST_REQUIRE(!p.isCouplingOngoing());
+}
+
+BOOST_AUTO_TEST_SUITE_END() // TimeHandling
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/time-handling/SimpleMaxTime.xml
+++ b/tests/time-handling/SimpleMaxTime.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="2">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="2">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <time-window-size value="0.01" />
+    <max-time value="0.04" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>


### PR DESCRIPTION
## Main changes of this PR

This PR further improves the time handling in the BaseCouplingScheme.

Using absolute times for both, the time window start time and the current time required to compute the current time window progress.
This was numerically problematic and lead to cancellation issues in computing the remainder of the time window.

We now store:
* the start time of the time window
* the progress in the current time window
* the remaining simulation time (essentially `max time - time window start time`)

This should eliminate all critical parts of cancellation.

Remaining are:
* `double maxDt = _timeWindowSize - getTimeWindowProgress()` to get the remaining time inside the time window
* `double leftoverTime = getRemainingTime() - getTimeWindowProgress()`, to get the remaining time of the simulation relative from the current time step


## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
