### PR TITLE
Add Ubuntu 24.04LTS to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,6 +70,10 @@ jobs:
             CONFIG: MPIPETScGinkgo
             CXX: 'g++'
             TYPE: Debug
+          - IMAGE: 'ubuntu-2404'
+            CONFIG: MPIPETScGinkgo
+            CXX: 'g++'
+            TYPE: Debug
           - IMAGE: 'archlinux'
             CONFIG: MPIPETSc
             CXX: 'g++'
@@ -106,9 +110,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Generate build directory
         run: mkdir -p build
-      - name: Install polars
-        run: pip install polars
-        if: ${{ contains(matrix.IMAGE, 'ubuntu') }}
+      - name: Install polars in venv
+        run: |
+          python3 -m venv --system-site-packages venv
+          venv/bin/pip install polars
+          venv/bin/pip list
       - name: Configure
         working-directory: build
         env:
@@ -118,6 +124,7 @@ jobs:
           PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
           Ginkgo: ${{ contains(matrix.CONFIG, 'Ginkgo') }}
         run: |
+          . ../venv/bin/activate # There is always a venv present
           cmake --version
           cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DPRECICE_FEATURE_GINKGO_MAPPING=${{ env.Ginkgo }} -DPRECICE_FEATURE_LIBBACKTRACE_STACKTRACES=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.COVFLAGS }}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
       - uses: actions/upload-artifact@v4
@@ -151,7 +158,7 @@ jobs:
           OMPI_MCA_btl_tcp_if_include: lo # required for arch
           PSM3_HAL: loopback # required for fedora
         working-directory: build
-        run: su -c "ctest" $PRECICE_USER
+        run: su -c ". ../venv/bin/activate && ctest" $PRECICE_USER
       - name: Coverage Report
         working-directory: build
         if: ${{ matrix.COVFLAGS }}


### PR DESCRIPTION
## Main changes of this PR

This PR adds the prerelease image of Ubuntu 24.04 LTS to the CI.

The point of this PR is to test if this is even working at all before adding it to the test suite on develop.

## Motivation and additional information

Let's start testing early rather than late.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
