### PR TITLE
Refactor Mesh and Vertex usage

### DIFF
--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -33,7 +33,7 @@ void ScaleByAreaAction::performAction()
     auto &targetValues              = _targetData->values();
     targetValues                    = targetStample.sample.values;
     const int       valueDimensions = _targetData->getDimensions();
-    Eigen::VectorXd areas           = Eigen::VectorXd::Zero(getMesh()->vertices().size());
+    Eigen::VectorXd areas           = Eigen::VectorXd::Zero(getMesh()->nVertices());
     PRECICE_ASSERT(targetValues.size() / valueDimensions == areas.size());
 
     if (meshDimensions == 2) {

--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -35,14 +35,14 @@ BOOST_AUTO_TEST_CASE(PerformActionWithGlobalIterationsCounter)
   Eigen::VectorXd v(3);
   v << 0.1, 0.2, 0.3;
   mesh->data(sourceID)->setSampleAtTime(1, time::Sample{1, v});
-  mesh->data(targetID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->vertices().size())});
+  mesh->data(targetID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->nVertices())});
 
   action.performAction();
 
   Eigen::VectorXd result(3);
   result << 1.1, 1.2, 1.3;
   BOOST_TEST(testing::equals(mesh->data(targetID)->values(), result));
-  mesh->data(sourceID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->vertices().size())});
+  mesh->data(sourceID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->nVertices())});
 
   action.performAction();
 

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh)
       mesh::Mesh recvMesh("Received Mesh", dim, testing::nextMeshID());
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       com::receiveMesh(comm, 0, recvMesh);
-      BOOST_TEST(recvMesh.vertices().size() == 4);
+      BOOST_TEST(recvMesh.nVertices() == 4);
       BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
       BOOST_TEST(recvMesh.vertices().at(1) == v0);
       BOOST_TEST(recvMesh.vertices().at(2) == v1);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh)
     // receiveMesh can also deal with delta meshes
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::receiveMesh(comm, 0, recvMesh);
-    BOOST_TEST(recvMesh.vertices().size() == 4);
+    BOOST_TEST(recvMesh.nVertices() == 4);
     BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
     BOOST_TEST(recvMesh.vertices().at(1) == v0);
     BOOST_TEST(recvMesh.vertices().at(2) == v1);
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh)
     // receiveMesh can also deal with delta meshes
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::broadcastReceiveMesh(comm, recvMesh);
-    BOOST_TEST(recvMesh.vertices().size() == 4);
+    BOOST_TEST(recvMesh.nVertices() == 4);
     BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
     BOOST_TEST(recvMesh.vertices().at(1) == v0);
     BOOST_TEST(recvMesh.vertices().at(2) == v1);
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(OneTetraCommunication)
     // receiveMesh can also deal with delta meshes
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::receiveMesh(comm, 0, recvMesh);
-    BOOST_TEST(recvMesh.vertices().size() == 5); // 4 + 1
+    BOOST_TEST(recvMesh.nVertices() == 5); // 4 + 1
     BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
     BOOST_TEST(recvMesh.tetrahedra().size() == 1);
     BOOST_TEST(testing::equals(recvMesh.tetrahedra()[0].vertex(0).getCoords(), Eigen::Vector3d{0.0, 0.0, 0.0}));
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(BroadcastTetra)
     // receiveMesh can also deal with delta meshes
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::broadcastReceiveMesh(comm, recvMesh);
-    BOOST_TEST(recvMesh.vertices().size() == 5); // 4 + 1
+    BOOST_TEST(recvMesh.nVertices() == 5); // 4 + 1
     BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
     BOOST_TEST(recvMesh.tetrahedra().size() == 1);
     BOOST_TEST(testing::equals(recvMesh.tetrahedra()[0].vertex(0).getCoords(), Eigen::Vector3d{0.0, 0.0, 0.0}));

--- a/src/com/tests/CommunicateMeshTest.cpp
+++ b/src/com/tests/CommunicateMeshTest.cpp
@@ -48,10 +48,10 @@ BOOST_AUTO_TEST_CASE(VertexEdgeMesh)
       recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
       com::receiveMesh(comm, 0, recvMesh);
       BOOST_TEST(recvMesh.nVertices() == 4);
