### PR TITLE
Skip zero samples when mapping initial data

### DIFF
--- a/docs/changelog/1942.md
+++ b/docs/changelog/1942.md
@@ -1,0 +1,1 @@
+- Changed 0 data samples to be skipped when mapping samples during `initialize`.

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -139,11 +139,11 @@ int DataContext::mapData(std::optional<double> after, bool skipZero)
           mapping.map(stample.sample, outSample.values);
         }
         PRECICE_DEBUG("Mapped values (t={}) = {}", stample.timestamp, utils::previewRange(3, outSample.values));
+        ++executedMappings;
       }
 
       // Store data from mapping buffer in storage
       context.toData->setSampleAtTime(stample.timestamp, std::move(outSample));
-      ++executedMappings;
     }
   }
   return executedMappings;

--- a/src/precice/impl/DataContext.hpp
+++ b/src/precice/impl/DataContext.hpp
@@ -81,10 +81,11 @@ public:
    * @brief Perform the mapping for mapping contexts and the corresponding data context (from and to data)
    *
    * @param[in] after only map samples after this optional time
+   * @param[in] skipZero set output sample to zero if the input sample is zero too
    *
    * @return the number of performed mappings
    */
-  int mapData(std::optional<double> after = std::nullopt);
+  int mapData(std::optional<double> after = std::nullopt, bool skipZero = false);
 
   /**
    * @brief Adds a MappingContext and the MeshContext required by the mapping to the corresponding DataContext data structures.

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -376,8 +376,14 @@ private:
   /// Helper for mapWrittenData and mapReadData
   void computeMappings(std::vector<MappingContext> &contexts, const std::string &mappingType);
 
+  /// Computes, and performs write mappings of the initial data in initialize
+  void mapInitialWrittenData();
+
   /// Computes, and performs suitable write mappings either entirely or after given time
   void mapWrittenData(std::optional<double> after = std::nullopt);
+
+  // Computes, and performs read mappings of the initial data in initialize
+  void mapInitialReadData();
 
   // Computes, and performs read mappings
   void mapReadData();

--- a/tests/serial/map-if-necessary/three-solvers/helper.hpp
+++ b/tests/serial/map-if-necessary/three-solvers/helper.hpp
@@ -25,6 +25,13 @@ inline void runMultipleSolversMappingCount(precice::testing::TestContext &contex
 
   participant.initialize();
 
+  BOOST_TEST_CONTEXT("Data isn't initialized, and thus isn't mapped")
+  {
+    auto mappedSubstep = precice::testing::WhiteboxAccessor::impl(participant).mappedSamples();
+    BOOST_TEST(mappedSubstep.write == 0);
+    BOOST_TEST(mappedSubstep.read == 0);
+  }
+
   participant.requiresWritingCheckpoint();
 
   // A and B are fully steered by the configuration

--- a/tests/serial/map-if-necessary/two-solvers/helper.hpp
+++ b/tests/serial/map-if-necessary/two-solvers/helper.hpp
@@ -25,6 +25,13 @@ inline void runTwoSolversMappingCount(precice::testing::TestContext &context, st
 
   participant.initialize();
 
+  BOOST_TEST_CONTEXT("Data isn't initialized, and thus isn't mapped")
+  {
+    auto mappedSubstep = precice::testing::WhiteboxAccessor::impl(participant).mappedSamples();
+    BOOST_TEST(mappedSubstep.write == 0);
+    BOOST_TEST(mappedSubstep.read == 0);
+  }
+
   BOOST_TEST(participant.requiresWritingCheckpoint() == implicit);
 
   size_t timeWindow = 0;

--- a/tests/serial/map-initial-data/helper.hpp
+++ b/tests/serial/map-initial-data/helper.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <precice/precice.hpp>
+
+#include "precice/impl/ParticipantImpl.hpp"
+#include "testing/Testing.hpp"
+
+/** Test for mappings mapping initial data when initialize="true"
+ * One writes data (dataToWrite to initialize and 1 at the end of the time window)
+ * This is where write mappings are tested.
+ *
+ * Two reads data and compares initial data to dataToExpect.
+ * This is where read mappings are tested.
+ *
+ * The mapping is either a read or a write mapping.
+ */
+inline void testMapInitialData(
+    precice::testing::TestContext &context,
+    double                         dataToWrite,
+    double                         dataToExpect,
+    int                            readMappingsToExpect,
+    int                            writeMappingsToExpect)
+{
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+
+  double                coord[] = {0.0, 0.0, 1.0, 1.0};
+  std::array<double, 2> writeData{dataToWrite, dataToWrite};
+  std::array<double, 2> readData{0.0, 0.0};
+  std::string           mesh = "Mesh" + context.name;
+
+  std::array<precice::VertexID, 2> vid;
+  p.setMeshVertices(mesh, coord, vid);
+
+  // Initialize data
+  if (context.isNamed("One") && p.requiresInitialData()) {
+    p.writeData(mesh, "Data", vid, writeData);
+  }
+  p.initialize();
+
+  // Check mappings in initialize of Two
+  auto mapped = precice::testing::WhiteboxAccessor::impl(p).mappedSamples();
+  if (context.isNamed("One")) {
+    BOOST_TEST(mapped.write == writeMappingsToExpect);
+  } else {
+    BOOST_TEST(mapped.read == readMappingsToExpect);
+
+    p.readData(mesh, "Data", vid, 0.0, readData);
+    BOOST_TEST(readData[0] == dataToExpect);
+    BOOST_TEST(readData[1] == dataToExpect);
+  }
+
+  if (context.isNamed("One")) {
+    // This is required to test the second participant in serial coupling schemes
+    writeData.fill(1.0);
+    p.writeData(mesh, "Data", vid, writeData);
+  }
+  p.advance(p.getMaxTimeStepSize());
+  BOOST_REQUIRE(!p.isCouplingOngoing());
+}

