### PR TITLE
Add check for polars version

### DIFF
--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -43,6 +43,17 @@ def requireModules(modules):
         sys.exit(1)
 
 
+def checkPolarsVersion():
+    import polars
+
+    major, minor, _ = tuple(map(int, polars.__version__.split(".")))
+    if (major == 0) and (minor < 19):
+        print(
+            f"This command requires a polars installation of at least version 0.19.0 (found: {polars.__version__})"
+        )
+        sys.exit(1)
+
+
 def loadRobust(content):
     try:
         return json.loads(content)
@@ -487,6 +498,8 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
     requireModules(["polars"])
     import polars as pl
 
+    checkPolarsVersion()
+
     run = Run(profilingfile)
     df = run.toDataFrame()
 
@@ -571,6 +584,8 @@ def histogramCommand(profilingfile, outfile, participant, event, rank, bins, uni
     requireModules(["polars", "matplotlib"])
     import matplotlib.pyplot as plt
     import polars as pl
+
+    checkPolarsVersion()
 
     run = Run(profilingfile)
     df = run.toDataFrame()


### PR DESCRIPTION
## Main changes of this PR

This PR adds a version check for polars.
The current minimum requirement of python polars is version `0.19.0`.

## Motivation and additional information

Prevent users to see users run into this error https://github.com/precice/precice/pull/1914#issuecomment-1904740930

```
AttributeError: 'DataFrame' object has no attribute 'group_by'. Did you mean: 'groupby'?
```

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