-      BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
-      BOOST_TEST(recvMesh.vertices().at(1) == v0);
-      BOOST_TEST(recvMesh.vertices().at(2) == v1);
-      BOOST_TEST(recvMesh.vertices().at(3) == v2);
+      BOOST_TEST(testing::equals(recvMesh.vertex(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+      BOOST_TEST(recvMesh.vertex(1) == v0);
+      BOOST_TEST(recvMesh.vertex(2) == v1);
+      BOOST_TEST(recvMesh.vertex(3) == v2);
       BOOST_TEST(recvMesh.edges().at(0) == e0);
       BOOST_TEST(recvMesh.edges().at(1) == e1);
       BOOST_TEST(recvMesh.edges().at(2) == e2);
@@ -85,10 +85,10 @@ BOOST_AUTO_TEST_CASE(VertexEdgeTriangleMesh)
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::receiveMesh(comm, 0, recvMesh);
     BOOST_TEST(recvMesh.nVertices() == 4);
-    BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
-    BOOST_TEST(recvMesh.vertices().at(1) == v0);
-    BOOST_TEST(recvMesh.vertices().at(2) == v1);
-    BOOST_TEST(recvMesh.vertices().at(3) == v2);
+    BOOST_TEST(testing::equals(recvMesh.vertex(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+    BOOST_TEST(recvMesh.vertex(1) == v0);
+    BOOST_TEST(recvMesh.vertex(2) == v1);
+    BOOST_TEST(recvMesh.vertex(3) == v2);
     BOOST_TEST(recvMesh.edges().at(0) == e0);
     BOOST_TEST(recvMesh.edges().at(1) == e1);
     BOOST_TEST(recvMesh.edges().at(2) == e2);
@@ -122,10 +122,10 @@ BOOST_AUTO_TEST_CASE(BroadcastVertexEdgeTriangleMesh)
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::broadcastReceiveMesh(comm, recvMesh);
     BOOST_TEST(recvMesh.nVertices() == 4);
-    BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
-    BOOST_TEST(recvMesh.vertices().at(1) == v0);
-    BOOST_TEST(recvMesh.vertices().at(2) == v1);
-    BOOST_TEST(recvMesh.vertices().at(3) == v2);
+    BOOST_TEST(testing::equals(recvMesh.vertex(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+    BOOST_TEST(recvMesh.vertex(1) == v0);
+    BOOST_TEST(recvMesh.vertex(2) == v1);
+    BOOST_TEST(recvMesh.vertex(3) == v2);
     BOOST_TEST(recvMesh.edges().at(0) == e0);
     BOOST_TEST(recvMesh.edges().at(1) == e1);
     BOOST_TEST(recvMesh.edges().at(2) == e2);
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(OneTetraCommunication)
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::receiveMesh(comm, 0, recvMesh);
     BOOST_TEST(recvMesh.nVertices() == 5); // 4 + 1
-    BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+    BOOST_TEST(testing::equals(recvMesh.vertex(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
     BOOST_TEST(recvMesh.tetrahedra().size() == 1);
     BOOST_TEST(testing::equals(recvMesh.tetrahedra()[0].vertex(0).getCoords(), Eigen::Vector3d{0.0, 0.0, 0.0}));
     BOOST_TEST(recvMesh.tetrahedra()[0] == t0);
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(BroadcastTetra)
     recvMesh.createVertex(Eigen::VectorXd::Constant(dim, 9));
     com::broadcastReceiveMesh(comm, recvMesh);
     BOOST_TEST(recvMesh.nVertices() == 5); // 4 + 1
-    BOOST_TEST(testing::equals(recvMesh.vertices().at(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
+    BOOST_TEST(testing::equals(recvMesh.vertex(0).getCoords(), Eigen::VectorXd::Constant(dim, 9)));
     BOOST_TEST(recvMesh.tetrahedra().size() == 1);
     BOOST_TEST(testing::equals(recvMesh.tetrahedra()[0].vertex(0).getCoords(), Eigen::Vector3d{0.0, 0.0, 0.0}));
     BOOST_TEST(recvMesh.tetrahedra()[0] == t0);

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -86,7 +86,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
     BOOST_TEST(meshConfig->meshes().size() == 1);
     mesh::PtrMesh mesh = meshConfig->meshes().at(0);
     BOOST_TEST(mesh->data().size() == 3);
-    BOOST_TEST(mesh->vertices().size() > 0);
+    BOOST_TEST(mesh->nVertices() > 0);
 
     double computedTime      = 0.0;
     int    computedTimesteps = 0;

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -44,7 +44,7 @@ void runSimpleExplicitCoupling(
   auto &dataValues0 = mesh->data(0)->values();
   auto &dataValues1 = mesh->data(1)->values();
   BOOST_TEST(mesh->nVertices() > 0);
-  mesh::Vertex &  vertex     = mesh->vertices().at(0);
+  mesh::Vertex &  vertex     = mesh->vertex(0);
   double          valueData0 = 1.0;
   Eigen::VectorXd valueData1 = Eigen::VectorXd::Constant(3, 1.0);
 
@@ -155,7 +155,7 @@ void runExplicitCouplingWithSubcycling(
   mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_TEST(mesh->data().size() == 2);
   BOOST_TEST(mesh->nVertices() > 0);
-  mesh::Vertex &  vertex      = mesh->vertices().at(0);
+  mesh::Vertex &  vertex      = mesh->vertex(0);
   double          valueData0  = 1.0;
   Eigen::VectorXd valueData1  = Eigen::VectorXd::Constant(3, 1.0);
   auto &          dataValues0 = mesh->data(0)->values();

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -43,7 +43,7 @@ void runSimpleExplicitCoupling(
   BOOST_TEST(mesh->data().size() == 2);
   auto &dataValues0 = mesh->data(0)->values();
   auto &dataValues1 = mesh->data(1)->values();
-  BOOST_TEST(mesh->vertices().size() > 0);
+  BOOST_TEST(mesh->nVertices() > 0);
   mesh::Vertex &  vertex     = mesh->vertices().at(0);
   double          valueData0 = 1.0;
   Eigen::VectorXd valueData1 = Eigen::VectorXd::Constant(3, 1.0);
@@ -154,7 +154,7 @@ void runExplicitCouplingWithSubcycling(
   BOOST_TEST(meshConfig.meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_TEST(mesh->data().size() == 2);
-  BOOST_TEST(mesh->vertices().size() > 0);
+  BOOST_TEST(mesh->nVertices() > 0);
   mesh::Vertex &  vertex      = mesh->vertices().at(0);
   double          valueData0  = 1.0;
   Eigen::VectorXd valueData1  = Eigen::VectorXd::Constant(3, 1.0);

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -56,7 +56,7 @@ void runCoupling(
   BOOST_REQUIRE(!mesh->empty());
   BOOST_REQUIRE(!validIterations.empty());
 
-  mesh::Vertex &  vertex               = mesh->vertices().at(0);
+  mesh::Vertex &  vertex               = mesh->vertex(0);
   int             index                = vertex.getID();
   auto &          dataValues0          = mesh->data(0)->values();
   auto &          dataValues1          = mesh->data(1)->values();

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -53,7 +53,7 @@ void runCoupling(
   BOOST_REQUIRE(meshConfig.meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_REQUIRE(mesh->data().size() == 2);
-  BOOST_REQUIRE(!mesh->vertices().empty());
+  BOOST_REQUIRE(!mesh->empty());
   BOOST_REQUIRE(!validIterations.empty());
 
   mesh::Vertex &  vertex               = mesh->vertices().at(0);
@@ -228,7 +228,7 @@ void runCouplingWithSubcycling(
   BOOST_REQUIRE(meshConfig.meshes().size() == 1);
   mesh::PtrMesh mesh = meshConfig.meshes().at(0);
   BOOST_REQUIRE(mesh->data().size() == 2);
-  BOOST_REQUIRE(!mesh->vertices().empty());
+  BOOST_REQUIRE(!mesh->empty());
   BOOST_REQUIRE(!validIterations.empty());
 
   double          initialStepsizeData0 = 5.0;

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -101,7 +101,7 @@ void ExportCSV::doExport(
   const std::string rankCol = ";" + std::to_string(rank);
   const auto        size    = mesh.nVertices();
   for (std::size_t vid = 0; vid < size; ++vid) {
-    const auto &vertex = mesh.vertices()[vid];
+    const auto &vertex = mesh.vertex(vid);
     outFile << vertex.coord(0] << ';';
     outFile << vertex.coord(1];
     if (is3d) {

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -102,10 +102,10 @@ void ExportCSV::doExport(
   const auto        size    = mesh.nVertices();
   for (std::size_t vid = 0; vid < size; ++vid) {
     const auto &vertex = mesh.vertex(vid);
-    outFile << vertex.coord(0] << ';';
-    outFile << vertex.coord(1];
+    outFile << vertex.coord(0) << ';';
+    outFile << vertex.coord(1);
     if (is3d) {
-      outFile << ";" << vertex.coord(2];
+      outFile << ";" << vertex.coord(2);
     }
     outFile << rankCol;
     for (auto &dc : dataColumns) {

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -102,10 +102,10 @@ void ExportCSV::doExport(
   const auto        size    = mesh.nVertices();
   for (std::size_t vid = 0; vid < size; ++vid) {
     const auto &vertex = mesh.vertices()[vid];
-    outFile << vertex.getCoords()[0] << ';';
-    outFile << vertex.getCoords()[1];
+    outFile << vertex.coord(0] << ';';
+    outFile << vertex.coord(1];
     if (is3d) {
-      outFile << ";" << vertex.getCoords()[2];
+      outFile << ";" << vertex.coord(2];
     }
     outFile << rankCol;
     for (auto &dc : dataColumns) {

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -44,7 +44,7 @@ void ExportCSV::doExport(
   PRECICE_ASSERT(!name.empty());
 
   // Ignore empty meshes
-  if (mesh.vertices().empty()) {
+  if (mesh.empty()) {
     return;
   }
 

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -77,7 +77,7 @@ void ExportCSV::doExport(
   for (const auto &data : mesh.data()) {
     auto dataName = data->getName();
     auto dim      = data->getDimensions();
-    PRECICE_ASSERT(static_cast<std::size_t>(data->values().size()) == mesh.vertices().size() * dim);
+    PRECICE_ASSERT(static_cast<std::size_t>(data->values().size()) == mesh.nVertices() * dim);
     outFile << ';' << dataName;
     if (dim == 2) {
       outFile << "X;" << dataName << 'Y';
@@ -99,7 +99,7 @@ void ExportCSV::doExport(
 
   // write vertex data
   const std::string rankCol = ";" + std::to_string(rank);
-  const auto        size    = mesh.vertices().size();
+  const auto        size    = mesh.nVertices();
   for (std::size_t vid = 0; vid < size; ++vid) {
     const auto &vertex = mesh.vertices()[vid];
     outFile << vertex.getCoords()[0] << ';';

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -49,7 +49,7 @@ void ExportVTK::exportMesh(
   PRECICE_TRACE(mesh.getName());
 
   // Plot vertices
-  outFile << "POINTS " << mesh.vertices().size() << " double \n\n";
+  outFile << "POINTS " << mesh.nVertices() << " double \n\n";
   for (const mesh::Vertex &vertex : mesh.vertices()) {
     writeVertex(vertex.getCoords(), outFile);
   }
@@ -121,11 +121,11 @@ void ExportVTK::exportData(
     std::ofstream &   outFile,
     const mesh::Mesh &mesh)
 {
-  outFile << "POINT_DATA " << mesh.vertices().size() << "\n\n";
+  outFile << "POINT_DATA " << mesh.nVertices() << "\n\n";
 
   outFile << "SCALARS Rank unsigned_int\n";
   outFile << "LOOKUP_TABLE default\n";
-  std::fill_n(std::ostream_iterator<char const *>(outFile), mesh.vertices().size(), "0 ");
+  std::fill_n(std::ostream_iterator<char const *>(outFile), mesh.nVertices(), "0 ");
   outFile << "\n\n";
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data

--- a/src/io/ExportVTP.cpp
+++ b/src/io/ExportVTP.cpp
@@ -25,7 +25,7 @@ std::string ExportVTP::getPieceExtension() const
 std::string ExportVTP::getPieceAttributes(const mesh::Mesh &mesh) const
 {
   std::ostringstream oss;
-  oss << "NumberOfPoints=\"" << mesh.vertices().size() << "\" ";
+  oss << "NumberOfPoints=\"" << mesh.nVertices() << "\" ";
   oss << "NumberOfLines=\"" << mesh.edges().size() << "\" ";
   oss << "NumberOfPolys=\"" << mesh.triangles().size() << "\"";
   return oss.str();

--- a/src/io/ExportVTU.cpp
+++ b/src/io/ExportVTU.cpp
@@ -37,7 +37,7 @@ std::string ExportVTU::getPieceExtension() const
 std::string ExportVTU::getPieceAttributes(const mesh::Mesh &mesh) const
 {
   std::ostringstream oss;
-  oss << "NumberOfPoints=\"" << mesh.vertices().size() << "\" ";
+  oss << "NumberOfPoints=\"" << mesh.nVertices() << "\" ";
   oss << "NumberOfCells=\"" << mesh.edges().size() + mesh.triangles().size() + mesh.tetrahedra().size() << "\" ";
   return oss.str();
 }

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -32,7 +32,7 @@ void ExportXML::doExport(
   if (utils::IntraComm::isPrimary()) {
     writeParallelFile(name, location, mesh);
   }
-  if (mesh.vertices().size() > 0) { // only procs at the coupling interface should write output (for performance reasons)
+  if (mesh.nVertices() > 0) { // only procs at the coupling interface should write output (for performance reasons)
     writeSubFile(name, location, mesh);
   }
 }
@@ -206,7 +206,7 @@ void ExportXML::exportData(
   outFile << "            <DataArray type=\"UInt32\" Name=\"Rank\" NumberOfComponents=\"1\" format=\"ascii\">\n";
   outFile << "               ";
   const auto rank = utils::IntraComm::getRank();
-  for (size_t count = 0; count < mesh.vertices().size(); ++count) {
+  for (size_t count = 0; count < mesh.nVertices(); ++count) {
     outFile << rank << ' ';
   }
   outFile << "\n            </DataArray>\n";
@@ -222,7 +222,7 @@ void ExportXML::exportData(
     outFile << "               ";
     if (dataDimensions > 1) {
       Eigen::VectorXd viewTemp(dataDimensions);
-      for (size_t count = 0; count < mesh.vertices().size(); count++) {
+      for (size_t count = 0; count < mesh.nVertices(); count++) {
         size_t offset = count * dataDimensions;
         for (int i = 0; i < dataDimensions; i++) {
           viewTemp[i] = values(offset + i);
@@ -236,7 +236,7 @@ void ExportXML::exportData(
         outFile << ' ';
       }
     } else if (dataDimensions == 1) {
-      for (size_t count = 0; count < mesh.vertices().size(); count++) {
+      for (size_t count = 0; count < mesh.nVertices(); count++) {
         outFile << values(count) << ' ';
       }
     }

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -362,17 +362,17 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
     if (context.isPrimary()) {
       // This rank should receive the mesh from rank 0 (fluid primary)
       BOOST_TEST(mesh->nVertices() == 2);
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 5.50);
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.0);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 2.0);
+      BOOST_TEST(mesh->vertices().at(0).coord(0) == 5.50);
+      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).coord(0) == 1.0);
+      BOOST_TEST(mesh->vertices().at(1).coord(1) == 2.0);
     } else {
       // This rank should receive the mesh from rank 1 (fluid secondary)
       BOOST_TEST(mesh->nVertices() == 2);
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 1.50);
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.50);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 2.0);
+      BOOST_TEST(mesh->vertices().at(0).coord(0) == 1.50);
+      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).coord(0) == 1.50);
+      BOOST_TEST(mesh->vertices().at(1).coord(1) == 2.0);
     }
   }
 }

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -362,17 +362,17 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
     if (context.isPrimary()) {
       // This rank should receive the mesh from rank 0 (fluid primary)
       BOOST_TEST(mesh->nVertices() == 2);
-      BOOST_TEST(mesh->vertices().at(0).coord(0) == 5.50);
-      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).coord(0) == 1.0);
-      BOOST_TEST(mesh->vertices().at(1).coord(1) == 2.0);
+      BOOST_TEST(mesh->vertex(0).coord(0) == 5.50);
+      BOOST_TEST(mesh->vertex(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertex(1).coord(0) == 1.0);
+      BOOST_TEST(mesh->vertex(1).coord(1) == 2.0);
     } else {
       // This rank should receive the mesh from rank 1 (fluid secondary)
       BOOST_TEST(mesh->nVertices() == 2);
-      BOOST_TEST(mesh->vertices().at(0).coord(0) == 1.50);
-      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).coord(0) == 1.50);
-      BOOST_TEST(mesh->vertices().at(1).coord(1) == 2.0);
+      BOOST_TEST(mesh->vertex(0).coord(0) == 1.50);
+      BOOST_TEST(mesh->vertex(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertex(1).coord(0) == 1.50);
+      BOOST_TEST(mesh->vertex(1).coord(1) == 2.0);
     }
   }
 }

--- a/src/m2n/tests/PointToPointCommunicationTest.cpp
+++ b/src/m2n/tests/PointToPointCommunicationTest.cpp
@@ -361,14 +361,14 @@ void runP2PMeshBroadcastTest(const TestContext &context, com::PtrCommunicationFa
 
     if (context.isPrimary()) {
       // This rank should receive the mesh from rank 0 (fluid primary)
-      BOOST_TEST(mesh->vertices().size() == 2);
+      BOOST_TEST(mesh->nVertices() == 2);
       BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 5.50);
       BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
       BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.0);
       BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 2.0);
     } else {
       // This rank should receive the mesh from rank 1 (fluid secondary)
-      BOOST_TEST(mesh->vertices().size() == 2);
+      BOOST_TEST(mesh->nVertices() == 2);
       BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 1.50);
       BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
       BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.50);

--- a/src/mapping/AxialGeoMultiscaleMapping.cpp
+++ b/src/mapping/AxialGeoMultiscaleMapping.cpp
@@ -49,7 +49,7 @@ void AxialGeoMultiscaleMapping::computeMapping()
                      "Unknown multiscale axis type.");
 
       // compute distances between 1D vertex and 3D vertices
-      mesh::Vertex &   v0                           = input()->vertices()[0];
+      mesh::Vertex &   v0                           = input()->vertex(0);
       size_t const     outSize                      = output()->nVertices();
       constexpr double distance_to_radius_threshold = 1.05;
 
@@ -59,7 +59,7 @@ void AxialGeoMultiscaleMapping::computeMapping()
       for (size_t i = 0; i < outSize; i++) {
         Eigen::VectorXd difference(outDataDimensions);
         difference = v0.getCoords();
-        difference -= output()->vertices()[i].getCoords();
+        difference -= output()->vertex(i).getCoords();
         double distance_to_radius = difference.norm() / _radius;
         PRECICE_CHECK(distance_to_radius <= distance_to_radius_threshold, "Output mesh has vertices that do not coincide with the geometric multiscale interface defined by the input mesh. Ratio of vertex distance to radius is {} (which is larger than the assumed threshold of distance_to_radius_threshold).", distance_to_radius);
         _vertexDistances.push_back(distance_to_radius);

--- a/src/mapping/AxialGeoMultiscaleMapping.cpp
+++ b/src/mapping/AxialGeoMultiscaleMapping.cpp
@@ -21,7 +21,7 @@ AxialGeoMultiscaleMapping::AxialGeoMultiscaleMapping(
 
 void AxialGeoMultiscaleMapping::computeMapping()
 {
-  PRECICE_TRACE(output()->vertices().size());
+  PRECICE_TRACE(output()->nVertices());
 
   PRECICE_ASSERT(input().get() != nullptr);
   PRECICE_ASSERT(output().get() != nullptr);
@@ -29,7 +29,7 @@ void AxialGeoMultiscaleMapping::computeMapping()
   if (getConstraint() == CONSISTENT) {
     PRECICE_DEBUG("Compute consistent mapping");
     if (_type == MultiscaleType::SPREAD) {
-      PRECICE_CHECK(input()->vertices().size() == 1, "You can only define an axial geometric multiscale mapping of type spread from a mesh with exactly one vertex.");
+      PRECICE_CHECK(input()->nVertices() == 1, "You can only define an axial geometric multiscale mapping of type spread from a mesh with exactly one vertex.");
 
       /* When we add support for 1D meshes (https://github.com/precice/precice/issues/1669),
         we should check for valid dimensions combination.
@@ -50,11 +50,11 @@ void AxialGeoMultiscaleMapping::computeMapping()
 
       // compute distances between 1D vertex and 3D vertices
       mesh::Vertex &   v0                           = input()->vertices()[0];
-      size_t const     outSize                      = output()->vertices().size();
+      size_t const     outSize                      = output()->nVertices();
       constexpr double distance_to_radius_threshold = 1.05;
 
       _vertexDistances.clear();
-      _vertexDistances.reserve(output()->vertices().size());
+      _vertexDistances.reserve(output()->nVertices());
 
       for (size_t i = 0; i < outSize; i++) {
         Eigen::VectorXd difference(outDataDimensions);
@@ -66,7 +66,7 @@ void AxialGeoMultiscaleMapping::computeMapping()
       }
     } else {
       PRECICE_ASSERT(_type == MultiscaleType::COLLECT);
-      PRECICE_CHECK(output()->vertices().size() == 1, "You can only define an axial geometric multiscale mapping of type spread from a mesh with exactly one vertex.");
+      PRECICE_CHECK(output()->nVertices() == 1, "You can only define an axial geometric multiscale mapping of type spread from a mesh with exactly one vertex.");
       // Nothing to do here: A consistent collect mapping only averages all the values, independently of their locations, and this is done in the mapConsistent() method.
     }
   } else {
@@ -99,7 +99,7 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
   const Eigen::VectorXd &inputValues      = inData.values;
   Eigen::VectorXd &      outputValues     = outData;
   // TODO: check if this needs to change when access to mesh dimension is possible
-  const int outDataDimensions = outData.size() / output()->vertices().size();
+  const int outDataDimensions = outData.size() / output()->nVertices();
 
   int effectiveCoordinate = static_cast<std::underlying_type_t<MultiscaleType>>(_axis);
   PRECICE_ASSERT(effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::X) ||
@@ -108,10 +108,10 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
                  "Unknown multiscale axis type.");
 
   // Check that the number of values for the input and output is right according to their dimensions
-  PRECICE_ASSERT((inputValues.size() / static_cast<std::size_t>(inDataDimensions) == input()->vertices().size()),
-                 inputValues.size(), inDataDimensions, input()->vertices().size());
-  PRECICE_ASSERT((outputValues.size() / static_cast<std::size_t>(outDataDimensions) == output()->vertices().size()),
-                 outputValues.size(), outDataDimensions, output()->vertices().size());
+  PRECICE_ASSERT((inputValues.size() / static_cast<std::size_t>(inDataDimensions) == input()->nVertices()),
+                 inputValues.size(), inDataDimensions, input()->nVertices());
+  PRECICE_ASSERT((outputValues.size() / static_cast<std::size_t>(outDataDimensions) == output()->nVertices()),
+                 outputValues.size(), outDataDimensions, output()->nVertices());
 
   // We currently don't support 1D data, so we need that the user specifies data of the same dimensions on both sides
   PRECICE_ASSERT(inDataDimensions == outDataDimensions);
@@ -122,8 +122,8 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
       3D vertices are assigned a value based on distance from the 1D vertex.
       Currently, a Hagen-Poiseuille profile determines the velocity value.
     */
-    PRECICE_ASSERT(input()->vertices().size() == 1);
-    size_t const outSize = output()->vertices().size();
+    PRECICE_ASSERT(input()->nVertices() == 1);
+    size_t const outSize = output()->nVertices();
 
     for (size_t i = 0; i < outSize; i++) {
       PRECICE_ASSERT(static_cast<size_t>((i * outDataDimensions) + effectiveCoordinate) < static_cast<size_t>(outputValues.size()), ((i * outDataDimensions) + effectiveCoordinate), outputValues.size());
@@ -136,9 +136,9 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
       1D vertex is assigned the averaged value over all 3D vertices at the outlet,
       but only of the effectiveCoordinate component of the velocity vector.
     */
-    PRECICE_ASSERT(output()->vertices().size() == 1);
+    PRECICE_ASSERT(output()->nVertices() == 1);
     outputValues(effectiveCoordinate) = 0;
-    size_t const inSize               = input()->vertices().size();
+    size_t const inSize               = input()->nVertices();
     for (size_t i = 0; i < inSize; i++) {
       PRECICE_ASSERT(static_cast<size_t>((i * inDataDimensions) + effectiveCoordinate) < static_cast<size_t>(inputValues.size()), ((i * inDataDimensions) + effectiveCoordinate), inputValues.size());
       outputValues(effectiveCoordinate) += inputValues((i * inDataDimensions) + effectiveCoordinate);
@@ -155,7 +155,7 @@ void AxialGeoMultiscaleMapping::tagMeshFirstRound()
 
   if (getConstraint() == CONSISTENT) {
     PRECICE_ASSERT(_type == MultiscaleType::SPREAD, "Not yet implemented");
-    PRECICE_ASSERT(input()->vertices().size() == 1);
+    PRECICE_ASSERT(input()->nVertices() == 1);
 
     input()->tagAll();
 

--- a/src/mapping/BarycentricBaseMapping.cpp
+++ b/src/mapping/BarycentricBaseMapping.cpp
@@ -40,15 +40,15 @@ void BarycentricBaseMapping::mapConservative(const time::Sample &inData, Eigen::
   precice::profiling::Event e("map.bbm.mapData.From" + input()->getName() + "To" + output()->getName(), profiling::Synchronize);
   PRECICE_ASSERT(getConstraint() == CONSERVATIVE);
   PRECICE_DEBUG("Map conservative using {}", getName());
-  PRECICE_ASSERT(_interpolations.size() == input()->vertices().size(),
-                 _interpolations.size(), input()->vertices().size());
+  PRECICE_ASSERT(_interpolations.size() == input()->nVertices(),
+                 _interpolations.size(), input()->nVertices());
   const int              dimensions = inData.dataDims;
   const Eigen::VectorXd &inValues   = inData.values;
   Eigen::VectorXd &      outValues  = outData;
 
   // For each input vertex, distribute the conserved data among the relevant output vertices
   // Do it for all dimensions (i.e. components if data is a vector)
-  for (size_t i = 0; i < input()->vertices().size(); i++) {
+  for (size_t i = 0; i < input()->nVertices(); i++) {
     const size_t inOffset = i * dimensions;
     const auto & elems    = _interpolations[i].getWeightedElements();
     for (const auto &elem : elems) {
@@ -67,8 +67,8 @@ void BarycentricBaseMapping::mapConsistent(const time::Sample &inData, Eigen::Ve
   PRECICE_TRACE();
   precice::profiling::Event e("map.bbm.mapData.From" + input()->getName() + "To" + output()->getName(), profiling::Synchronize);
   PRECICE_DEBUG("Map {} using {}", (hasConstraint(CONSISTENT) ? "consistent" : "scaled-consistent"), getName());
-  PRECICE_ASSERT(_interpolations.size() == output()->vertices().size(),
-                 _interpolations.size(), output()->vertices().size());
+  PRECICE_ASSERT(_interpolations.size() == output()->nVertices(),
+                 _interpolations.size(), output()->nVertices());
 
   const int              dimensions = inData.dataDims;
   const Eigen::VectorXd &inValues   = inData.values;
@@ -76,7 +76,7 @@ void BarycentricBaseMapping::mapConsistent(const time::Sample &inData, Eigen::Ve
 
   // For each output vertex, compute the linear combination of input vertices
   // Do it for all dimensions (i.e. components if data is a vector)
-  for (size_t i = 0; i < output()->vertices().size(); i++) {
+  for (size_t i = 0; i < output()->nVertices(); i++) {
     const auto &elems     = _interpolations[i].getWeightedElements();
     size_t      outOffset = i * dimensions;
     for (const auto &elem : elems) {
@@ -110,7 +110,7 @@ void BarycentricBaseMapping::tagMeshFirstRound()
   // Gather all vertices to be tagged in a first phase.
   // max_count is used to shortcut if all vertices have been tagged.
   std::unordered_set<int> tagged;
-  const std::size_t       max_count = origins->vertices().size();
+  const std::size_t       max_count = origins->nVertices();
 
   for (const Polation &interpolation : _interpolations) {
     for (const auto &elem : interpolation.getWeightedElements()) {

--- a/src/mapping/GinkgoRadialBasisFctSolver.hpp
+++ b/src/mapping/GinkgoRadialBasisFctSolver.hpp
@@ -225,8 +225,8 @@ GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::GinkgoRadialBasisFctSolver(
   PRECICE_ASSERT((inputMesh.getDimensions() == 3) || activeAxis[2] == false);
   PRECICE_ASSERT((inputSize >= 1 + polyparams) || polynomial != Polynomial::ON, inputSize);
 
-  const std::size_t inputMeshSize  = inputMesh.vertices().size();
-  const std::size_t outputMeshSize = outputMesh.vertices().size();
+  const std::size_t inputMeshSize  = inputMesh.nVertices();
+  const std::size_t outputMeshSize = outputMesh.nVertices();
   const std::size_t meshDim        = inputMesh.vertices().at(0).getDimensions();
 
   _scalarOne         = gko::share(gko::initialize<GinkgoScalar>({1.0}, _deviceExecutor));

--- a/src/mapping/GinkgoRadialBasisFctSolver.hpp
+++ b/src/mapping/GinkgoRadialBasisFctSolver.hpp
@@ -227,7 +227,7 @@ GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::GinkgoRadialBasisFctSolver(
 
   const std::size_t inputMeshSize  = inputMesh.nVertices();
   const std::size_t outputMeshSize = outputMesh.nVertices();
-  const std::size_t meshDim        = inputMesh.vertices().at(0).getDimensions();
+  const std::size_t meshDim        = inputMesh.vertex(0).getDimensions();
 
   _scalarOne         = gko::share(gko::initialize<GinkgoScalar>({1.0}, _deviceExecutor));
   _scalarNegativeOne = gko::share(gko::initialize<GinkgoScalar>({-1.0}, _deviceExecutor));
@@ -261,18 +261,18 @@ GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::GinkgoRadialBasisFctSolver(
   for (std::size_t i = 0; i < inputMeshSize; ++i) {
     for (std::size_t j = 0; j < meshDim; ++j) {
       if ("cuda-executor" == ginkgoParameter.executor || "hip-executor" == ginkgoParameter.executor) {
-        inputVertices->at(j, i) = inputMesh.vertices().at(i).rawCoords()[j];
+        inputVertices->at(j, i) = inputMesh.vertex(i).rawCoords()[j];
       } else {
-        inputVertices->at(i, j) = inputMesh.vertices().at(i).rawCoords()[j];
+        inputVertices->at(i, j) = inputMesh.vertex(i).rawCoords()[j];
       }
     }
   }
   for (std::size_t i = 0; i < outputMeshSize; ++i) {
     for (std::size_t j = 0; j < meshDim; ++j) {
       if ("cuda-executor" == ginkgoParameter.executor || "hip-executor" == ginkgoParameter.executor) {
-        outputVertices->at(j, i) = outputMesh.vertices().at(i).rawCoords()[j];
+        outputVertices->at(j, i) = outputMesh.vertex(i).rawCoords()[j];
       } else {
-        outputVertices->at(i, j) = outputMesh.vertices().at(i).rawCoords()[j];
+        outputVertices->at(i, j) = outputMesh.vertex(i).rawCoords()[j];
       }
     }
   }

--- a/src/mapping/GinkgoRadialBasisFctSolver.hpp
+++ b/src/mapping/GinkgoRadialBasisFctSolver.hpp
@@ -261,18 +261,18 @@ GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::GinkgoRadialBasisFctSolver(
   for (std::size_t i = 0; i < inputMeshSize; ++i) {
     for (std::size_t j = 0; j < meshDim; ++j) {
       if ("cuda-executor" == ginkgoParameter.executor || "hip-executor" == ginkgoParameter.executor) {
-        inputVertices->at(j, i) = inputMesh.vertex(i).rawCoords()[j];
+        inputVertices->at(j, i) = inputMesh.vertex(i).coord(j);
       } else {
-        inputVertices->at(i, j) = inputMesh.vertex(i).rawCoords()[j];
+        inputVertices->at(i, j) = inputMesh.vertex(i).coord(j);
       }
     }
   }
   for (std::size_t i = 0; i < outputMeshSize; ++i) {
     for (std::size_t j = 0; j < meshDim; ++j) {
       if ("cuda-executor" == ginkgoParameter.executor || "hip-executor" == ginkgoParameter.executor) {
-        outputVertices->at(j, i) = outputMesh.vertex(i).rawCoords()[j];
+        outputVertices->at(j, i) = outputMesh.vertex(i).coord(j);
       } else {
-        outputVertices->at(i, j) = outputMesh.vertex(i).rawCoords()[j];
+        outputVertices->at(i, j) = outputMesh.vertex(i).coord(j);
       }
     }
   }

--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -30,7 +30,7 @@ LinearCellInterpolationMapping::LinearCellInterpolationMapping(
 
 void LinearCellInterpolationMapping::computeMapping()
 {
-  PRECICE_TRACE(input()->vertices().size(), output()->vertices().size());
+  PRECICE_TRACE(input()->nVertices(), output()->nVertices());
   const std::string         baseEvent = "map.vci.computeMapping.From" + input()->getName() + "To" + output()->getName();
   precice::profiling::Event e(baseEvent, profiling::Synchronize);
 

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -192,7 +192,7 @@ void Mapping::scaleConsistentMapping(const Eigen::VectorXd &input, Eigen::Vector
   bool requiresTetra     = (spaceDimension == 3 and volumeMode);
 
   for (mesh::PtrMesh mesh : {this->input(), this->output()}) {
-    if (not mesh->vertices().empty()) {
+    if (not mesh->empty()) {
 
       PRECICE_CHECK(!(requiresEdges && mesh->edges().empty()), "Edges connectivity information is missing for the mesh \"{}\". "
                                                                "Scaled consistent mapping requires connectivity information.",

--- a/src/mapping/Mapping.cpp
+++ b/src/mapping/Mapping.cpp
@@ -135,10 +135,10 @@ void Mapping::map(int inputDataID,
                  getDimensions(), output()->getDimensions());
   PRECICE_ASSERT(input()->data(inputDataID)->getDimensions() == output()->data(outputDataID)->getDimensions(),
                  input()->data(inputDataID)->getDimensions(), output()->data(outputDataID)->getDimensions());
-  PRECICE_ASSERT(input()->data(inputDataID)->values().size() / input()->data(inputDataID)->getDimensions() == static_cast<int>(input()->vertices().size()),
-                 input()->data(inputDataID)->values().size(), input()->data(inputDataID)->getDimensions(), input()->vertices().size());
-  PRECICE_ASSERT(output()->data(outputDataID)->values().size() / output()->data(outputDataID)->getDimensions() == static_cast<int>(output()->vertices().size()),
-                 output()->data(outputDataID)->values().size(), output()->data(outputDataID)->getDimensions(), output()->vertices().size());
+  PRECICE_ASSERT(input()->data(inputDataID)->values().size() / input()->data(inputDataID)->getDimensions() == static_cast<int>(input()->nVertices()),
+                 input()->data(inputDataID)->values().size(), input()->data(inputDataID)->getDimensions(), input()->nVertices());
+  PRECICE_ASSERT(output()->data(outputDataID)->values().size() / output()->data(outputDataID)->getDimensions() == static_cast<int>(output()->nVertices()),
+                 output()->data(outputDataID)->values().size(), output()->data(outputDataID)->getDimensions(), output()->nVertices());
 
   time::Sample sample{input()->data(inputDataID)->getDimensions(),
                       input()->data(inputDataID)->values(),
@@ -208,7 +208,7 @@ void Mapping::scaleConsistentMapping(const Eigen::VectorXd &input, Eigen::Vector
     }
   }
 
-  const int valueDimensions = input.size() / this->input()->vertices().size();
+  const int valueDimensions = input.size() / this->input()->nVertices();
 
   Eigen::VectorXd integralInput;
   Eigen::VectorXd integralOutput;

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -29,7 +29,7 @@ NearestNeighborBaseMapping::NearestNeighborBaseMapping(
 
 void NearestNeighborBaseMapping::computeMapping()
 {
-  PRECICE_TRACE(input()->vertices().size());
+  PRECICE_TRACE(input()->nVertices());
 
   PRECICE_ASSERT(input().get() != nullptr);
   PRECICE_ASSERT(output().get() != nullptr);
@@ -50,7 +50,7 @@ void NearestNeighborBaseMapping::computeMapping()
   }
 
   // Set up of output arrays
-  const size_t verticesSize   = origins->vertices().size();
+  const size_t verticesSize   = origins->nVertices();
   const auto & sourceVertices = origins->vertices();
   _vertexIndices.resize(verticesSize);
 

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -64,7 +64,7 @@ void NearestNeighborBaseMapping::computeMapping()
     _vertexIndices[i]         = matchedVertex.index;
 
     // Compute distance between input and output vertiex for the stats
-    const auto &matchCoords = searchSpace->vertices()[matchedVertex.index].getCoords();
+    const auto &matchCoords = searchSpace->vertex(matchedVertex.index).getCoords();
     auto        distance    = (sourceCoords - matchCoords).norm();
     distanceStatistics(distance);
   }

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -71,7 +71,7 @@ void NearestNeighborGradientMapping::mapConsistent(const time::Sample &inData, E
 
   // Consistent mapping
   PRECICE_DEBUG("Map {} using {}", (hasConstraint(CONSISTENT) ? "consistent" : "scaled-consistent"), getName());
-  const size_t outSize = output()->vertices().size();
+  const size_t outSize = output()->nVertices();
 
   for (size_t i = 0; i < outSize; i++) {
     int inputIndex = _vertexIndices[i] * valueDimensions;

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -42,8 +42,8 @@ void NearestNeighborGradientMapping::onMappingComputed(mesh::PtrMesh origins, me
   // Calculate offsets
   for (size_t i = 0; i < _vertexIndices.size(); ++i) {
 
-    const auto &matchedVertexCoords = searchSpace.get()->vertices()[_vertexIndices[i]].getCoords();
-    const auto &sourceVertexCoords  = origins->vertices()[i].getCoords();
+    const auto &matchedVertexCoords = searchSpace.get()->vertex(_vertexIndices[i)].getCoords();
+    const auto &sourceVertexCoords  = origins->vertex(i).getCoords();
 
     // We calculate the distances uniformly for consistent mapping constraint as the difference (output - input)
     // For consistent mapping: the source is the output vertex and the matched vertex is the input since we iterate over all outputs

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -42,7 +42,7 @@ void NearestNeighborGradientMapping::onMappingComputed(mesh::PtrMesh origins, me
   // Calculate offsets
   for (size_t i = 0; i < _vertexIndices.size(); ++i) {
 
-    const auto &matchedVertexCoords = searchSpace.get()->vertex(_vertexIndices[i)].getCoords();
+    const auto &matchedVertexCoords = searchSpace->vertex(_vertexIndices[i]).getCoords();
     const auto &sourceVertexCoords  = origins->vertex(i).getCoords();
 
     // We calculate the distances uniformly for consistent mapping constraint as the difference (output - input)

--- a/src/mapping/NearestNeighborGradientMapping.cpp
+++ b/src/mapping/NearestNeighborGradientMapping.cpp
@@ -62,7 +62,7 @@ void NearestNeighborGradientMapping::mapConsistent(const time::Sample &inData, E
                  input()->getName());
 
   /// Check if input has gradient data, else send Error
-  PRECICE_WARN_IF(input()->vertices().empty(), "The mesh doesn't contain any vertices.");
+  PRECICE_WARN_IF(input()->empty(), "The mesh doesn't contain any vertices.");
 
   const int              valueDimensions = inData.dataDims;
   const Eigen::VectorXd &inputValues     = inData.values;

--- a/src/mapping/NearestNeighborMapping.cpp
+++ b/src/mapping/NearestNeighborMapping.cpp
@@ -36,7 +36,7 @@ void NearestNeighborMapping::mapConservative(const time::Sample &inData, Eigen::
   Eigen::VectorXd &      outputValues = outData;
 
   // Data dimensions (for scalar = 1, for vectors > 1)
-  const size_t inSize          = input()->vertices().size();
+  const size_t inSize          = input()->nVertices();
   const int    valueDimensions = inData.dataDims;
 
   for (size_t i = 0; i < inSize; i++) {
@@ -63,7 +63,7 @@ void NearestNeighborMapping::mapConsistent(const time::Sample &inData, Eigen::Ve
   Eigen::VectorXd &      outputValues = outData;
 
   // Data dimensions (for scalar = 1, for vectors > 1)
-  const size_t outSize         = output()->vertices().size();
+  const size_t outSize         = output()->nVertices();
   const int    valueDimensions = inData.dataDims;
 
   for (size_t i = 0; i < outSize; i++) {

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -44,7 +44,7 @@ NearestProjectionMapping::NearestProjectionMapping(
 
 void NearestProjectionMapping::computeMapping()
 {
-  PRECICE_TRACE(input()->vertices().size(), output()->vertices().size());
+  PRECICE_TRACE(input()->nVertices(), output()->nVertices());
   const std::string         baseEvent = "map.np.computeMapping.From" + input()->getName() + "To" + output()->getName();
   precice::profiling::Event e(baseEvent, profiling::Synchronize);
 

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -303,7 +303,7 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
     outMesh    = this->output(); // local
   }
 
-  if (outMesh->vertices().empty())
+  if (outMesh->empty())
     return; // Ranks not at the interface should never hold interface vertices
 
   // Note that we don't use the corresponding bounding box functions from

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -353,7 +353,7 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
   // ... and tag all affected vertices
   auto verticesNew = filterMesh->index().getVerticesInsideBox(localBB);
 
-  std::for_each(verticesNew.begin(), verticesNew.end(), [&filterMesh](VertexID v) { filterMesh->vertices()[v].tag(); });
+  std::for_each(verticesNew.begin(), verticesNew.end(), [&filterMesh](VertexID v) { filterMesh->vertex(v).tag(); });
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -165,7 +165,7 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
   eClusters.stop();
 
   _clusterRadius = clusterRadius;
-  PRECICE_ASSERT(_clusterRadius > 0 || inMesh->vertices().size() == 0 || outMesh->vertices().size() == 0);
+  PRECICE_ASSERT(_clusterRadius > 0 || inMesh->nVertices() == 0 || outMesh->nVertices() == 0);
 
   // Step 2: check, which of the resulting clusters are non-empty and register the cluster centers in a mesh
   // Here, the VertexCluster computes the matrix decompositions directly in case the cluster is non-empty
@@ -330,13 +330,13 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
   // vertices, but the user could increase the safety-factor or disable the filtering.
   // When no geometric filter is applid, vertices().size() is here the same as
   // getGlobalNumberOfVertices
-  if (filterMesh->vertices().size() < _verticesPerCluster &&
-      filterMesh->vertices().size() < static_cast<std::size_t>(filterMesh->getGlobalNumberOfVertices())) {
+  if (filterMesh->nVertices() < _verticesPerCluster &&
+      filterMesh->nVertices() < static_cast<std::size_t>(filterMesh->getGlobalNumberOfVertices())) {
     PRECICE_WARN("The repartitioning of the received mesh \"{}\" resulted in {} vertices on this "
                  "rank, which is less than the desired number of vertices per cluster configured "
                  "in the partition of unity mapping ({}). Consider increasing the safety-factor "
                  "or switching off the geometric filter (<receive-mesh: ... geometric-filter=\"no-filter\" .../>)",
-                 filterMesh->getName(), filterMesh->vertices().size(), _verticesPerCluster);
+                 filterMesh->getName(), filterMesh->nVertices(), _verticesPerCluster);
   }
 
   if (_clusterRadius == 0)
@@ -378,8 +378,8 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::exportClusterCentersAsVTU
   // We have to create the global offsets in order to export things in parallel
   if (utils::IntraComm::isSecondary()) {
     // send number of vertices
-    PRECICE_DEBUG("Send number of vertices: {}", centerMesh.vertices().size());
-    int numberOfVertices = centerMesh.vertices().size();
+    PRECICE_DEBUG("Send number of vertices: {}", centerMesh.nVertices());
+    int numberOfVertices = centerMesh.nVertices();
     utils::IntraComm::getCommunication()->send(numberOfVertices, 0);
 
     // receive vertex offsets
@@ -391,7 +391,7 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::exportClusterCentersAsVTU
   } else if (utils::IntraComm::isPrimary()) {
 
     mesh::Mesh::VertexOffsets vertexOffsets(utils::IntraComm::getSize());
-    vertexOffsets[0] = centerMesh.vertices().size();
+    vertexOffsets[0] = centerMesh.nVertices();
 
     // receive number of secondary vertices and fill vertex offsets
     for (int secondaryRank : utils::IntraComm::allSecondaryRanks()) {

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -313,7 +313,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       for (int dim = 0; dim < dimensions; dim++) {
         if (not this->_deadAxis[dim]) {
           colIdx[colNum]    = colNum;
-          rowVals[colNum++] = inVertex.getCoords()[dim];
+          rowVals[colNum++] = inVertex.coord(dim);
         }
       }
 
@@ -386,7 +386,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
       for (int dim = 0; dim < dimensions; dim++) {
         if (not this->_deadAxis[dim]) {
           colIdx[colNum]    = colNum;
-          rowVals[colNum++] = oVertex.getCoords()[dim];
+          rowVals[colNum++] = oVertex.coord(dim);
         }
       }
       ierr = MatSetValues(*m, 1, &row, colNum, colIdx.data(), rowVals.data(), INSERT_VALUES);

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -238,11 +238,11 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::computeMapping()
 
   auto n = myIndizes.size(); // polyparams, if on rank 0, are included here
 
-  auto outputSize = outMesh->vertices().size();
+  auto outputSize = outMesh->nVertices();
 
   PetscErrorCode ierr = 0;
-  PRECICE_DEBUG("inMesh->vertices().size() = {}", inMesh->vertices().size());
-  PRECICE_DEBUG("outMesh->vertices().size() = {}", outMesh->vertices().size());
+  PRECICE_DEBUG("inMesh->nVertices() = {}", inMesh->nVertices());
+  PRECICE_DEBUG("outMesh->nVertices() = {}", outMesh->nVertices());
   ePreCompute.stop();
 
   precice::profiling::Event eCreateMatrices("map.pet.createMatrices.From" + this->input()->getName() + "To" + this->output()->getName(), profiling::Synchronize);
@@ -585,10 +585,10 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConsistent(const time
 
     // Fill input from input data values
     std::vector<PetscScalar> inVals;
-    inVals.reserve(this->input()->vertices().size());
+    inVals.reserve(this->input()->nVertices());
     std::vector<PetscInt> inIdx;
-    inIdx.reserve(this->input()->vertices().size());
-    for (size_t i = 0; i < this->input()->vertices().size(); ++i) {
+    inIdx.reserve(this->input()->nVertices());
+    for (size_t i = 0; i < this->input()->nVertices(); ++i) {
       if (not this->input()->vertices()[i].isOwner())
         continue;
       inVals.emplace_back(inValues[i * valueDim + dim]);
@@ -708,7 +708,7 @@ void PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::mapConservative(const ti
     printMappingInfo(dim);
 
     // Fill input from input data values
-    for (size_t i = 0; i < this->input()->vertices().size(); i++) {
+    for (size_t i = 0; i < this->input()->nVertices(); i++) {
       auto const globalIndex = this->input()->vertices()[i].getGlobalIndex(); // globalIndex is target row
       if (globalIndex >= inRangeStart and globalIndex < inRangeEnd)           // only fill local rows
         ierr = VecSetValue(in, globalIndex, inValues[i * valueDim + dim], INSERT_VALUES);

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -144,7 +144,7 @@ void RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
     bb.expandBy(_basisFunction.getSupportRadius());
 
     auto vertices = filterMesh->index().getVerticesInsideBox(bb);
-    std::for_each(vertices.begin(), vertices.end(), [&filterMesh](size_t v) { filterMesh->vertices()[v].tag(); });
+    std::for_each(vertices.begin(), vertices.end(), [&filterMesh](size_t v) { filterMesh->vertex(v).tag(); });
   } else {
     filterMesh->tagAll();
   }
@@ -182,7 +182,7 @@ void RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshSecondRound()
   // Enlarge bb by support radius
   bb.expandBy(_basisFunction.getSupportRadius());
   auto vertices = mesh->index().getVerticesInsideBox(bb);
-  std::for_each(vertices.begin(), vertices.end(), [&mesh](size_t v) { mesh->vertices()[v].tag(); });
+  std::for_each(vertices.begin(), vertices.end(), [&mesh](size_t v) { mesh->vertex(v).tag(); });
 }
 } // namespace mapping
 } // namespace precice

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -134,7 +134,7 @@ void RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshFirstRound()
     otherMesh  = output(); // local
   }
 
-  if (otherMesh->vertices().empty())
+  if (otherMesh->empty())
     return; // Ranks not at the interface should never hold interface vertices
 
   // Tags all vertices that are inside otherMesh's bounding box, enlarged by the support radius

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -279,7 +279,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
       // Filter data
       int outputCounter = 0;
       for (int i = 0; i < static_cast<int>(this->output()->nVertices()); ++i) {
-        if (this->output()->vertices()[i].isOwner()) {
+        if (this->output()->vertex(i).isOwner()) {
           for (int dim = 0; dim < valueDim; ++dim) {
             outData[i * valueDim + dim] = outputValues(outputCounter);
             ++outputCounter;
@@ -305,7 +305,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
 
     int outputCounter = 0;
     for (int i = 0; i < static_cast<int>(this->output()->nVertices()); ++i) {
-      if (this->output()->vertices()[i].isOwner()) {
+      if (this->output()->vertex(i).isOwner()) {
         for (int dim = 0; dim < valueDim; ++dim) {
           outData[i * valueDim + dim] = receivedValues.at(outputCounter);
           ++outputCounter;

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -156,11 +156,11 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::computeMapping()
 
     // Forwarding the tuples here requires some template magic I don't want to implement
     if constexpr (std::tuple_size_v<std::tuple<Args...>>> 0) {
-      _rbfSolver = std::make_unique<SOLVER_T>(this->_basisFunction, globalInMesh, boost::irange<Eigen::Index>(0, globalInMesh.vertices().size()),
-                                              globalOutMesh, boost::irange<Eigen::Index>(0, globalOutMesh.vertices().size()), this->_deadAxis, _polynomial, std::get<0>(optionalArgs));
+      _rbfSolver = std::make_unique<SOLVER_T>(this->_basisFunction, globalInMesh, boost::irange<Eigen::Index>(0, globalInMesh.nVertices()),
+                                              globalOutMesh, boost::irange<Eigen::Index>(0, globalOutMesh.nVertices()), this->_deadAxis, _polynomial, std::get<0>(optionalArgs));
     } else {
-      _rbfSolver = std::make_unique<SOLVER_T>(this->_basisFunction, globalInMesh, boost::irange<Eigen::Index>(0, globalInMesh.vertices().size()),
-                                              globalOutMesh, boost::irange<Eigen::Index>(0, globalOutMesh.vertices().size()), this->_deadAxis, _polynomial);
+      _rbfSolver = std::make_unique<SOLVER_T>(this->_basisFunction, globalInMesh, boost::irange<Eigen::Index>(0, globalInMesh.nVertices()),
+                                              globalOutMesh, boost::irange<Eigen::Index>(0, globalOutMesh.nVertices()), this->_deadAxis, _polynomial);
     }
   }
   this->_hasComputedMapping = true;
@@ -278,7 +278,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
 
       // Filter data
       int outputCounter = 0;
-      for (int i = 0; i < static_cast<int>(this->output()->vertices().size()); ++i) {
+      for (int i = 0; i < static_cast<int>(this->output()->nVertices()); ++i) {
         if (this->output()->vertices()[i].isOwner()) {
           for (int dim = 0; dim < valueDim; ++dim) {
             outData[i * valueDim + dim] = outputValues(outputCounter);
@@ -304,7 +304,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
     const int valueDim = inData.dataDims;
 
     int outputCounter = 0;
-    for (int i = 0; i < static_cast<int>(this->output()->vertices().size()); ++i) {
+    for (int i = 0; i < static_cast<int>(this->output()->nVertices()); ++i) {
       if (this->output()->vertices()[i].isOwner()) {
         for (int dim = 0; dim < valueDim; ++dim) {
           outData[i * valueDim + dim] = receivedValues.at(outputCounter);

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -101,9 +101,9 @@ constexpr void reduceActiveAxis(const mesh::Mesh &mesh, const IndexContainer &ID
     if (axis[d] == false) {
       differences[d] = std::make_pair<int, double>(d, std::numeric_limits<double>::max());
     } else {
-      auto res = std::minmax_element(IDs.begin(), IDs.end(), [&](const auto &a, const auto &b) { return mesh.vertex(a).coord(d) < mesh.vertices()[b].coord(d); });
+      auto res = std::minmax_element(IDs.begin(), IDs.end(), [&](const auto &a, const auto &b) { return mesh.vertex(a).coord(d) < mesh.vertex(b).coord(d); });
       // Check if we are above or below the threshold
-      differences[d] = std::make_pair<int, double>(d, std::abs(mesh.vertex(*res.second).coord(d) - mesh.vertices()[*res.first].coord(d)));
+      differences[d] = std::make_pair<int, double>(d, std::abs(mesh.vertex(*res.second).coord(d) - mesh.vertex(*res.first).coord(d)));
     }
   }
 

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -101,9 +101,9 @@ constexpr void reduceActiveAxis(const mesh::Mesh &mesh, const IndexContainer &ID
     if (axis[d] == false) {
       differences[d] = std::make_pair<int, double>(d, std::numeric_limits<double>::max());
     } else {
-      auto res = std::minmax_element(IDs.begin(), IDs.end(), [&](const auto &a, const auto &b) { return mesh.vertices()[a].rawCoords()[d] < mesh.vertices()[b].rawCoords()[d]; });
+      auto res = std::minmax_element(IDs.begin(), IDs.end(), [&](const auto &a, const auto &b) { return mesh.vertices()[a].coord(d) < mesh.vertices()[b].coord(d); });
       // Check if we are above or below the threshold
-      differences[d] = std::make_pair<int, double>(d, std::abs(mesh.vertices()[*res.second].rawCoords()[d] - mesh.vertices()[*res.first].rawCoords()[d]));
+      differences[d] = std::make_pair<int, double>(d, std::abs(mesh.vertices()[*res.second].coord(d) - mesh.vertices()[*res.first].coord(d)));
     }
   }
 

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -101,9 +101,9 @@ constexpr void reduceActiveAxis(const mesh::Mesh &mesh, const IndexContainer &ID
     if (axis[d] == false) {
       differences[d] = std::make_pair<int, double>(d, std::numeric_limits<double>::max());
     } else {
-      auto res = std::minmax_element(IDs.begin(), IDs.end(), [&](const auto &a, const auto &b) { return mesh.vertices()[a].coord(d) < mesh.vertices()[b].coord(d); });
+      auto res = std::minmax_element(IDs.begin(), IDs.end(), [&](const auto &a, const auto &b) { return mesh.vertex(a).coord(d) < mesh.vertices()[b].coord(d); });
       // Check if we are above or below the threshold
-      differences[d] = std::make_pair<int, double>(d, std::abs(mesh.vertices()[*res.second].coord(d) - mesh.vertices()[*res.first].coord(d)));
+      differences[d] = std::make_pair<int, double>(d, std::abs(mesh.vertex(*res.second).coord(d) - mesh.vertices()[*res.first].coord(d)));
     }
   }
 
@@ -123,7 +123,7 @@ inline void fillPolynomialEntries(Eigen::MatrixXd &matrix, const mesh::Mesh &mes
     matrix(i.index(), startIndex) = 1.0;
 
     // 2. the linear contribution
-    const auto & u = mesh.vertices()[i.value()].rawCoords();
+    const auto & u = mesh.vertex(i.value()).rawCoords();
     unsigned int k = 0;
     // Loop over all three space dimension and ignore dead axis
     for (unsigned int d = 0; d < activeAxis.size(); ++d) {
@@ -164,11 +164,11 @@ Eigen::MatrixXd buildMatrixCLU(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh
   auto         i_iter  = inputIDs.begin();
   Eigen::Index i_index = 0;
   for (; i_iter != inputIDs.end(); ++i_iter, ++i_index) {
-    const auto &u       = inputMesh.vertices()[*i_iter].rawCoords();
+    const auto &u       = inputMesh.vertex(*i_iter).rawCoords();
     auto        j_iter  = i_iter;
     auto        j_index = i_index;
     for (; j_iter != inputIDs.end(); ++j_iter, ++j_index) {
-      const auto &v                 = inputMesh.vertices()[*j_iter].rawCoords();
+      const auto &v                 = inputMesh.vertex(*j_iter).rawCoords();
       double      squaredDifference = computeSquaredDifference(u, v, activeAxis);
       matrixCLU(i_index, j_index)   = basisFunction.evaluate(std::sqrt(squaredDifference));
     }
@@ -202,9 +202,9 @@ Eigen::MatrixXd buildMatrixA(RADIAL_BASIS_FUNCTION_T basisFunction, const mesh::
 
   // Compute RBF values for matrix A
   for (const auto &i : outputIDs | boost::adaptors::indexed()) {
-    const auto &u = outputMesh.vertices()[i.value()].rawCoords();
+    const auto &u = outputMesh.vertex(i.value()).rawCoords();
     for (const auto &j : inputIDs | boost::adaptors::indexed()) {
-      const auto &v                 = inputMesh.vertices()[j.value()].rawCoords();
+      const auto &v                 = inputMesh.vertex(j.value()).rawCoords();
       double      squaredDifference = computeSquaredDifference(u, v, activeAxis);
       matrixA(i.index(), j.index()) = basisFunction.evaluate(std::sqrt(squaredDifference));
     }

--- a/src/mapping/RadialGeoMultiscaleMapping.cpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.cpp
@@ -62,7 +62,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
       _vertexIndicesSpread.clear();
       _vertexIndicesSpread.reserve(output()->nVertices());
       for (size_t i = 0; i < outSize; i++) {
-        auto   vertexCoord = output()->vertices()[i].coord(effectiveCoordinate);
+        auto   vertexCoord = output()->vertex(i).coord(effectiveCoordinate);
         size_t index       = 0;
         while (vertexCoord > axisMidpoints(index)) {
           PRECICE_ASSERT(index + 1 < inSize);
@@ -90,8 +90,8 @@ void RadialGeoMultiscaleMapping::computeMapping()
                        });
       // Compute the midpoints of the 1D output mesh
       for (size_t i = 0; i < (outSize - 1); i++) {
-        auto axisPositionCurrent = output()->vertices()[i].coord(effectiveCoordinate);
-        auto axisPositionNext    = output()->vertices()[i + 1].coord(effectiveCoordinate);
+        auto axisPositionCurrent = output()->vertex(i).coord(effectiveCoordinate);
+        auto axisPositionNext    = output()->vertex(i + 1).coord(effectiveCoordinate);
         axisMidpoints(i)         = (axisPositionCurrent + axisPositionNext) / 2;
       }
       axisMidpoints(outSize - 1) = std::numeric_limits<double>::max(); // large number, such that vertices after the last midpoint are still assigned
@@ -102,7 +102,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
       _vertexIndicesCollect.clear();
       _vertexIndicesCollect.reserve(input()->nVertices());
       for (size_t i = 0; i < inSize; i++) {
-        auto   vertexCoords = input()->vertices()[i].coord(effectiveCoordinate);
+        auto   vertexCoords = input()->vertex(i).coord(effectiveCoordinate);
         size_t index        = 0;
         while (vertexCoords > axisMidpoints(index)) {
           PRECICE_ASSERT(index + 1 < outSize);

--- a/src/mapping/RadialGeoMultiscaleMapping.cpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.cpp
@@ -45,12 +45,12 @@ void RadialGeoMultiscaleMapping::computeMapping()
       std::iota(ordered_vertex_indices.begin(), ordered_vertex_indices.end(), 0);
       std::stable_sort(ordered_vertex_indices.begin(), ordered_vertex_indices.end(),
                        [effectiveCoordinate, &inputVerticesRef](const size_t aindex, const size_t bindex) {
-                         return inputVerticesRef[aindex].rawCoords()[effectiveCoordinate] < inputVerticesRef[bindex].rawCoords()[effectiveCoordinate];
+                         return inputVerticesRef[aindex].coord(effectiveCoordinate) < inputVerticesRef[bindex].coord(effectiveCoordinate);
                        });
       // Compute the midpoints of the 1D input mesh
       for (size_t i = 0; i < (inSize - 1); i++) {
-        auto axisPositionCurrent = inputVerticesRef[ordered_vertex_indices[i]].rawCoords()[effectiveCoordinate];
-        auto axisPositionNext    = inputVerticesRef[ordered_vertex_indices[i] + 1].rawCoords()[effectiveCoordinate];
+        auto axisPositionCurrent = inputVerticesRef[ordered_vertex_indices[i]].coord(effectiveCoordinate);
+        auto axisPositionNext    = inputVerticesRef[ordered_vertex_indices[i] + 1].coord(effectiveCoordinate);
         axisMidpoints(i)         = (axisPositionCurrent + axisPositionNext) / 2;
       }
       axisMidpoints(inSize - 1) = std::numeric_limits<double>::max(); // large number, such that vertices after the last midpoint are still assigned
@@ -62,7 +62,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
       _vertexIndicesSpread.clear();
       _vertexIndicesSpread.reserve(output()->nVertices());
       for (size_t i = 0; i < outSize; i++) {
-        auto   vertexCoord = output()->vertices()[i].rawCoords()[effectiveCoordinate];
+        auto   vertexCoord = output()->vertices()[i].coord(effectiveCoordinate);
         size_t index       = 0;
         while (vertexCoord > axisMidpoints(index)) {
           PRECICE_ASSERT(index + 1 < inSize);
@@ -86,12 +86,12 @@ void RadialGeoMultiscaleMapping::computeMapping()
       std::iota(ordered_vertex_indices.begin(), ordered_vertex_indices.end(), 0);
       std::stable_sort(ordered_vertex_indices.begin(), ordered_vertex_indices.end(),
                        [effectiveCoordinate, &outputVerticesRef](const size_t aindex, const size_t bindex) {
-                         return outputVerticesRef[aindex].rawCoords()[effectiveCoordinate] < outputVerticesRef[bindex].rawCoords()[effectiveCoordinate];
+                         return outputVerticesRef[aindex].coord(effectiveCoordinate) < outputVerticesRef[bindex].coord(effectiveCoordinate);
                        });
       // Compute the midpoints of the 1D output mesh
       for (size_t i = 0; i < (outSize - 1); i++) {
-        auto axisPositionCurrent = output()->vertices()[i].rawCoords()[effectiveCoordinate];
-        auto axisPositionNext    = output()->vertices()[i + 1].rawCoords()[effectiveCoordinate];
+        auto axisPositionCurrent = output()->vertices()[i].coord(effectiveCoordinate);
+        auto axisPositionNext    = output()->vertices()[i + 1].coord(effectiveCoordinate);
         axisMidpoints(i)         = (axisPositionCurrent + axisPositionNext) / 2;
       }
       axisMidpoints(outSize - 1) = std::numeric_limits<double>::max(); // large number, such that vertices after the last midpoint are still assigned
@@ -102,7 +102,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
       _vertexIndicesCollect.clear();
       _vertexIndicesCollect.reserve(input()->nVertices());
       for (size_t i = 0; i < inSize; i++) {
-        auto   vertexCoords = input()->vertices()[i].rawCoords()[effectiveCoordinate];
+        auto   vertexCoords = input()->vertices()[i].coord(effectiveCoordinate);
         size_t index        = 0;
         while (vertexCoords > axisMidpoints(index)) {
           PRECICE_ASSERT(index + 1 < outSize);

--- a/src/mapping/RadialGeoMultiscaleMapping.cpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.cpp
@@ -20,13 +20,13 @@ RadialGeoMultiscaleMapping::RadialGeoMultiscaleMapping(
 
 void RadialGeoMultiscaleMapping::computeMapping()
 {
-  PRECICE_TRACE(output()->vertices().size());
+  PRECICE_TRACE(output()->nVertices());
 
   PRECICE_ASSERT(input().get() != nullptr);
   PRECICE_ASSERT(output().get() != nullptr);
 
-  size_t const inSize  = input()->vertices().size();
-  size_t const outSize = output()->vertices().size();
+  size_t const inSize  = input()->nVertices();
+  size_t const outSize = output()->nVertices();
 
   int effectiveCoordinate = static_cast<std::underlying_type_t<MultiscaleType>>(_axis);
   PRECICE_ASSERT(effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::X) ||
@@ -41,7 +41,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
       Eigen::VectorXd axisMidpoints(inSize);
       auto &          inputVerticesRef = input()->vertices();
       // Order the vertices of the 1D input mesh, to correctly compute the midpoints of the segments between neighboring vertices
-      std::vector<size_t> ordered_vertex_indices(input()->vertices().size());
+      std::vector<size_t> ordered_vertex_indices(input()->nVertices());
       std::iota(ordered_vertex_indices.begin(), ordered_vertex_indices.end(), 0);
       std::stable_sort(ordered_vertex_indices.begin(), ordered_vertex_indices.end(),
                        [effectiveCoordinate, &inputVerticesRef](const size_t aindex, const size_t bindex) {
@@ -60,7 +60,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
         to the nearest neighbors of the 1D vertices in projection space.
       */
       _vertexIndicesSpread.clear();
-      _vertexIndicesSpread.reserve(output()->vertices().size());
+      _vertexIndicesSpread.reserve(output()->nVertices());
       for (size_t i = 0; i < outSize; i++) {
         auto   vertexCoord = output()->vertices()[i].rawCoords()[effectiveCoordinate];
         size_t index       = 0;
@@ -82,7 +82,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
       auto &          outputVerticesRef = output()->vertices();
 
       // Order the vertices of the 1D output mesh, to correctly compute the midpoints of the segments between neighboring vertices
-      std::vector<size_t> ordered_vertex_indices(output()->vertices().size());
+      std::vector<size_t> ordered_vertex_indices(output()->nVertices());
       std::iota(ordered_vertex_indices.begin(), ordered_vertex_indices.end(), 0);
       std::stable_sort(ordered_vertex_indices.begin(), ordered_vertex_indices.end(),
                        [effectiveCoordinate, &outputVerticesRef](const size_t aindex, const size_t bindex) {
@@ -100,7 +100,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
 
       // Identify which vertex (index) of the 3D mesh corresponds to which vertex (index) of the 1D meesh
       _vertexIndicesCollect.clear();
-      _vertexIndicesCollect.reserve(input()->vertices().size());
+      _vertexIndicesCollect.reserve(input()->nVertices());
       for (size_t i = 0; i < inSize; i++) {
         auto   vertexCoords = input()->vertices()[i].rawCoords()[effectiveCoordinate];
         size_t index        = 0;
@@ -145,17 +145,17 @@ void RadialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen
   const Eigen::VectorXd &inputValues      = inData.values;
   Eigen::VectorXd &      outputValues     = outData;
 
-  size_t const inSize  = input()->vertices().size();
-  size_t const outSize = output()->vertices().size();
+  size_t const inSize  = input()->nVertices();
+  size_t const outSize = output()->nVertices();
 
   PRECICE_ASSERT(!output()->vertices().empty());
   auto outDataDimensions = outputValues.size() / outSize;
 
   // Check that the number of values for the input and output is right according to their dimensions
-  PRECICE_ASSERT((inputValues.size() / static_cast<std::size_t>(inDataDimensions) == input()->vertices().size()),
-                 inputValues.size(), inDataDimensions, input()->vertices().size());
-  PRECICE_ASSERT((outputValues.size() / outDataDimensions == output()->vertices().size()),
-                 outputValues.size(), outDataDimensions, output()->vertices().size());
+  PRECICE_ASSERT((inputValues.size() / static_cast<std::size_t>(inDataDimensions) == input()->nVertices()),
+                 inputValues.size(), inDataDimensions, input()->nVertices());
+  PRECICE_ASSERT((outputValues.size() / outDataDimensions == output()->nVertices()),
+                 outputValues.size(), outDataDimensions, output()->nVertices());
 
   // We currently don't support 1D data, so we need that the user specifies data of the same dimensions on both sides
   PRECICE_ASSERT(static_cast<std::size_t>(inDataDimensions) == outDataDimensions);

--- a/src/mapping/RadialGeoMultiscaleMapping.cpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.cpp
@@ -148,7 +148,7 @@ void RadialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen
   size_t const inSize  = input()->nVertices();
   size_t const outSize = output()->nVertices();
 
-  PRECICE_ASSERT(!output()->vertices().empty());
+  PRECICE_ASSERT(!output()->empty());
   auto outDataDimensions = outputValues.size() / outSize;
 
   // Check that the number of values for the input and output is right according to their dimensions

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -312,7 +312,7 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   PRECICE_ASSERT(inMesh->getDimensions() == outMesh->getDimensions());
 
   // If we have either no input or no output vertices, we return immediately
-  if (inMesh->vertices().size() == 0 || outMesh->vertices().size() == 0)
+  if (inMesh->nVertices() == 0 || outMesh->nVertices() == 0)
     return {double{}, Vertices{}};
 
   PRECICE_ASSERT(!outMesh->vertices().empty() && !inMesh->vertices().empty());
@@ -350,7 +350,7 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   // The single cluster has in principle a radius of inf. We use here twice the
   // length of the longest bounding box edge length and the center of the bounding
   // box for the center point.
-  if (inMesh->vertices().size() < verticesPerCluster * 2)
+  if (inMesh->nVertices() < verticesPerCluster * 2)
     return {localBB.longestEdgeLength() * 2, Vertices{mesh::Vertex({localBB.center(), 0})}};
 
   // We define a convenience alias for the localBB. In case we need to synchronize the clustering across ranks later on, we need

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -315,7 +315,7 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   if (inMesh->nVertices() == 0 || outMesh->nVertices() == 0)
     return {double{}, Vertices{}};
 
-  PRECICE_ASSERT(!outMesh->vertices().empty() && !inMesh->vertices().empty());
+  PRECICE_ASSERT(!outMesh->empty() && !inMesh->vertices().empty());
 
   // startGridAtEdge boolean switch in order to decide either to start the clustering at the edge of the bounding box in each direction
   // (true) or start the clustering inside the bounding box (edge + 0.5 radius). The latter approach leads to fewer clusters,

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -262,7 +262,7 @@ inline double estimateClusterRadius(unsigned int verticesPerCluster, mesh::PtrMe
     // compute the distance of each point to the center
     std::vector<double> squaredRadius(kNearestVertexIDs.size());
     std::transform(kNearestVertexIDs.begin(), kNearestVertexIDs.end(), squaredRadius.begin(), [&inMesh, s](auto i) {
-      return computeSquaredDifference(inMesh->vertex(i).rawCoords(), inMesh->vertices()[s].rawCoords());
+      return computeSquaredDifference(inMesh->vertex(i).rawCoords(), inMesh->vertex(s).rawCoords());
     });
     // Store the maximum distance
     auto maxRadius = std::max_element(squaredRadius.begin(), squaredRadius.end());
@@ -315,7 +315,7 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
   if (inMesh->nVertices() == 0 || outMesh->nVertices() == 0)
     return {double{}, Vertices{}};
 
-  PRECICE_ASSERT(!outMesh->empty() && !inMesh->vertices().empty());
+  PRECICE_ASSERT(!outMesh->empty() && !inMesh->empty());
 
   // startGridAtEdge boolean switch in order to decide either to start the clustering at the edge of the bounding box in each direction
   // (true) or start the clustering inside the bounding box (edge + 0.5 radius). The latter approach leads to fewer clusters,

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -154,7 +154,7 @@ void projectClusterCentersToinputMesh(Vertices &clusterCenters, mesh::PtrMesh me
   std::transform(clusterCenters.begin(), clusterCenters.end(), clusterCenters.begin(), [&](auto &v) {
     if (!v.isTagged()) {
       auto closestCenter = mesh->index().getClosestVertex(v.getCoords()).index;
-      return mesh::Vertex{mesh->vertices()[closestCenter].getCoords(), v.getID()};
+      return mesh::Vertex{mesh->vertex(closestCenter).getCoords(), v.getID()};
     } else {
       return v;
     }
@@ -258,11 +258,11 @@ inline double estimateClusterRadius(unsigned int verticesPerCluster, mesh::PtrMe
   std::vector<double> sampledClusterRadii;
   for (auto s : randomSamples) {
     // ask the index tree for the k-nearest neighbors  in order to estimate the point density
-    auto kNearestVertexIDs = inMesh->index().getClosestVertices(inMesh->vertices()[s].getCoords(), verticesPerCluster);
+    auto kNearestVertexIDs = inMesh->index().getClosestVertices(inMesh->vertex(s).getCoords(), verticesPerCluster);
     // compute the distance of each point to the center
     std::vector<double> squaredRadius(kNearestVertexIDs.size());
     std::transform(kNearestVertexIDs.begin(), kNearestVertexIDs.end(), squaredRadius.begin(), [&inMesh, s](auto i) {
-      return computeSquaredDifference(inMesh->vertices()[i].rawCoords(), inMesh->vertices()[s].rawCoords());
+      return computeSquaredDifference(inMesh->vertex(i).rawCoords(), inMesh->vertices()[s].rawCoords());
     });
     // Store the maximum distance
     auto maxRadius = std::max_element(squaredRadius.begin(), squaredRadius.end());

--- a/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
+++ b/src/mapping/tests/LinearCellInterpolationMappingTest.cpp
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(Consistent)
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
   // Check expected
-  Eigen::VectorXd expected(outMesh->vertices().size());
+  Eigen::VectorXd expected(outMesh->nVertices());
   expected << 2.0, 1.0, 2.0, 3.0, 1.49, 2.25, 1.5, 1.0, 2.0, 3.0;
   BOOST_CHECK(equals(expected, outValuesScalar));
 }
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(Conservative)
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
   // Check expected
-  Eigen::VectorXd expected(outMesh->vertices().size());
+  Eigen::VectorXd expected(outMesh->nVertices());
   const double    expectedA = forceOnMid / 3 + forceOnMidAB / 2 + forceOnA;
   const double    expectedB = forceOnMid / 3 + forceOnMidAB / 2 + unbalancedforceOnBC * 0.75;
   const double    expectedC = forceOnMid / 3 + forceOnC + unbalancedforceOnBC * 0.25;
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(ConsistentOneTetra3D)
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
   // Check expected
-  Eigen::VectorXd expected(outMesh->vertices().size());
+  Eigen::VectorXd expected(outMesh->nVertices());
   expected << 2.5, 1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 3.3, 3.6;
   BOOST_CHECK(equals(expected, outValuesScalar));
 }
@@ -284,7 +284,7 @@ BOOST_AUTO_TEST_CASE(ConservativeOneTetra3D)
   BOOST_TEST(mapping.hasComputedMapping() == true);
 
   // Check expected
-  Eigen::VectorXd expected(outMesh->vertices().size());
+  Eigen::VectorXd expected(outMesh->nVertices());
   const double    expectedA = forceOnMid / 4 + forceOnMidAB / 2 + forceOnA + 0.4 * unbalancedInternalForce;
   const double    expectedB = forceOnMid / 4 + forceOnMidAB / 2 + unbalancedforceOnBC * 0.75 + 0.1 * unbalancedInternalForce;
   const double    expectedC = forceOnMid / 4 + forceOnC + unbalancedforceOnBC * 0.25 + 0.2 * unbalancedInternalForce;

--- a/src/mapping/tests/PartitionOfUnityMappingTest.cpp
+++ b/src/mapping/tests/PartitionOfUnityMappingTest.cpp
@@ -395,7 +395,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   inMesh->createVertex(Vector2d(5, 1));
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   auto &values = inData->values();
   values << 10.0, 0.0, 0.0, 10.0, 0.0;
@@ -421,7 +421,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
 
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);

--- a/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/PetRadialBasisFctMappingTest.cpp
@@ -1039,7 +1039,7 @@ void testTagging(const TestContext &context,
   mesh::PtrMesh outMesh(new mesh::Mesh("outMesh", meshDimension, testing::nextMeshID()));
   mesh::PtrData outData = outMesh->createData("OutData", valueDimension, 1_dataID);
   getDistributedMesh(context, outMeshSpec, outMesh, outData);
-  BOOST_TEST_MESSAGE("Mesh sizes in: " << inMesh->vertices().size() << " out: " << outMesh->vertices().size());
+  BOOST_TEST_MESSAGE("Mesh sizes in: " << inMesh->nVertices() << " out: " << outMesh->nVertices());
 
   Gaussian fct(4.5); // Support radius approx. 1
   BOOST_TEST_MESSAGE("Basis function has support radius " << fct.getSupportRadius());

--- a/src/mapping/tests/RadialBasisFctHelper.hpp
+++ b/src/mapping/tests/RadialBasisFctHelper.hpp
@@ -62,7 +62,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   inMesh->createVertex(Vector2d(0.0, 1.0));
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   auto &values = inData->values();
   values << 1.0, 2.0, 2.0, 1.0;
@@ -74,7 +74,7 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
@@ -159,7 +159,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   inMesh->createVertex(Vector2d(0.0, 1.0));
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   auto &values = inData->values();
   values << 1.0, 4.0, 2.0, 5.0, 2.0, 5.0, 1.0, 4.0;
@@ -171,7 +171,7 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
@@ -277,7 +277,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   inMesh->createVertex(Eigen::Vector3d(1.0, 1.0, 1.0));
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   auto &values = inData->values();
   values << 1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0;
@@ -289,7 +289,7 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   mesh::Vertex &vertex    = outMesh->createVertex(Eigen::Vector3d::Zero());
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
@@ -415,7 +415,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
 
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   auto &inValues = inData->values();
   inValues << 1.0, 2.0, 2.0, 1.0;
@@ -434,7 +434,7 @@ void perform2DTestScaledConsistentMapping(Mapping &mapping)
   outMesh->createEdge(outV1, outV4);
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
@@ -471,7 +471,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
 
   inMesh->allocateDataValues();
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   auto &inValues = inData->values();
   inValues << 1.0, 2.0, 4.0, 6.0, 8.0, 9.0;
@@ -490,7 +490,7 @@ void perform3DTestScaledConsistentMapping(Mapping &mapping)
 
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
@@ -517,7 +517,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0;
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
@@ -529,7 +529,7 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   outMesh->createVertex(Vector2d(0.0, 1.0));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   auto &values = outData->values();
 
@@ -587,7 +587,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
   inMesh->allocateDataValues();
   inData->values() << 1.0, 4.0, 2.0, 5.0;
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
@@ -599,7 +599,7 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
   outMesh->createVertex(Vector2d(0.0, 1.0));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   auto &values = outData->values();
 
@@ -661,7 +661,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
   inMesh->allocateDataValues();
   inData->values() << 1.0, 2.0;
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   // Create mesh to map to
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
@@ -677,7 +677,7 @@ void perform3DTestConservativeMapping(Mapping &mapping)
   outMesh->createVertex(Vector3d(0.0, 1.0, 1.0));
   outMesh->allocateDataValues();
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   auto & values      = outData->values();
   double expectedSum = inData->values().sum();

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -1409,7 +1409,7 @@ void testDeadAxis2d(Polynomial polynomial, Mapping::Constraint constraint)
   inMesh->createVertex(Vector2d(2.0, 1.0));
   inMesh->createVertex(Vector2d(3.0, 1.0));
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   Eigen::VectorXd values(4);
   values << 1.0, 2.0, 2.0, 1.0;
@@ -1421,7 +1421,7 @@ void testDeadAxis2d(Polynomial polynomial, Mapping::Constraint constraint)
   outMesh->createVertex(Vector2d(1.3, 1.));
   outMesh->createVertex(Vector2d(5, 1.));
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);
@@ -1470,7 +1470,7 @@ void testDeadAxis3d(Polynomial polynomial, Mapping::Constraint constraint)
   inMesh->createVertex(Vector3d(0.0, 3.0, 1.0));
   inMesh->createVertex(Vector3d(1.0, 3.0, 1.0));
   addGlobalIndex(inMesh);
-  inMesh->setGlobalNumberOfVertices(inMesh->vertices().size());
+  inMesh->setGlobalNumberOfVertices(inMesh->nVertices());
 
   Eigen::VectorXd values(4);
   values << 1.0, 2.0, 3.0, 4.0;
@@ -1482,7 +1482,7 @@ void testDeadAxis3d(Polynomial polynomial, Mapping::Constraint constraint)
   outMesh->createVertex(Vector3d(0.1, 2.9, 0.9));
   outMesh->createVertex(Vector3d(1.1, 2.9, 1.1));
   addGlobalIndex(outMesh);
-  outMesh->setGlobalNumberOfVertices(outMesh->vertices().size());
+  outMesh->setGlobalNumberOfVertices(outMesh->nVertices());
 
   // Setup mapping with mapping coordinates and geometry used
   mapping.setMeshes(inMesh, outMesh);

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -19,7 +19,7 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
   // Create a flat_map which can contain all vertices of the original mesh.
   // This prevents resizes during the map build-up.
   boost::container::flat_map<VertexID, Vertex *> vertexMap;
-  vertexMap.reserve(source.vertices().size());
+  vertexMap.reserve(source.nVertices());
 
   for (const Vertex &vertex : source.vertices()) {
     if (p(vertex)) {

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -313,7 +313,7 @@ void Mesh::addMesh(
   PRECICE_ASSERT(_dimensions == deltaMesh.getDimensions());
 
   boost::container::flat_map<VertexID, Vertex *> vertexMap;
-  vertexMap.reserve(deltaMesh.vertices().size());
+  vertexMap.reserve(deltaMesh.nVertices());
   Eigen::VectorXd coords(_dimensions);
   for (const Vertex &vertex : deltaMesh.vertices()) {
     coords    = vertex.getCoords();

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -227,7 +227,7 @@ MeshID Mesh::getID() const
 
 bool Mesh::isValidVertexID(VertexID vertexID) const
 {
-  return (0 <= vertexID) && (static_cast<size_t>(vertexID) < vertices().size());
+  return (0 <= vertexID) && (static_cast<size_t>(vertexID) < nVertices());
 }
 
 void Mesh::allocateDataValues()
@@ -279,11 +279,11 @@ void Mesh::clearPartitioning()
 Eigen::VectorXd Mesh::getOwnedVertexData(const Eigen::VectorXd &values)
 {
   std::vector<double> ownedDataVector;
-  PRECICE_ASSERT(static_cast<std::size_t>(values.size()) >= vertices().size());
-  if (vertices().empty()) {
+  PRECICE_ASSERT(static_cast<std::size_t>(values.size()) >= nVertices());
+  if (empty()) {
     return {};
   }
-  int valueDim = values.size() / vertices().size();
+  int valueDim = values.size() / nVertices();
   int index    = 0;
 
   for (const auto &vertex : vertices()) {

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -38,6 +38,18 @@ Mesh::Mesh(
   PRECICE_ASSERT(_name != std::string(""));
 }
 
+Vertex &Mesh::vertex(VertexID id)
+{
+  PRECICE_ASSERT(isValidVertexID(id), id, nVertices());
+  return _vertices.at(id);
+}
+
+const Vertex &Mesh::vertex(VertexID id) const
+{
+  PRECICE_ASSERT(isValidVertexID(id), id, nVertices());
+  return _vertices.at(id);
+}
+
 Mesh::VertexContainer &Mesh::vertices()
 {
   return _vertices;
@@ -46,6 +58,11 @@ Mesh::VertexContainer &Mesh::vertices()
 const Mesh::VertexContainer &Mesh::vertices() const
 {
   return _vertices;
+}
+
+std::size_t Mesh::nVertices() const
+{
+  return _vertices.size();
 }
 
 Mesh::EdgeContainer &Mesh::edges()

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -69,11 +69,20 @@ public:
       int         dimensions,
       MeshID      id);
 
+  /// Mutable access to a vertex by VertexID
+  Vertex &vertex(VertexID id);
+
+  /// Const access to a vertex by VertexID
+  const Vertex &vertex(VertexID id) const;
+
   /// Returns modifieable container holding all vertices.
   VertexContainer &vertices();
 
   /// Returns const container holding all vertices.
   const VertexContainer &vertices() const;
+
+  /// Returns the number of vertices
+  std::size_t nVertices() const;
 
   /// Returns modifiable container holding all edges.
   EdgeContainer &edges();

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -84,6 +84,12 @@ public:
   /// Returns the number of vertices
   std::size_t nVertices() const;
 
+  /// Does the mesh contain any vertices?
+  bool empty() const
+  {
+    return _vertices.empty();
+  }
+
   /// Returns modifiable container holding all edges.
   EdgeContainer &edges();
 

--- a/src/mesh/Utils.cpp
+++ b/src/mesh/Utils.cpp
@@ -10,9 +10,9 @@ namespace precice::mesh {
 /// Given the data and the mesh, this function returns the surface integral. Assumes no overlap exists for the mesh
 Eigen::VectorXd integrateSurface(const PtrMesh &mesh, const Eigen::VectorXd &input)
 {
-  PRECICE_ASSERT(mesh->vertices().size() > 0);
+  PRECICE_ASSERT(mesh->nVertices() > 0);
   const int       meshDimensions  = mesh->getDimensions();
-  const int       valueDimensions = input.size() / mesh->vertices().size();
+  const int       valueDimensions = input.size() / mesh->nVertices();
   const auto &    values          = input;
   Eigen::VectorXd integral        = Eigen::VectorXd::Zero(valueDimensions);
 
@@ -40,9 +40,9 @@ Eigen::VectorXd integrateSurface(const PtrMesh &mesh, const Eigen::VectorXd &inp
 
 Eigen::VectorXd integrateVolume(const PtrMesh &mesh, const Eigen::VectorXd &input)
 {
-  PRECICE_ASSERT(mesh->vertices().size() > 0);
+  PRECICE_ASSERT(mesh->nVertices() > 0);
   const int       meshDimensions  = mesh->getDimensions();
-  const int       valueDimensions = input.size() / mesh->vertices().size();
+  const int       valueDimensions = input.size() / mesh->nVertices();
   const auto &    values          = input;
   Eigen::VectorXd integral        = Eigen::VectorXd::Zero(valueDimensions);
   if (meshDimensions == 2) {

--- a/src/mesh/Utils.hpp
+++ b/src/mesh/Utils.hpp
@@ -114,7 +114,7 @@ std::array<Vertex *, n> vertexPtrsFor(Mesh &mesh, const std::array<int, n> &vert
   static_assert(n > 0, "Cannot handle nothing.");
   std::array<Vertex *, n> vptrs;
   std::transform(vertexIDs.begin(), vertexIDs.end(), vptrs.begin(),
-                 [&mesh](int id) { return &(mesh.vertices()[id]); });
+                 [&mesh](int id) { return &(mesh.vertex(id)); });
   return vptrs;
 }
 
@@ -124,7 +124,7 @@ std::array<Eigen::VectorXd, n> coordsFor(const Mesh &mesh, const std::array<int,
 {
   std::array<Eigen::VectorXd, n> coords;
   std::transform(vertexIDs.begin(), vertexIDs.end(), coords.begin(),
-                 [&mesh](int id) { return mesh.vertices()[id].getCoords(); });
+                 [&mesh](int id) { return mesh.vertex(id).getCoords(); });
   return coords;
 }
 

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -53,6 +53,9 @@ public:
 
   void tag();
 
+  /// Returns a coordinate of a vertex
+  inline double coord(int index) const;
+
   inline bool operator==(const Vertex &rhs) const;
 
   inline bool operator!=(const Vertex &rhs) const;
@@ -120,6 +123,12 @@ inline Eigen::VectorXd Vertex::getCoords() const
 inline const Vertex::RawCoords &Vertex::rawCoords() const
 {
   return _coords;
+}
+
+inline double Vertex::coord(int index) const
+{
+  PRECICE_ASSERT(0 <= index && index < _dim, index, _dim);
+  return _coords.at(index);
 }
 
 inline bool Vertex::operator==(const Vertex &rhs) const

--- a/src/mesh/tests/FilterTest.cpp
+++ b/src/mesh/tests/FilterTest.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(Vertices2D)
   mesh::filterMesh(dest, src, p);
 
   // dest should contain Constante(4) and Constant(3), but not Constant(2)
-  BOOST_TEST(dest.vertices().size() == 2);
+  BOOST_TEST(dest.nVertices() == 2);
   BOOST_TEST(dest.vertices()[0] == v0);
   BOOST_TEST(dest.vertices()[1] == v1);
 }
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(Vertices3D)
   mesh::filterMesh(dest, src, p);
 
   // dest should contain Constante(4) and Constant(3), but not Constant(2)
-  BOOST_TEST(dest.vertices().size() == 2);
+  BOOST_TEST(dest.nVertices() == 2);
   BOOST_TEST(dest.vertices()[0] == v0);
   BOOST_TEST(dest.vertices()[1] == v1);
 }
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(Edges)
 
   mesh::filterMesh(dest, src, p);
 
-  BOOST_TEST(dest.vertices().size() == 3);
+  BOOST_TEST(dest.nVertices() == 3);
   BOOST_TEST(dest.vertices()[0] == v0);
   BOOST_TEST(dest.vertices()[1] == v1);
   BOOST_TEST(dest.vertices()[2] == v2);
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(Triangles)
 
   mesh::filterMesh(dest, src, p);
 
-  BOOST_TEST(dest.vertices().size() == 4);
+  BOOST_TEST(dest.nVertices() == 4);
 
   // Only t1 should survive (because v4 not passed)
   BOOST_TEST(dest.triangles().size() == 1);
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(Tetrahedra)
 
   mesh::filterMesh(dest, src, p);
 
-  BOOST_TEST(dest.vertices().size() == 5);
+  BOOST_TEST(dest.nVertices() == 5);
 
   // Only t1 should survive (because v5 not passed)
   BOOST_TEST(dest.tetrahedra().size() == 1);

--- a/src/mesh/tests/FilterTest.cpp
+++ b/src/mesh/tests/FilterTest.cpp
@@ -32,8 +32,8 @@ BOOST_AUTO_TEST_CASE(Vertices2D)
 
   // dest should contain Constante(4) and Constant(3), but not Constant(2)
   BOOST_TEST(dest.nVertices() == 2);
-  BOOST_TEST(dest.vertices()[0] == v0);
-  BOOST_TEST(dest.vertices()[1] == v1);
+  BOOST_TEST(dest.vertex(0) == v0);
+  BOOST_TEST(dest.vertex(1) == v1);
 }
 
 BOOST_AUTO_TEST_CASE(Vertices3D)
@@ -55,8 +55,8 @@ BOOST_AUTO_TEST_CASE(Vertices3D)
 
   // dest should contain Constante(4) and Constant(3), but not Constant(2)
   BOOST_TEST(dest.nVertices() == 2);
-  BOOST_TEST(dest.vertices()[0] == v0);
-  BOOST_TEST(dest.vertices()[1] == v1);
+  BOOST_TEST(dest.vertex(0) == v0);
+  BOOST_TEST(dest.vertex(1) == v1);
 }
 
 BOOST_AUTO_TEST_CASE(Edges)
@@ -82,9 +82,9 @@ BOOST_AUTO_TEST_CASE(Edges)
   mesh::filterMesh(dest, src, p);
 
   BOOST_TEST(dest.nVertices() == 3);
-  BOOST_TEST(dest.vertices()[0] == v0);
-  BOOST_TEST(dest.vertices()[1] == v1);
-  BOOST_TEST(dest.vertices()[2] == v2);
+  BOOST_TEST(dest.vertex(0) == v0);
+  BOOST_TEST(dest.vertex(1) == v1);
+  BOOST_TEST(dest.vertex(2) == v2);
 
   // Only e0 should survive
   BOOST_TEST(dest.edges().size() == 1);

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(ResizeDataGrow)
   mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
   mesh.createVertex(Vector3d(1.0, 0.0, 1.0));
 
-  BOOST_TEST(mesh.vertices().size() == 2);
+  BOOST_TEST(mesh.nVertices() == 2);
   mesh.allocateDataValues();
   BOOST_TEST(values.size() == 2);
 
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(ResizeDataGrow)
   mesh.createVertex(Vector3d(2.0, 0.0, 2.0));
   mesh.createVertex(Vector3d(2.0, 0.0, 2.1));
 
-  BOOST_TEST(mesh.vertices().size() == 5);
+  BOOST_TEST(mesh.nVertices() == 5);
   mesh.allocateDataValues();
   BOOST_TEST(values.size() == 5);
 }
@@ -285,7 +285,7 @@ BOOST_AUTO_TEST_CASE(ResizeDataShrink)
   mesh.createVertex(Vector3d(1.0, 1.0, 1.0));
   mesh.createVertex(Vector3d(2.0, 2.0, 2.0));
 
-  BOOST_TEST(mesh.vertices().size() == 4);
+  BOOST_TEST(mesh.nVertices() == 4);
   mesh.allocateDataValues();
   BOOST_TEST(values.size() == 4);
 
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(ResizeDataShrink)
   mesh.createVertex(Vector3d(0.0, 0.0, 0.0));
   mesh.createVertex(Vector3d(1.0, 0.0, 1.0));
 
-  BOOST_TEST(mesh.vertices().size() == 2);
+  BOOST_TEST(mesh.nVertices() == 2);
   mesh.allocateDataValues();
   BOOST_TEST(values.size() == 2);
 }
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(AsChain)
   Vertex &v2 = mesh.createVertex(coords2);
   Vertex &v3 = mesh.createVertex(coords3);
 
-  BOOST_TEST(mesh.vertices().size() == 4);
+  BOOST_TEST(mesh.nVertices() == 4);
 
   Edge &e0 = mesh.createEdge(v0, v1);
   Edge &e1 = mesh.createEdge(v3, v2);
@@ -361,7 +361,7 @@ BOOST_AUTO_TEST_CASE(ShareVertex)
   Vertex *v1 = &mesh.createVertex(coords1);
   Vertex *v2 = &mesh.createVertex(coords2);
   Vertex *v3 = &mesh.createVertex(coords3);
-  BOOST_REQUIRE(mesh.vertices().size() == 4);
+  BOOST_REQUIRE(mesh.nVertices() == 4);
 
   Edge &e0 = mesh.createEdge(*v0, *v1);
   Edge &e1 = mesh.createEdge(*v1, *v2);
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(VertexPtrsFor)
   Vertex &v1 = mesh.createVertex(coords1);
   Vertex &v2 = mesh.createVertex(coords2);
   mesh.createVertex(coords3);
-  BOOST_TEST(mesh.vertices().size() == 4);
+  BOOST_TEST(mesh.nVertices() == 4);
 
   std::array<int, 3>      ids{v0.getID(), v2.getID(), v1.getID()};
   std::array<Vertex *, 3> expected{&v0, &v2, &v1};
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(CoordsForIDs)
   Vertex &v1 = mesh.createVertex(coords1);
   Vertex &v2 = mesh.createVertex(coords2);
   mesh.createVertex(coords3);
-  BOOST_TEST(mesh.vertices().size() == 4);
+  BOOST_TEST(mesh.nVertices() == 4);
 
   std::array<int, 3>             ids{v0.getID(), v2.getID(), v1.getID()};
   std::array<Eigen::VectorXd, 3> expected{coords0, coords2, coords1};
@@ -471,7 +471,7 @@ BOOST_AUTO_TEST_CASE(CoordsForPtrs)
   Vertex &v1 = mesh.createVertex(coords1);
   Vertex &v2 = mesh.createVertex(coords2);
   mesh.createVertex(coords3);
-  BOOST_TEST(mesh.vertices().size() == 4);
+  BOOST_TEST(mesh.nVertices() == 4);
 
   std::array<Vertex *, 3>        ptrs{&v0, &v2, &v1};
   std::array<Eigen::VectorXd, 3> expected{coords0, coords2, coords1};
@@ -815,7 +815,7 @@ BOOST_AUTO_TEST_CASE(AddMesh)
   subMesh->createTetrahedron(v15, v12, v13, v14);
 
   globalMesh->addMesh(*subMesh);
-  BOOST_TEST(globalMesh->vertices().size() == 9);
+  BOOST_TEST(globalMesh->nVertices() == 9);
   BOOST_TEST(globalMesh->edges().size() == 3);
   BOOST_TEST(globalMesh->triangles().size() == 3);
   BOOST_TEST(globalMesh->tetrahedra().size() == 3);

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -127,7 +127,7 @@ void ProvidedPartition::prepare()
 
     // set globals IDs on primary rank
     for (int i = 0; i < numberOfVertices; i++) {
-      _mesh->vertices()[i].setGlobalIndex(i);
+      _mesh->vertex(i).setGlobalIndex(i);
     }
 
     mesh::Mesh::VertexOffsets vertexOffsets(utils::IntraComm::getSize());
@@ -186,7 +186,7 @@ void ProvidedPartition::prepare()
     utils::IntraComm::getCommunication()->receive(globalVertexCounter, 0);
     PRECICE_DEBUG("Set global vertex indices");
     for (int i = 0; i < numberOfVertices; i++) {
-      _mesh->vertices()[i].setGlobalIndex(globalVertexCounter + i);
+      _mesh->vertex(i).setGlobalIndex(globalVertexCounter + i);
     }
 
     // set global number of vertices
@@ -210,7 +210,7 @@ void ProvidedPartition::prepare()
       mesh::Mesh::VertexDistribution vertexDistribution;
       for (int i = 0; i < numberOfVertices; i++) {
         vertexDistribution[0].push_back(i);
-        _mesh->vertices()[i].setGlobalIndex(i);
+        _mesh->vertex(i).setGlobalIndex(i);
       }
       return vertexDistribution;
     }());

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -66,7 +66,7 @@ void ProvidedPartition::communicate()
       // the min and max of global vertex IDs of this rank's partition
       PRECICE_ASSERT(_mesh->getVertexOffsets().size() == static_cast<decltype(_mesh->getVertexOffsets().size())>(utils::IntraComm::getSize()));
       const int vertexOffset      = _mesh->getVertexOffsets()[utils::IntraComm::getRank()];
-      const int minGlobalVertexID = vertexOffset - _mesh->vertices().size();
+      const int minGlobalVertexID = vertexOffset - _mesh->nVertices();
       const int maxGlobalVertexID = vertexOffset - 1;
 
       // each rank sends its min/max global vertex index to connected remote ranks
@@ -91,7 +91,7 @@ void ProvidedPartition::communicate()
 
           for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
             com::receiveMesh(*utils::IntraComm::getCommunication(), secondaryRank, globalMesh);
-            PRECICE_DEBUG("Received sub-mesh, from secondary rank: {}, global vertexCount: {}", secondaryRank, globalMesh.vertices().size());
+            PRECICE_DEBUG("Received sub-mesh, from secondary rank: {}, global vertexCount: {}", secondaryRank, globalMesh.nVertices());
           }
         }
         if (utils::IntraComm::isSecondary()) {
@@ -105,7 +105,7 @@ void ProvidedPartition::communicate()
       Event e("partition.sendGlobalMesh." + _mesh->getName(), profiling::Synchronize);
 
       if (not utils::IntraComm::isSecondary()) {
-        PRECICE_CHECK(globalMesh.vertices().size() > 0,
+        PRECICE_CHECK(globalMesh.nVertices() > 0,
                       "The provided mesh \"{}\" is empty. Please set the mesh using setMeshXXX() prior to calling initialize().",
                       globalMesh.getName());
         com::sendMesh(*m2n->getPrimaryRankCommunication(), 0, globalMesh);
@@ -120,7 +120,7 @@ void ProvidedPartition::prepare()
   PRECICE_INFO("Prepare partition for mesh {}", _mesh->getName());
   Event e("partition.prepareMesh." + _mesh->getName(), profiling::Synchronize);
 
-  int numberOfVertices = _mesh->vertices().size();
+  int numberOfVertices = _mesh->nVertices();
 
   if (utils::IntraComm::isPrimary()) {
     PRECICE_ASSERT(utils::IntraComm::getSize() > 1);

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -43,7 +43,7 @@ ReceivedPartition::ReceivedPartition(
 void ReceivedPartition::communicate()
 {
   PRECICE_TRACE();
-  PRECICE_ASSERT(_mesh->vertices().empty());
+  PRECICE_ASSERT(_mesh->empty());
 
   // for two-level initialization, receive mesh partitions
   if (m2n().usesTwoLevelInitialization()) {
@@ -307,7 +307,7 @@ void ReceivedPartition::filterByBoundingBox()
       com::receiveMesh(*utils::IntraComm::getCommunication(), 0, *_mesh);
 
       if (isAnyProvidedMeshNonEmpty()) {
-        PRECICE_CHECK(not _mesh->vertices().empty(), errorMeshFilteredOut(_mesh->getName(), utils::IntraComm::getRank()));
+        PRECICE_CHECK(not _mesh->empty(), errorMeshFilteredOut(_mesh->getName(), utils::IntraComm::getRank()));
       }
 
     } else { // Primary
@@ -336,7 +336,7 @@ void ReceivedPartition::filterByBoundingBox()
       _mesh->addMesh(filteredMesh);
 
       if (isAnyProvidedMeshNonEmpty()) {
-        PRECICE_CHECK(not _mesh->vertices().empty(), errorMeshFilteredOut(_mesh->getName(), utils::IntraComm::getRank()));
+        PRECICE_CHECK(not _mesh->empty(), errorMeshFilteredOut(_mesh->getName(), utils::IntraComm::getRank()));
       }
     }
   } else {
@@ -367,7 +367,7 @@ void ReceivedPartition::filterByBoundingBox()
       _mesh->clear();
       _mesh->addMesh(filteredMesh);
       if (isAnyProvidedMeshNonEmpty()) {
-        PRECICE_CHECK(not _mesh->vertices().empty(), errorMeshFilteredOut(_mesh->getName(), utils::IntraComm::getRank()));
+        PRECICE_CHECK(not _mesh->empty(), errorMeshFilteredOut(_mesh->getName(), utils::IntraComm::getRank()));
       }
     } else {
       PRECICE_ASSERT(_geometricFilter == NO_FILTER);
@@ -879,12 +879,12 @@ void ReceivedPartition::createOwnerInformation()
 bool ReceivedPartition::isAnyProvidedMeshNonEmpty() const
 {
   for (const auto &fromMapping : _fromMappings) {
-    if (not fromMapping->getOutputMesh()->vertices().empty()) {
+    if (not fromMapping->getOutputMesh()->empty()) {
       return true;
     }
   }
   for (const auto &toMapping : _toMappings) {
-    if (not toMapping->getInputMesh()->vertices().empty()) {
+    if (not toMapping->getInputMesh()->empty()) {
       return true;
     }
   }

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -184,7 +184,7 @@ void ReceivedPartition::compute()
 
     for (size_t vertexIndex = 0; vertexIndex < _mesh->nVertices(); ++vertexIndex) {
       for (size_t rankIndex = 0; rankIndex < _mesh->getConnectedRanks().size(); ++rankIndex) {
-        int globalVertexIndex = _mesh->vertices()[vertexIndex].getGlobalIndex();
+        int globalVertexIndex = _mesh->vertex(vertexIndex).getGlobalIndex();
         if (globalVertexIndex <= _remoteMaxGlobalVertexIDs[rankIndex] && globalVertexIndex >= _remoteMinGlobalVertexIDs[rankIndex]) {
           int remoteRank = _mesh->getConnectedRanks()[rankIndex];
           remoteCommunicationMap[remoteRank].push_back(globalVertexIndex - _remoteMinGlobalVertexIDs[rankIndex]); // remote local vertex index
@@ -204,7 +204,7 @@ void ReceivedPartition::compute()
       int                   numberOfVertices = _mesh->nVertices();
       std::vector<VertexID> vertexIDs(numberOfVertices, -1);
       for (int i = 0; i < numberOfVertices; i++) {
-        vertexIDs[i] = _mesh->vertices()[i].getGlobalIndex();
+        vertexIDs[i] = _mesh->vertex(i).getGlobalIndex();
       }
       PRECICE_DEBUG("Send partition feedback to primary rank");
       utils::IntraComm::getCommunication()->sendRange(vertexIDs, 0);
@@ -214,7 +214,7 @@ void ReceivedPartition::compute()
       int                            numberOfVertices = _mesh->nVertices();
       std::vector<VertexID>          vertexIDs(numberOfVertices, -1);
       for (int i = 0; i < numberOfVertices; i++) {
-        vertexIDs[i] = _mesh->vertices()[i].getGlobalIndex();
+        vertexIDs[i] = _mesh->vertex(i).getGlobalIndex();
       }
       vertexDistribution[0] = std::move(vertexIDs);
 
@@ -618,11 +618,11 @@ void ReceivedPartition::createOwnerInformation()
     std::vector<VertexID> globalIDs(numberOfVertices, -1);
     int                   ownedVerticesCount = 0; // number of vertices owned by this rank
     for (int i = 0; i < numberOfVertices; i++) {
-      globalIDs[i] = _mesh->vertices()[i].getGlobalIndex();
-      if (_mesh->vertices()[i].isTagged()) {
+      globalIDs[i] = _mesh->vertex(i).getGlobalIndex();
+      if (_mesh->vertex(i).isTagged()) {
         bool vertexIsShared = false;
         for (const auto &neighborRank : localConnectedBBMap) {
-          if (neighborRank.second.contains(_mesh->vertices()[i])) {
+          if (neighborRank.second.contains(_mesh->vertex(i))) {
             vertexIsShared = true;
             sharedVerticesSendMap[neighborRank.first].push_back(globalIDs[i]);
           }
@@ -736,8 +736,8 @@ void ReceivedPartition::createOwnerInformation()
         std::vector<VertexID> globalIDs(numberOfVertices, -1);
         bool                  atInterface = false;
         for (int i = 0; i < numberOfVertices; i++) {
-          globalIDs[i] = _mesh->vertices()[i].getGlobalIndex();
-          if (_mesh->vertices()[i].isTagged()) {
+          globalIDs[i] = _mesh->vertex(i).getGlobalIndex();
+          if (_mesh->vertex(i).isTagged()) {
             tags[i]     = 1;
             atInterface = true;
           } else {
@@ -776,8 +776,8 @@ void ReceivedPartition::createOwnerInformation()
       secondaryGlobalIDs[0].resize(_mesh->nVertices());
       secondaryTags[0].resize(_mesh->nVertices());
       for (size_t i = 0; i < _mesh->nVertices(); i++) {
-        secondaryGlobalIDs[0][i] = _mesh->vertices()[i].getGlobalIndex();
-        if (_mesh->vertices()[i].isTagged()) {
+        secondaryGlobalIDs[0][i] = _mesh->vertex(i).getGlobalIndex();
+        if (_mesh->vertex(i).isTagged()) {
           primaryRankAtInterface = true;
           secondaryTags[0][i]    = 1;
         } else {

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
     part.addM2N(m2n);
     part.communicate();
 
-    BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+    BOOST_TEST(pSolidzMesh->nVertices() == 6);
     BOOST_TEST(pSolidzMesh->edges().size() == 4);
 
     for (int i = 0; i < 6; i++) {
@@ -125,7 +125,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
     part.addM2N(m2n);
     part.communicate();
 
-    BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+    BOOST_TEST(pSolidzMesh->nVertices() == 6);
     BOOST_TEST(pSolidzMesh->edges().size() == 6);
     BOOST_TEST(pSolidzMesh->triangles().size() == 2);
 
@@ -558,7 +558,7 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
 
     part.communicate();
 
-    BOOST_TEST(mesh->vertices().size() == 4);
+    BOOST_TEST(mesh->nVertices() == 4);
 
     if (context.isPrimary()) {
       BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 0.5);

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -561,23 +561,23 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
     BOOST_TEST(mesh->nVertices() == 4);
 
     if (context.isPrimary()) {
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 0.5);
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 1.5);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(2).getCoords()(0) == 2.0);
-      BOOST_TEST(mesh->vertices().at(2).getCoords()(1) == 1.0);
-      BOOST_TEST(mesh->vertices().at(3).getCoords()(0) == 0.5);
-      BOOST_TEST(mesh->vertices().at(3).getCoords()(1) == 1.0);
+      BOOST_TEST(mesh->vertices().at(0).coord(0) == 0.5);
+      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).coord(0) == 1.5);
+      BOOST_TEST(mesh->vertices().at(1).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(2).coord(0) == 2.0);
+      BOOST_TEST(mesh->vertices().at(2).coord(1) == 1.0);
+      BOOST_TEST(mesh->vertices().at(3).coord(0) == 0.5);
+      BOOST_TEST(mesh->vertices().at(3).coord(1) == 1.0);
     } else {
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(0) == 2.5);
-      BOOST_TEST(mesh->vertices().at(0).getCoords()(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(0) == 3.5);
-      BOOST_TEST(mesh->vertices().at(1).getCoords()(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(2).getCoords()(0) == 3.5);
-      BOOST_TEST(mesh->vertices().at(2).getCoords()(1) == 1.0);
-      BOOST_TEST(mesh->vertices().at(3).getCoords()(0) == 2.0);
-      BOOST_TEST(mesh->vertices().at(3).getCoords()(1) == 1.0);
+      BOOST_TEST(mesh->vertices().at(0).coord(0) == 2.5);
+      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(1).coord(0) == 3.5);
+      BOOST_TEST(mesh->vertices().at(1).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertices().at(2).coord(0) == 3.5);
+      BOOST_TEST(mesh->vertices().at(2).coord(1) == 1.0);
+      BOOST_TEST(mesh->vertices().at(3).coord(0) == 2.0);
+      BOOST_TEST(mesh->vertices().at(3).coord(1) == 1.0);
     }
   }
 }

--- a/src/partition/tests/ProvidedPartitionTest.cpp
+++ b/src/partition/tests/ProvidedPartitionTest.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate2D)
     BOOST_TEST(pSolidzMesh->edges().size() == 4);
 
     for (int i = 0; i < 6; i++) {
-      BOOST_TEST(pSolidzMesh->vertices().at(i).getGlobalIndex() == i);
+      BOOST_TEST(pSolidzMesh->vertex(i).getGlobalIndex() == i);
     }
   } else { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(TestGatherAndCommunicate3D)
     BOOST_TEST(pSolidzMesh->triangles().size() == 2);
 
     for (int i = 0; i < 6; i++) {
-      BOOST_TEST(pSolidzMesh->vertices().at(i).getGlobalIndex() == i);
+      BOOST_TEST(pSolidzMesh->vertex(i).getGlobalIndex() == i);
     }
   } else { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -261,10 +261,10 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
       BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
       BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
       BOOST_TEST(pMesh->getVertexOffsets().at(3) == 5);
-      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 0);
-      BOOST_TEST(pMesh->vertices().at(1).getGlobalIndex() == 1);
-      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
-      BOOST_TEST(pMesh->vertices().at(1).isOwner() == true);
+      BOOST_TEST(pMesh->vertex(0).getGlobalIndex() == 0);
+      BOOST_TEST(pMesh->vertex(1).getGlobalIndex() == 1);
+      BOOST_TEST(pMesh->vertex(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertex(1).isOwner() == true);
     } else if (context.isRank(1)) { //SecondaryRank1
       BOOST_TEST(pMesh->getGlobalNumberOfVertices() == 5);
       BOOST_TEST_REQUIRE(pMesh->getVertexOffsets().size() == 4);
@@ -272,8 +272,8 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
       BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
       BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
       BOOST_TEST(pMesh->getVertexOffsets().at(3) == 5);
-      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 2);
-      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertex(0).getGlobalIndex() == 2);
+      BOOST_TEST(pMesh->vertex(0).isOwner() == true);
     } else if (context.isRank(2)) { //Secondary rank 2
       BOOST_TEST(pMesh->getGlobalNumberOfVertices() == 5);
       BOOST_TEST_REQUIRE(pMesh->getVertexOffsets().size() == 4);
@@ -288,10 +288,10 @@ BOOST_AUTO_TEST_CASE(TestOnlyDistribution2D)
       BOOST_TEST(pMesh->getVertexOffsets().at(1) == 3);
       BOOST_TEST(pMesh->getVertexOffsets().at(2) == 3);
       BOOST_TEST(pMesh->getVertexOffsets().at(3) == 5);
-      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 3);
-      BOOST_TEST(pMesh->vertices().at(1).getGlobalIndex() == 4);
-      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
-      BOOST_TEST(pMesh->vertices().at(1).isOwner() == true);
+      BOOST_TEST(pMesh->vertex(0).getGlobalIndex() == 3);
+      BOOST_TEST(pMesh->vertex(1).getGlobalIndex() == 4);
+      BOOST_TEST(pMesh->vertex(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertex(1).isOwner() == true);
     }
   }
 }
@@ -561,23 +561,23 @@ BOOST_AUTO_TEST_CASE(TestCommunicateLocalMeshPartitions)
     BOOST_TEST(mesh->nVertices() == 4);
 
     if (context.isPrimary()) {
-      BOOST_TEST(mesh->vertices().at(0).coord(0) == 0.5);
-      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).coord(0) == 1.5);
-      BOOST_TEST(mesh->vertices().at(1).coord(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(2).coord(0) == 2.0);
-      BOOST_TEST(mesh->vertices().at(2).coord(1) == 1.0);
-      BOOST_TEST(mesh->vertices().at(3).coord(0) == 0.5);
-      BOOST_TEST(mesh->vertices().at(3).coord(1) == 1.0);
+      BOOST_TEST(mesh->vertex(0).coord(0) == 0.5);
+      BOOST_TEST(mesh->vertex(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertex(1).coord(0) == 1.5);
+      BOOST_TEST(mesh->vertex(1).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertex(2).coord(0) == 2.0);
+      BOOST_TEST(mesh->vertex(2).coord(1) == 1.0);
+      BOOST_TEST(mesh->vertex(3).coord(0) == 0.5);
+      BOOST_TEST(mesh->vertex(3).coord(1) == 1.0);
     } else {
-      BOOST_TEST(mesh->vertices().at(0).coord(0) == 2.5);
-      BOOST_TEST(mesh->vertices().at(0).coord(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(1).coord(0) == 3.5);
-      BOOST_TEST(mesh->vertices().at(1).coord(1) == 0.0);
-      BOOST_TEST(mesh->vertices().at(2).coord(0) == 3.5);
-      BOOST_TEST(mesh->vertices().at(2).coord(1) == 1.0);
-      BOOST_TEST(mesh->vertices().at(3).coord(0) == 2.0);
-      BOOST_TEST(mesh->vertices().at(3).coord(1) == 1.0);
+      BOOST_TEST(mesh->vertex(0).coord(0) == 2.5);
+      BOOST_TEST(mesh->vertex(0).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertex(1).coord(0) == 3.5);
+      BOOST_TEST(mesh->vertex(1).coord(1) == 0.0);
+      BOOST_TEST(mesh->vertex(2).coord(0) == 3.5);
+      BOOST_TEST(mesh->vertex(2).coord(1) == 1.0);
+      BOOST_TEST(mesh->vertex(3).coord(0) == 2.0);
+      BOOST_TEST(mesh->vertex(3).coord(1) == 1.0);
     }
   }
 }

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -436,36 +436,36 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
       if (context.isPrimary()) { //Primary
         BOOST_TEST(pSolidzMesh->nVertices() == 6);
         BOOST_TEST(pSolidzMesh->edges().size() == 5);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(4).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(5).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertex(4).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertex(5).getGlobalIndex() == 5);
       } else if (context.isRank(1)) { //Secondary rank 2
         BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 3
         BOOST_TEST(pSolidzMesh->nVertices() == 6);
         BOOST_TEST(pSolidzMesh->edges().size() == 5);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(4).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(5).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertex(4).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertex(5).getGlobalIndex() == 5);
       }
     }
   }
@@ -521,24 +521,24 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
       if (context.isPrimary()) { //Primary
         BOOST_TEST(pSolidzMesh->nVertices() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
       } else if (context.isRank(1)) { //Secondary rank 2
         BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 3
         BOOST_TEST(pSolidzMesh->nVertices() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 5);
       }
     }
   }
@@ -594,30 +594,30 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
       if (context.isPrimary()) { //Primary
         BOOST_TEST(pSolidzMesh->nVertices() == 4);
         BOOST_TEST(pSolidzMesh->edges().size() == 3);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 3);
       } else if (context.isRank(1)) { //Secondary rank 2
         BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 3
         BOOST_TEST(pSolidzMesh->nVertices() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 4);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 4);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 5);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(4).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertex(4).getGlobalIndex() == 5);
       }
     }
   }
@@ -676,16 +676,16 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
         BOOST_TEST(pSolidzMesh->nVertices() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 6);
         BOOST_TEST(pSolidzMesh->triangles().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(4).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertex(4).getGlobalIndex() == 4);
       } else if (context.isRank(1)) { //Secondary rank 2
         BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
@@ -694,16 +694,16 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
         BOOST_TEST(pSolidzMesh->nVertices() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 6);
         BOOST_TEST(pSolidzMesh->triangles().size() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
-        BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-        BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-        BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
-        BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
-        BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
+        BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == false);
+        BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(4).isOwner() == true);
+        BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+        BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+        BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
+        BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 3);
+        BOOST_TEST(pSolidzMesh->vertex(4).getGlobalIndex() == 4);
       }
     }
   }
@@ -834,14 +834,14 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
       BOOST_TEST(pMesh->getVertexDistribution().at(0).at(1) == 1);
       BOOST_TEST(pMesh->getVertexDistribution().at(1).at(0) == 1);
       BOOST_TEST(pMesh->nVertices() == 2);
-      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 0);
-      BOOST_TEST(pMesh->vertices().at(1).getGlobalIndex() == 1);
-      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
-      BOOST_TEST(pMesh->vertices().at(1).isOwner() == false);
+      BOOST_TEST(pMesh->vertex(0).getGlobalIndex() == 0);
+      BOOST_TEST(pMesh->vertex(1).getGlobalIndex() == 1);
+      BOOST_TEST(pMesh->vertex(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertex(1).isOwner() == false);
     } else if (context.isRank(1)) { //Secondary rank 2
       BOOST_TEST(pMesh->nVertices() == 1);
-      BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 1);
-      BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
+      BOOST_TEST(pMesh->vertex(0).getGlobalIndex() == 1);
+      BOOST_TEST(pMesh->vertex(0).isOwner() == true);
     } else if (context.isRank(2)) { //Secondary rank 3
       BOOST_TEST(pMesh->nVertices() == 0);
     }
@@ -868,18 +868,18 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
     BOOST_TEST(pSolidzMesh->edges().size() == 5);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 1);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 6);
-    BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-    BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-    BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
-    BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
-    BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
-    BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
-    BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+    BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+    BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
+    BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 3);
+    BOOST_TEST(pSolidzMesh->vertex(4).getGlobalIndex() == 4);
+    BOOST_TEST(pSolidzMesh->vertex(5).getGlobalIndex() == 5);
+    BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(4).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(5).isOwner() == true);
   } else {
     BOOST_TEST(context.isNamed("Fluid"));
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
@@ -901,18 +901,18 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
     BOOST_TEST(pSolidzMesh->edges().size() == 5);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 1);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 6);
-    BOOST_TEST(pSolidzMesh->vertices().at(0).getGlobalIndex() == 0);
-    BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
-    BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
-    BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
-    BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
-    BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
-    BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(2).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(3).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(4).isOwner() == true);
-    BOOST_TEST(pSolidzMesh->vertices().at(5).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(0).getGlobalIndex() == 0);
+    BOOST_TEST(pSolidzMesh->vertex(1).getGlobalIndex() == 1);
+    BOOST_TEST(pSolidzMesh->vertex(2).getGlobalIndex() == 2);
+    BOOST_TEST(pSolidzMesh->vertex(3).getGlobalIndex() == 3);
+    BOOST_TEST(pSolidzMesh->vertex(4).getGlobalIndex() == 4);
+    BOOST_TEST(pSolidzMesh->vertex(5).getGlobalIndex() == 5);
+    BOOST_TEST(pSolidzMesh->vertex(0).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(1).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(2).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(3).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(4).isOwner() == true);
+    BOOST_TEST(pSolidzMesh->vertex(5).isOwner() == true);
   }
 }
 

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -1155,7 +1155,7 @@ BOOST_AUTO_TEST_CASE(parallelSetOwnerInformationVertexCount)
   for (auto &vertex : mesh->vertices()) {
     vertex.setGlobalIndex(vertex.getID() + 5 * utils::IntraComm::getRank());
 
-    if (vertex.getCoords()[0] == 0 && vertex.getCoords()[1] == 0) {
+    if (vertex.coord(0) == 0 && vertex.coord(1) == 0) {
       vertex.setGlobalIndex(0);
     }
   }
@@ -1304,10 +1304,10 @@ BOOST_AUTO_TEST_CASE(parallelSetOwnerInformationLowerRank)
   for (auto &vertex : mesh->vertices()) {
     vertex.setGlobalIndex(vertex.getID() + 10 * utils::IntraComm::getRank());
 
-    if (vertex.getCoords()[0] == 0 && vertex.getCoords()[1] == 0) {
-      if (vertex.getCoords()[2] == 0) {
+    if (vertex.coord(0) == 0 && vertex.coord(1) == 0) {
+      if (vertex.coord(2) == 0) {
         vertex.setGlobalIndex(0);
-      } else if (vertex.getCoords()[2] == 1) {
+      } else if (vertex.coord(2) == 1) {
         vertex.setGlobalIndex(6);
       }
     }
@@ -1432,10 +1432,10 @@ BOOST_AUTO_TEST_CASE(parallelSetOwnerInformationEmptyPartition)
   for (auto &vertex : mesh->vertices()) {
     vertex.setGlobalIndex(vertex.getID() + 10 * utils::IntraComm::getRank());
 
-    if (vertex.getCoords()[0] == 0 && vertex.getCoords()[1] == 0) {
-      if (vertex.getCoords()[2] == 0) {
+    if (vertex.coord(0) == 0 && vertex.coord(1) == 0) {
+      if (vertex.coord(2) == 0) {
         vertex.setGlobalIndex(0);
-      } else if (vertex.getCoords()[2] == 1) {
+      } else if (vertex.coord(2) == 1) {
         vertex.setGlobalIndex(6);
       }
     }

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D)
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
-    BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+    BOOST_TEST(pSolidzMesh->nVertices() == 6);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
@@ -271,13 +271,13 @@ BOOST_AUTO_TEST_CASE(RePartitionNNBroadcastFilter2D)
     {
       // check if the sending and filtering worked right
       if (context.isPrimary()) { //Primary
-        BOOST_TEST(pSolidzMesh->vertices().size() == 2);
+        BOOST_TEST(pSolidzMesh->nVertices() == 2);
         BOOST_TEST(pSolidzMesh->edges().size() == 1);
       } else if (context.isRank(1)) { //SecondaryRank1
-        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 2
-        BOOST_TEST(pSolidzMesh->vertices().size() == 2);
+        BOOST_TEST(pSolidzMesh->nVertices() == 2);
         BOOST_TEST(pSolidzMesh->edges().size() == 1);
       }
     }
@@ -323,13 +323,13 @@ BOOST_AUTO_TEST_CASE(RePartitionNNDoubleNode2D)
 
     // check if the sending and filtering worked right
     if (context.isPrimary()) { //Primary
-      BOOST_TEST(pSolidzMesh->vertices().size() == 2);
+      BOOST_TEST(pSolidzMesh->nVertices() == 2);
       BOOST_TEST(pSolidzMesh->edges().size() == 1);
     } else if (context.isRank(1)) { //SecondaryRank1
-      BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+      BOOST_TEST(pSolidzMesh->nVertices() == 0);
       BOOST_TEST(pSolidzMesh->edges().size() == 0);
     } else if (context.isRank(2)) { //Secondary rank 2
-      BOOST_TEST(pSolidzMesh->vertices().size() == 2);
+      BOOST_TEST(pSolidzMesh->nVertices() == 2);
       BOOST_TEST(pSolidzMesh->edges().size() == 1);
     }
   }
@@ -374,13 +374,13 @@ BOOST_AUTO_TEST_CASE(RePartitionNPPreFilterPostFilter2D)
     {
       // check if the sending and filtering worked right
       if (context.isPrimary()) { //Primary
-        BOOST_TEST(pSolidzMesh->vertices().size() == 3);
+        BOOST_TEST(pSolidzMesh->nVertices() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
       } else if (context.isRank(1)) { //SecondaryRank1
-        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 2
-        BOOST_TEST(pSolidzMesh->vertices().size() == 3);
+        BOOST_TEST(pSolidzMesh->nVertices() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
       }
     }
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
 
       // check if the sending and filtering worked right
       if (context.isPrimary()) { //Primary
-        BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+        BOOST_TEST(pSolidzMesh->nVertices() == 6);
         BOOST_TEST(pSolidzMesh->edges().size() == 5);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
@@ -449,10 +449,10 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFGlobal2D)
         BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
         BOOST_TEST(pSolidzMesh->vertices().at(5).getGlobalIndex() == 5);
       } else if (context.isRank(1)) { //Secondary rank 2
-        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 3
-        BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+        BOOST_TEST(pSolidzMesh->nVertices() == 6);
         BOOST_TEST(pSolidzMesh->edges().size() == 5);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
         BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
@@ -519,7 +519,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
 
       // check if the sending and filtering worked right
       if (context.isPrimary()) { //Primary
-        BOOST_TEST(pSolidzMesh->vertices().size() == 3);
+        BOOST_TEST(pSolidzMesh->nVertices() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
@@ -528,10 +528,10 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D1)
         BOOST_TEST(pSolidzMesh->vertices().at(1).getGlobalIndex() == 1);
         BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
       } else if (context.isRank(1)) { //Secondary rank 2
-        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 3
-        BOOST_TEST(pSolidzMesh->vertices().size() == 3);
+        BOOST_TEST(pSolidzMesh->nVertices() == 3);
         BOOST_TEST(pSolidzMesh->edges().size() == 2);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
@@ -592,7 +592,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
 
       // check if the sending and filtering worked right
       if (context.isPrimary()) { //Primary
-        BOOST_TEST(pSolidzMesh->vertices().size() == 4);
+        BOOST_TEST(pSolidzMesh->nVertices() == 4);
         BOOST_TEST(pSolidzMesh->edges().size() == 3);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
         BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == true);
@@ -603,10 +603,10 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal2D2)
         BOOST_TEST(pSolidzMesh->vertices().at(2).getGlobalIndex() == 2);
         BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
       } else if (context.isRank(1)) { //Secondary rank 2
-        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 3
-        BOOST_TEST(pSolidzMesh->vertices().size() == 5);
+        BOOST_TEST(pSolidzMesh->nVertices() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 4);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
         BOOST_TEST(pSolidzMesh->vertices().at(1).isOwner() == false);
@@ -673,7 +673,7 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
 
       // check if the sending and filtering worked right
       if (context.isPrimary()) { //Primary
-        BOOST_TEST(pSolidzMesh->vertices().size() == 5);
+        BOOST_TEST(pSolidzMesh->nVertices() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 6);
         BOOST_TEST(pSolidzMesh->triangles().size() == 2);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == true);
@@ -687,11 +687,11 @@ BOOST_AUTO_TEST_CASE(RePartitionRBFLocal3D)
         BOOST_TEST(pSolidzMesh->vertices().at(3).getGlobalIndex() == 3);
         BOOST_TEST(pSolidzMesh->vertices().at(4).getGlobalIndex() == 4);
       } else if (context.isRank(1)) { //Secondary rank 2
-        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
         BOOST_TEST(pSolidzMesh->triangles().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 3
-        BOOST_TEST(pSolidzMesh->vertices().size() == 5);
+        BOOST_TEST(pSolidzMesh->nVertices() == 5);
         BOOST_TEST(pSolidzMesh->edges().size() == 6);
         BOOST_TEST(pSolidzMesh->triangles().size() == 2);
         BOOST_TEST(pSolidzMesh->vertices().at(0).isOwner() == false);
@@ -748,15 +748,15 @@ BOOST_AUTO_TEST_CASE(RePartitionNPBroadcastFilter3D)
 
     // check if the sending and filtering worked right
     if (context.isPrimary()) { //Primary
-      BOOST_TEST(pSolidzMesh->vertices().size() == 2);
+      BOOST_TEST(pSolidzMesh->nVertices() == 2);
       BOOST_TEST(pSolidzMesh->edges().size() == 1);
       BOOST_TEST(pSolidzMesh->triangles().size() == 0);
     } else if (context.isRank(1)) { //SecondaryRank1
-      BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+      BOOST_TEST(pSolidzMesh->nVertices() == 0);
       BOOST_TEST(pSolidzMesh->edges().size() == 0);
       BOOST_TEST(pSolidzMesh->triangles().size() == 0);
     } else if (context.isRank(2)) { //Secondary rank 2
-      BOOST_TEST(pSolidzMesh->vertices().size() == 3);
+      BOOST_TEST(pSolidzMesh->nVertices() == 3);
       BOOST_TEST(pSolidzMesh->edges().size() == 3);
       BOOST_TEST(pSolidzMesh->triangles().size() == 1);
     }
@@ -833,17 +833,17 @@ BOOST_AUTO_TEST_CASE(TestRepartitionAndDistribution2D)
       BOOST_TEST(pMesh->getVertexDistribution().at(0).at(0) == 0);
       BOOST_TEST(pMesh->getVertexDistribution().at(0).at(1) == 1);
       BOOST_TEST(pMesh->getVertexDistribution().at(1).at(0) == 1);
-      BOOST_TEST(pMesh->vertices().size() == 2);
+      BOOST_TEST(pMesh->nVertices() == 2);
       BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 0);
       BOOST_TEST(pMesh->vertices().at(1).getGlobalIndex() == 1);
       BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
       BOOST_TEST(pMesh->vertices().at(1).isOwner() == false);
     } else if (context.isRank(1)) { //Secondary rank 2
-      BOOST_TEST(pMesh->vertices().size() == 1);
+      BOOST_TEST(pMesh->nVertices() == 1);
       BOOST_TEST(pMesh->vertices().at(0).getGlobalIndex() == 1);
       BOOST_TEST(pMesh->vertices().at(0).isOwner() == true);
     } else if (context.isRank(2)) { //Secondary rank 3
-      BOOST_TEST(pMesh->vertices().size() == 0);
+      BOOST_TEST(pMesh->nVertices() == 0);
     }
   }
 }
@@ -864,7 +864,7 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
     part.compute();
 
     BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
-    BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+    BOOST_TEST(pSolidzMesh->nVertices() == 6);
     BOOST_TEST(pSolidzMesh->edges().size() == 5);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 1);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 6);
@@ -897,7 +897,7 @@ BOOST_AUTO_TEST_CASE(ProvideAndReceiveCouplingMode)
     part.compute();
 
     BOOST_TEST(pSolidzMesh->getGlobalNumberOfVertices() == 6);
-    BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+    BOOST_TEST(pSolidzMesh->nVertices() == 6);
     BOOST_TEST(pSolidzMesh->edges().size() == 5);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().size() == 1);
     BOOST_TEST(pSolidzMesh->getVertexOffsets().at(0) == 6);
@@ -1150,7 +1150,7 @@ BOOST_AUTO_TEST_CASE(parallelSetOwnerInformationVertexCount)
   }
 
   mesh->computeBoundingBox();
-  mesh->setGlobalNumberOfVertices(mesh->vertices().size());
+  mesh->setGlobalNumberOfVertices(mesh->nVertices());
 
   for (auto &vertex : mesh->vertices()) {
     vertex.setGlobalIndex(vertex.getID() + 5 * utils::IntraComm::getRank());
@@ -1299,7 +1299,7 @@ BOOST_AUTO_TEST_CASE(parallelSetOwnerInformationLowerRank)
   }
 
   mesh->computeBoundingBox();
-  mesh->setGlobalNumberOfVertices(mesh->vertices().size());
+  mesh->setGlobalNumberOfVertices(mesh->nVertices());
 
   for (auto &vertex : mesh->vertices()) {
     vertex.setGlobalIndex(vertex.getID() + 10 * utils::IntraComm::getRank());
@@ -1427,7 +1427,7 @@ BOOST_AUTO_TEST_CASE(parallelSetOwnerInformationEmptyPartition)
   }
 
   mesh->computeBoundingBox();
-  mesh->setGlobalNumberOfVertices(mesh->vertices().size());
+  mesh->setGlobalNumberOfVertices(mesh->nVertices());
 
   for (auto &vertex : mesh->vertices()) {
     vertex.setGlobalIndex(vertex.getID() + 10 * utils::IntraComm::getRank());
@@ -1471,7 +1471,7 @@ BOOST_AUTO_TEST_CASE(RePartitionMultipleMappings)
   if (context.isNamed("Solid")) { //SOLIDZ
     mesh::PtrMesh pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     createSolidzMesh2D(pSolidzMesh);
-    BOOST_TEST(pSolidzMesh->vertices().size() == 6);
+    BOOST_TEST(pSolidzMesh->nVertices() == 6);
     ProvidedPartition part(pSolidzMesh);
     part.addM2N(m2n);
     part.communicate();
@@ -1529,13 +1529,13 @@ BOOST_AUTO_TEST_CASE(RePartitionMultipleMappings)
     {
       // check if the sending and filtering worked right
       if (context.isPrimary()) { //Primary
-        BOOST_TEST(pSolidzMesh->vertices().size() == 2);
+        BOOST_TEST(pSolidzMesh->nVertices() == 2);
         BOOST_TEST(pSolidzMesh->edges().size() == 1);
       } else if (context.isRank(1)) { //SecondaryRank1
-        BOOST_TEST(pSolidzMesh->vertices().size() == 0);
+        BOOST_TEST(pSolidzMesh->nVertices() == 0);
         BOOST_TEST(pSolidzMesh->edges().size() == 0);
       } else if (context.isRank(2)) { //Secondary rank 2
-        BOOST_TEST(pSolidzMesh->vertices().size() == 2);
+        BOOST_TEST(pSolidzMesh->nVertices() == 2);
         BOOST_TEST(pSolidzMesh->edges().size() == 1);
       }
     }

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -51,7 +51,7 @@ std::string DataContext::getMeshName() const
 int DataContext::getMeshVertexCount() const
 {
   PRECICE_ASSERT(_mesh);
-  return _mesh->vertices().size();
+  return _mesh->nVertices();
 }
 
 MeshID DataContext::getMeshID() const
@@ -124,7 +124,7 @@ int DataContext::mapData(std::optional<double> after, bool skipZero)
 
       time::Sample outSample{
           dataDims,
-          Eigen::VectorXd::Zero(dataDims * mapping.getOutputMesh()->vertices().size())};
+          Eigen::VectorXd::Zero(dataDims * mapping.getOutputMesh()->nVertices())};
 
       bool skipMapping = skipZero && stample.sample.values.isZero();
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -722,8 +722,8 @@ void ParticipantImpl::setMeshEdge(
     using impl::errorInvalidVertexID;
     PRECICE_CHECK(mesh->isValidVertexID(first), errorInvalidVertexID(first));
     PRECICE_CHECK(mesh->isValidVertexID(second), errorInvalidVertexID(second));
-    mesh::Vertex &v0 = mesh->vertices()[first];
-    mesh::Vertex &v1 = mesh->vertices()[second];
+    mesh::Vertex &v0 = mesh->vertex(first);
+    mesh::Vertex &v1 = mesh->vertex(second);
     mesh->createEdge(v0, v1);
   }
 }
@@ -758,7 +758,7 @@ void ParticipantImpl::setMeshEdges(
   for (unsigned long i = 0; i < vertices.size() / 2; ++i) {
     auto aid = vertices[2 * i];
     auto bid = vertices[2 * i + 1];
-    mesh->createEdge(mesh->vertices()[aid], mesh->vertices()[bid]);
+    mesh->createEdge(mesh->vertex(aid), mesh->vertices()[bid]);
   }
 }
 
@@ -783,9 +783,9 @@ void ParticipantImpl::setMeshTriangle(
                   "setMeshTriangle() was called with repeated Vertex IDs ({}, {}, {}).",
                   first, second, third);
     mesh::Vertex *vertices[3];
-    vertices[0] = &mesh->vertices()[first];
-    vertices[1] = &mesh->vertices()[second];
-    vertices[2] = &mesh->vertices()[third];
+    vertices[0] = &mesh->vertex(first);
+    vertices[1] = &mesh->vertex(second);
+    vertices[2] = &mesh->vertex(third);
     PRECICE_CHECK(utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
                                                            vertices[1]->getCoords(), vertices[2]->getCoords())),
                   "setMeshTriangle() was called with vertices located at identical coordinates (IDs: {}, {}, {}).",
@@ -830,9 +830,9 @@ void ParticipantImpl::setMeshTriangles(
     auto aid = vertices[3 * i];
     auto bid = vertices[3 * i + 1];
     auto cid = vertices[3 * i + 2];
-    mesh->createTriangle(mesh->vertices()[aid],
-                         mesh->vertices()[bid],
-                         mesh->vertices()[cid]);
+    mesh->createTriangle(mesh->vertex(aid),
+                         mesh->vertex(bid),
+                         mesh->vertex(cid));
   }
 }
 
@@ -970,10 +970,10 @@ void ParticipantImpl::setMeshTetrahedron(
     PRECICE_CHECK(mesh->isValidVertexID(second), errorInvalidVertexID(second));
     PRECICE_CHECK(mesh->isValidVertexID(third), errorInvalidVertexID(third));
     PRECICE_CHECK(mesh->isValidVertexID(fourth), errorInvalidVertexID(fourth));
-    mesh::Vertex &A = mesh->vertices()[first];
-    mesh::Vertex &B = mesh->vertices()[second];
-    mesh::Vertex &C = mesh->vertices()[third];
-    mesh::Vertex &D = mesh->vertices()[fourth];
+    mesh::Vertex &A = mesh->vertex(first);
+    mesh::Vertex &B = mesh->vertex(second);
+    mesh::Vertex &C = mesh->vertex(third);
+    mesh::Vertex &D = mesh->vertex(fourth);
 
     mesh->createTetrahedron(A, B, C, D);
   }
@@ -1011,10 +1011,10 @@ void ParticipantImpl::setMeshTetrahedra(
     auto bid = vertices[4 * i + 1];
     auto cid = vertices[4 * i + 2];
     auto did = vertices[4 * i + 3];
-    mesh->createTetrahedron(mesh->vertices()[aid],
-                            mesh->vertices()[bid],
-                            mesh->vertices()[cid],
-                            mesh->vertices()[did]);
+    mesh->createTetrahedron(mesh->vertex(aid),
+                            mesh->vertex(bid),
+                            mesh->vertex(cid),
+                            mesh->vertex(did));
   }
 }
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -758,7 +758,7 @@ void ParticipantImpl::setMeshEdges(
   for (unsigned long i = 0; i < vertices.size() / 2; ++i) {
     auto aid = vertices[2 * i];
     auto bid = vertices[2 * i + 1];
-    mesh->createEdge(mesh->vertex(aid), mesh->vertices()[bid]);
+    mesh->createEdge(mesh->vertex(aid), mesh->vertex(bid));
   }
 }
 
@@ -1198,9 +1198,8 @@ void ParticipantImpl::getMeshVertexIDsAndCoordinates(
   const MeshContext & context = _accessor->meshContext(meshName);
   const mesh::PtrMesh mesh(context.mesh);
 
-  const auto &vertices = mesh->vertices();
-  const auto  meshSize = vertices.size();
-  const auto  meshDims = mesh->getDimensions();
+  const auto meshSize = mesh->nVertices();
+  const auto meshDims = mesh->getDimensions();
   PRECICE_CHECK(ids.size() == meshSize,
                 "Output size is incorrect attempting to get vertex ids of {}D mesh \"{}\". "
                 "You passed {} vertices indices, but we expected {}. "
@@ -1213,15 +1212,15 @@ void ParticipantImpl::getMeshVertexIDsAndCoordinates(
                 "Use getMeshVertexSize(\"{}\") and getMeshDimensions(\"{}\") to receive the required amount components",
                 meshDims, meshName, coordinates.size(), expectedCoordinatesSize, meshSize, meshDims, meshName, meshName);
 
-  PRECICE_CHECK(ids.size() <= vertices.size(), "The queried size exceeds the number of available points.");
+  PRECICE_CHECK(ids.size() <= meshSize, "The queried size exceeds the number of available points.");
 
   Eigen::Map<Eigen::MatrixXd> posMatrix{
       coordinates.data(), mesh->getDimensions(), static_cast<EIGEN_DEFAULT_DENSE_INDEX_TYPE>(ids.size())};
 
   for (unsigned long i = 0; i < ids.size(); i++) {
-    PRECICE_ASSERT(i < vertices.size(), i, vertices.size());
-    ids[i]           = vertices[i].getID();
-    posMatrix.col(i) = vertices[i].getCoords();
+    PRECICE_ASSERT(mesh->isValidVertexID(i), i, meshSize);
+    ids[i]           = mesh->vertex(i).getID();
+    posMatrix.col(i) = mesh->vertex(i).getCoords();
   }
 }
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -637,7 +637,7 @@ int ParticipantImpl::getMeshVertexSize(
                 meshName, _accessor->getName());
   MeshContext &context = _accessor->usedMeshContext(meshName);
   PRECICE_ASSERT(context.mesh.get() != nullptr);
-  return context.mesh->vertices().size();
+  return context.mesh->nVertices();
 }
 
 /// @todo Currently not supported as we would need to re-compute the re-partition
@@ -667,7 +667,7 @@ VertexID ParticipantImpl::setMeshVertex(
   auto index = mesh.createVertex(Eigen::Map<const Eigen::VectorXd>{position.data(), mesh.getDimensions()}).getID();
   mesh.allocateDataValues();
 
-  const auto newSize = mesh.vertices().size();
+  const auto newSize = mesh.nVertices();
   for (auto &context : _accessor->writeDataContexts()) {
     if (context.getMeshName() == mesh.getName()) {
       context.resizeBufferTo(newSize);
@@ -701,7 +701,7 @@ void ParticipantImpl::setMeshVertices(
   }
   mesh.allocateDataValues();
 
-  const auto newSize = mesh.vertices().size();
+  const auto newSize = mesh.nVertices();
   for (auto &context : _accessor->writeDataContexts()) {
     if (context.getMeshName() == mesh.getName()) {
       context.resizeBufferTo(newSize);
@@ -1372,7 +1372,7 @@ void ParticipantImpl::computePartitions()
 
     meshContext->mesh->allocateDataValues();
 
-    const auto requiredSize = meshContext->mesh->vertices().size();
+    const auto requiredSize = meshContext->mesh->nVertices();
     for (auto &context : _accessor->writeDataContexts()) {
       if (context.getMeshName() == meshContext->mesh->getName()) {
         context.resizeBufferTo(requiredSize);

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -57,7 +57,7 @@ void WatchPoint::initialize()
 {
   PRECICE_TRACE();
 
-  if (_mesh->vertices().size() > 0) {
+  if (_mesh->nVertices() > 0) {
     auto match        = _mesh->index().findCellOrProjection(_point, 4);
     _shortestDistance = match.polation.distance();
     _interpolation    = std::make_unique<mapping::Polation>(std::move(match.polation));

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -99,7 +99,7 @@ void WatchPoint::exportPointData(
   // Export watch point coordinates
   Eigen::VectorXd coords = Eigen::VectorXd::Constant(_mesh->getDimensions(), 0.0);
   for (const auto &elem : _interpolation->getWeightedElements()) {
-    coords += elem.weight * _mesh->vertices()[elem.vertexID].getCoords();
+    coords += elem.weight * _mesh->vertex(elem.vertexID).getCoords();
   }
   if (coords.size() == 2) {
     _txtWriter.writeData("Coordinate", Eigen::Vector2d(coords));

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -172,7 +172,7 @@ VertexMatch Index::getClosestVertex(const Eigen::VectorXd &sourceCoord)
 {
   PRECICE_TRACE();
 
-  PRECICE_ASSERT(not _mesh->vertices().empty(), _mesh->getName());
+  PRECICE_ASSERT(not _mesh->empty(), _mesh->getName());
   VertexMatch match;
   const auto &rtree = _pimpl->getVertexRTree(*_mesh);
   rtree->query(bgi::nearest(sourceCoord, 1), boost::make_function_output_iterator([&](size_t matchID) {
@@ -184,7 +184,7 @@ VertexMatch Index::getClosestVertex(const Eigen::VectorXd &sourceCoord)
 std::vector<VertexID> Index::getClosestVertices(const Eigen::VectorXd &sourceCoord, int n)
 {
   PRECICE_TRACE();
-  PRECICE_ASSERT(!(_mesh->vertices().empty()), _mesh->getName());
+  PRECICE_ASSERT(!(_mesh->empty()), _mesh->getName());
   std::vector<VertexID> matches;
   const auto &          rtree = _pimpl->getVertexRTree(*_mesh);
 

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -56,7 +56,7 @@ VertexTraits::Ptr Index::IndexImpl::getVertexRTree(const mesh::Mesh &mesh)
   impl::RTreeParameters     params;
   VertexTraits::IndexGetter ind(mesh.vertices());
   auto                      tree = std::make_shared<VertexTraits::RTree>(
-      boost::irange<std::size_t>(0lu, mesh.vertices().size()), params, ind);
+      boost::irange<std::size_t>(0lu, mesh.nVertices()), params, ind);
 
   indices.vertexRTree = std::move(tree);
   return indices.vertexRTree;
@@ -370,7 +370,7 @@ mesh::BoundingBox Index::getRtreeBounds()
   // if the mesh is empty, we will most likely hit an assertion in the bounding box class
   // therefore, we keep the assert here, but might want to return an empty bounding box in case
   // we want to allow calling this function with empty meshes
-  PRECICE_ASSERT(_mesh->vertices().size() > 0);
+  PRECICE_ASSERT(_mesh->nVertices() > 0);
 
   auto            rtreeBox = _pimpl->getVertexRTree(*_mesh)->bounds();
   int             dim      = _mesh->getDimensions();

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -230,7 +230,7 @@ std::vector<VertexID> Index::getVerticesInsideBox(const mesh::Vertex &centerVert
 
   const auto &          rtree = _pimpl->getVertexRTree(*_mesh);
   std::vector<VertexID> matches;
-  rtree->query(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertices()[i]) < radius; }),
+  rtree->query(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertex(i)) < radius; }),
                std::back_inserter(matches));
   return matches;
 }
@@ -245,7 +245,7 @@ bool Index::isAnyVertexInsideBox(const mesh::Vertex &centerVertex, double radius
 
   const auto &rtree = _pimpl->getVertexRTree(*_mesh);
 
-  auto queryIter = rtree->qbegin(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertices()[i]) < radius; }));
+  auto queryIter = rtree->qbegin(bgi::intersects(searchBox) and bg::index::satisfies([&](size_t const i) { return bg::distance(centerVertex, _mesh->vertex(i)) < radius; }));
   bool hasMatch  = queryIter != rtree->qend();
   return hasMatch;
 }
@@ -312,7 +312,7 @@ ProjectionMatch Index::findCellOrProjection(const Eigen::VectorXd &location, int
 ProjectionMatch Index::findVertexProjection(const Eigen::VectorXd &location)
 {
   auto match = getClosestVertex(location);
-  return {mapping::Polation{location, _mesh->vertices()[match.index]}};
+  return {mapping::Polation{location, _mesh->vertex(match.index)}};
 }
 
 ProjectionMatch Index::findEdgeProjection(const Eigen::VectorXd &location, int n, ProjectionMatch closestVertex)

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(Query2DVertex)
   Eigen::Vector2d location(0.2, 0.8);
 
   auto result = indexTree.getClosestVertex(location);
-  BOOST_TEST(mesh->vertices().at(result.index).getCoords() == Eigen::Vector2d(0, 1));
+  BOOST_TEST(mesh->vertex(result.index).getCoords() == Eigen::Vector2d(0, 1));
 }
 
 BOOST_AUTO_TEST_CASE(Query3DVertex)
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(Query3DVertex)
   Eigen::Vector3d location(0.8, 0.0, 0.8);
 
   auto result = indexTree.getClosestVertex(location);
-  BOOST_TEST(mesh->vertices().at(result.index).getCoords() == Eigen::Vector3d(1, 0, 1));
+  BOOST_TEST(mesh->vertex(result.index).getCoords() == Eigen::Vector3d(1, 0, 1));
 }
 
 BOOST_AUTO_TEST_CASE(Query3DFullVertex)
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(Query3DFullVertex)
     Eigen::Vector3d location(0.8, 0.0, 0.8);
     auto            result = indexTree.getClosestVertex(location);
 
-    BOOST_TEST(mesh->vertices().at(result.index).getID() == v10.getID());
+    BOOST_TEST(mesh->vertex(result.index).getID() == v10.getID());
   }
   {
     Eigen::Vector3d       location(0.8, 0.0, 0.8);
@@ -195,8 +195,8 @@ BOOST_AUTO_TEST_CASE(QueryWithBox2Matches)
 
   auto results = indexTree.getVerticesInsideBox(searchVertex, radius);
   BOOST_TEST(results.size() == 2);
-  BOOST_TEST(mesh->vertices().at(results.at(0)).getCoords() == Eigen::Vector3d(0, 1, 0));
-  BOOST_TEST(mesh->vertices().at(results.at(1)).getCoords() == Eigen::Vector3d(1, 1, 0));
+  BOOST_TEST(mesh->vertex(results.at(0)).getCoords() == Eigen::Vector3d(0, 1, 0));
+  BOOST_TEST(mesh->vertex(results.at(1)).getCoords() == Eigen::Vector3d(1, 1, 0));
 }
 
 /// Resembles how boost geometry is used inside the PetRBF

--- a/tests/parallel/TestFinalize.cpp
+++ b/tests/parallel/TestFinalize.cpp
@@ -19,8 +19,8 @@ BOOST_AUTO_TEST_CASE(TestFinalize)
     double               v[]      = {xCoord, 0, 0};
     participant.setMeshVertex(meshName, v);
     participant.initialize();
-    BOOST_TEST(precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne").vertices().size() == 1);
-    BOOST_TEST(precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshTwo").vertices().size() == 1);
+    BOOST_TEST(precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne").nVertices() == 1);
+    BOOST_TEST(precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshTwo").nVertices() == 1);
     participant.finalize();
   } else {
     BOOST_TEST(context.isNamed("SolverTwo"));
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(TestFinalize)
     double               v[]      = {xCoord, 0, 0};
     participant.setMeshVertex(meshName, v);
     participant.initialize();
-    BOOST_TEST(precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshTwo").vertices().size() == 1);
+    BOOST_TEST(precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshTwo").nVertices() == 1);
     participant.finalize();
   }
 }

--- a/tests/parallel/mapping-volume/ParallelCube1To3.cpp
+++ b/tests/parallel/mapping-volume/ParallelCube1To3.cpp
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(ParallelCube1To3)
     participant.setMeshTetrahedron(meshName, v000, v100, v110, v111);
 
     auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 8);
+    BOOST_REQUIRE(mesh.nVertices() == 8);
     BOOST_REQUIRE(mesh.tetrahedra().size() == 6);
 
     participant.initialize();

--- a/tests/parallel/mapping-volume/ParallelCubeConservative3To1.cpp
+++ b/tests/parallel/mapping-volume/ParallelCubeConservative3To1.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(ParallelCubeConservative3To1)
     participant.setMeshTetrahedron(meshName, v000, v100, v110, v111);
 
     auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshTwo");
-    BOOST_REQUIRE(mesh.vertices().size() == 8);
+    BOOST_REQUIRE(mesh.nVertices() == 8);
     BOOST_REQUIRE(mesh.tetrahedra().size() == 6);
     participant.initialize();
     dt = participant.getMaxTimeStepSize();

--- a/tests/serial/mapping-nearest-projection/helpers.cpp
+++ b/tests/serial/mapping-nearest-projection/helpers.cpp
@@ -174,7 +174,7 @@ void testQuadMappingNearestProjection(bool defineEdgesExplicitly, bool useBulkFu
     }
 
     auto &mesh = testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 4);
+    BOOST_REQUIRE(mesh.nVertices() == 4);
     if (defineEdgesExplicitly) {
       BOOST_REQUIRE(mesh.edges().size() == 4);
     } else {
@@ -276,7 +276,7 @@ void testQuadMappingNearestProjectionTallKite(bool defineEdgesExplicitly, bool u
     }
 
     auto &mesh = testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 4);
+    BOOST_REQUIRE(mesh.nVertices() == 4);
     if (defineEdgesExplicitly) {
       BOOST_REQUIRE(mesh.edges().size() == 4);
     } else {
@@ -335,7 +335,7 @@ void testQuadMappingNearestProjectionWideKite(bool defineEdgesExplicitly, bool u
     }
 
     auto &mesh = testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 4);
+    BOOST_REQUIRE(mesh.nVertices() == 4);
     if (defineEdgesExplicitly) {
       BOOST_REQUIRE(mesh.edges().size() == 4);
     } else {

--- a/tests/serial/mapping-scaled-consistent/helpers.cpp
+++ b/tests/serial/mapping-scaled-consistent/helpers.cpp
@@ -44,7 +44,7 @@ void testQuadMappingScaledConsistent(const std::string configFile, const TestCon
     participant.setMeshQuad(meshOneID, idA, idB, idC, idD);
 
     auto &mesh = testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 4);
+    BOOST_REQUIRE(mesh.nVertices() == 4);
     BOOST_REQUIRE(mesh.edges().empty());
     BOOST_REQUIRE(mesh.triangles().size() == 2);
 
@@ -146,7 +146,7 @@ void testQuadMappingScaledConsistentVolumetric(const std::string configFile, con
     participant.setMeshTriangle(meshOneID, idB, idC, idExtra);
 
     auto &mesh = testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 5);
+    BOOST_REQUIRE(mesh.nVertices() == 5);
     BOOST_REQUIRE(mesh.triangles().size() == 3);
 
     auto   dataAID  = "DataOne";
@@ -253,7 +253,7 @@ void testTetraScaledConsistentVolumetric(const std::string configFile, const Tes
     participant.setMeshTetrahedron(meshOneID, idC, idB, idD, idExtra);
 
     auto &mesh = testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 5);
+    BOOST_REQUIRE(mesh.nVertices() == 5);
     BOOST_REQUIRE(mesh.tetrahedra().size() == 2);
 
     auto   dataAID  = "DataOne";

--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -33,7 +33,7 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
     BOOST_CHECK(participant.getMeshVertexSize(meshName) == 3);
 
     auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-    BOOST_REQUIRE(mesh.vertices().size() == 3);
+    BOOST_REQUIRE(mesh.nVertices() == 3);
     BOOST_REQUIRE(mesh.edges().size() == 3);
     BOOST_REQUIRE(mesh.triangles().size() == 1);
 
@@ -69,7 +69,7 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
     // If "read" mapping, check received mesh
     if (read) {
       auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-      BOOST_REQUIRE(mesh.vertices().size() == 3);
+      BOOST_REQUIRE(mesh.nVertices() == 3);
       BOOST_REQUIRE(mesh.edges().size() == 3);
       BOOST_REQUIRE(mesh.triangles().size() == 1);
     }
@@ -190,7 +190,7 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
 
     auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
     // setMeshTetrahedron currently adds underlying connectivity
-    BOOST_REQUIRE(mesh.vertices().size() == 4);
+    BOOST_REQUIRE(mesh.nVertices() == 4);
     BOOST_REQUIRE(mesh.edges().empty());
     BOOST_REQUIRE(mesh.triangles().empty());
     BOOST_REQUIRE(mesh.tetrahedra().size() == 1);
@@ -231,7 +231,7 @@ void testMappingVolumeOneTetra(const std::string configFile, const TestContext &
     // If "read" mapping, check received mesh, including connectivity
     if (read) {
       auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
-      BOOST_CHECK(mesh.vertices().size() == 4);
+      BOOST_CHECK(mesh.nVertices() == 4);
       BOOST_CHECK(mesh.edges().size() == 6);
       BOOST_CHECK(mesh.triangles().size() == 4);
       BOOST_CHECK(mesh.tetrahedra().size() == 1);
@@ -306,7 +306,7 @@ void testMappingVolumeOneTetraConservative(const std::string configFile, const T
 
     auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshTwo");
     // setMeshTetrahedron currently adds underlying connectivity
-    BOOST_REQUIRE(mesh.vertices().size() == 4);
+    BOOST_REQUIRE(mesh.nVertices() == 4);
     BOOST_REQUIRE(mesh.edges().empty());
     BOOST_REQUIRE(mesh.triangles().empty());
     BOOST_REQUIRE(mesh.tetrahedra().size() == 1);

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
     auto velocitiesID = "Velocities";
     while (cplInterface.isCouplingOngoing()) {
       std::vector<double> data;
-      for (size_t i = 0; i < testing::WhiteboxAccessor::impl(cplInterface).mesh("Test-Square-One").vertices().size(); ++i) {
+      for (size_t i = 0; i < testing::WhiteboxAccessor::impl(cplInterface).mesh("Test-Square-One").nVertices(); ++i) {
         data.push_back(i);
         data.push_back(i);
       }
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
 
     auto velocitiesID = "Velocities";
     while (cplInterface.isCouplingOngoing()) {
-      const auto size = testing::WhiteboxAccessor::impl(cplInterface).mesh("Test-Square-Two").vertices().size();
+      const auto size = testing::WhiteboxAccessor::impl(cplInterface).mesh("Test-Square-Two").nVertices();
 
       std::vector<double> expected;
       for (size_t i = 0; i < size; ++i) {


### PR DESCRIPTION
## Main changes of this PR

This PR adds
* `Mesh::empty()` to replace `mesh.vertices().empty()`
* `Mesh::nVertices()` to replace `mesh.vertices().size()`
* `Mesh::vertex(vid)` to replace `mesh.vertices()[vid]` and `mesh.vertices().at(vid)`
* `Vertex::coord(i)` to replace `vertex.getCoords()[i]` (which is allocating) and `vertex.rawCoords()[i]` as long as it doesn't require the 3rd coord of a 2D vertex.

Now `mesh.vertices()` is only required to iterate over the vertices.

## Motivation and additional information

This removes a lot of boilerplate from Mappings and makes the code more readable in many places, especially tests.

The pretty common `mesh->vertices().at(i).rawCoords()[j]` now becomes `mesh->vertex(i).coord(j)`.

Addresses most of #1919

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