--- a/tests/serial/map-initial-data/non-zero-data/ParallelRead.cpp
+++ b/tests/serial/map-initial-data/non-zero-data/ParallelRead.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(NonZeroData)
+BOOST_AUTO_TEST_CASE(ParallelRead)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 1.0, 1.0, 1, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/non-zero-data/ParallelRead.xml
+++ b/tests/serial/map-initial-data/non-zero-data/ParallelRead.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <receive-mesh name="MeshOne" from="One" />
+    <read-data name="Data" mesh="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshOne" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-initial-data/non-zero-data/ParallelWrite.cpp
+++ b/tests/serial/map-initial-data/non-zero-data/ParallelWrite.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(NonZeroData)
+BOOST_AUTO_TEST_CASE(ParallelWrite)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 1.0, 1.0, 0, 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/non-zero-data/ParallelWrite.xml
+++ b/tests/serial/map-initial-data/non-zero-data/ParallelWrite.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <write-data name="Data" mesh="MeshOne" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Data" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshTwo" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-initial-data/non-zero-data/SerialRead.cpp
+++ b/tests/serial/map-initial-data/non-zero-data/SerialRead.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(NonZeroData)
+BOOST_AUTO_TEST_CASE(SerialRead)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 1.0, 1.0, 2, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/non-zero-data/SerialRead.xml
+++ b/tests/serial/map-initial-data/non-zero-data/SerialRead.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <receive-mesh name="MeshOne" from="One" />
+    <read-data name="Data" mesh="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshOne" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-initial-data/non-zero-data/SerialWrite.cpp
+++ b/tests/serial/map-initial-data/non-zero-data/SerialWrite.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(NonZeroData)
+BOOST_AUTO_TEST_CASE(SerialWrite)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 1.0, 1.0, 0, 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/non-zero-data/SerialWrite.xml
+++ b/tests/serial/map-initial-data/non-zero-data/SerialWrite.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <write-data name="Data" mesh="MeshOne" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Data" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshTwo" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-initial-data/zero-data/ParallelRead.cpp
+++ b/tests/serial/map-initial-data/zero-data/ParallelRead.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(ZeroData)
+BOOST_AUTO_TEST_CASE(ParallelRead)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 0.0, 0.0, 0, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/zero-data/ParallelRead.xml
+++ b/tests/serial/map-initial-data/zero-data/ParallelRead.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <receive-mesh name="MeshOne" from="One" />
+    <read-data name="Data" mesh="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshOne" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-initial-data/zero-data/ParallelWrite.cpp
+++ b/tests/serial/map-initial-data/zero-data/ParallelWrite.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(ZeroData)
+BOOST_AUTO_TEST_CASE(ParallelWrite)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 0.0, 0.0, 0, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/zero-data/ParallelWrite.xml
+++ b/tests/serial/map-initial-data/zero-data/ParallelWrite.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <write-data name="Data" mesh="MeshOne" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Data" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshTwo" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/map-initial-data/zero-data/SerialRead.cpp
+++ b/tests/serial/map-initial-data/zero-data/SerialRead.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(ZeroData)
+BOOST_AUTO_TEST_CASE(SerialRead)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 0.0, 0.0, 1, 0); // End of time window is not zero
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/zero-data/SerialRead.xml
+++ b/tests/serial/map-initial-data/zero-data/SerialRead.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <receive-mesh name="MeshOne" from="One" />
+    <read-data name="Data" mesh="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshOne" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/serial/map-initial-data/zero-data/SerialWrite.cpp
+++ b/tests/serial/map-initial-data/zero-data/SerialWrite.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_SUITE(ZeroData)
+BOOST_AUTO_TEST_CASE(SerialWrite)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(1_rank));
+
+  testMapInitialData(context, 0.0, 0.0, 0, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // NonZeroData
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/map-initial-data/zero-data/SerialWrite.xml
+++ b/tests/serial/map-initial-data/zero-data/SerialWrite.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="Two" />
+    <write-data name="Data" mesh="MeshOne" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Data" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshTwo" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -168,6 +168,15 @@ target_sources(testprecice
     tests/serial/map-if-necessary/two-solvers/without-substeps/ParallelImplicit.cpp
     tests/serial/map-if-necessary/two-solvers/without-substeps/SerialExplicit.cpp
     tests/serial/map-if-necessary/two-solvers/without-substeps/SerialImplicit.cpp
+    tests/serial/map-initial-data/helper.hpp
+    tests/serial/map-initial-data/non-zero-data/ParallelRead.cpp
+    tests/serial/map-initial-data/non-zero-data/ParallelWrite.cpp
+    tests/serial/map-initial-data/non-zero-data/SerialRead.cpp
+    tests/serial/map-initial-data/non-zero-data/SerialWrite.cpp
+    tests/serial/map-initial-data/zero-data/ParallelRead.cpp
+    tests/serial/map-initial-data/zero-data/ParallelWrite.cpp
+    tests/serial/map-initial-data/zero-data/SerialRead.cpp
+    tests/serial/map-initial-data/zero-data/SerialWrite.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadScalar.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalReadVector.cpp
     tests/serial/mapping-nearest-neighbor-gradient/GradientTestBidirectionalWriteScalar.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds the functionality to skip samples containing only 0 when mapping initial data.

## Motivation and additional information

This prevents possibly expensive data mappings of samples where the user provided no data / a zero initial condition.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
