### PR TITLE
Add transformation in acceleration methods to treat bounded values

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -38,12 +38,16 @@ BaseQNAcceleration::BaseQNAcceleration(
     int                     filter,
     double                  singularityLimit,
     std::vector<int>        dataIDs,
+    std::map<int, double>   lowerBounds,
+    std::map<int, double>   upperBounds,
     impl::PtrPreconditioner preconditioner)
     : _preconditioner(std::move(preconditioner)),
       _initialRelaxation(initialRelaxation),
       _maxIterationsUsed(maxIterationsUsed),
       _timeWindowsReused(timeWindowsReused),
       _dataIDs(std::move(dataIDs)),
+      _lowerBounds(lowerBounds),
+      _upperBounds(upperBounds),
       _forceInitialRelaxation(forceInitialRelaxation),
       _qrV(filter),
       _filter(filter),
@@ -170,7 +174,100 @@ void BaseQNAcceleration::initialize(
 
   _preconditioner->initialize(subVectorSizes);
 }
+void BaseQNAcceleration::projectFWInput(DataMap &cplData, const std::vector<DataID> &dataIDs, std::map<int, double> lowerBounds,
+                                        std::map<int, double> upperBounds)
+{
+  Eigen::Index offset = 0;
+  for (auto id : dataIDs) {
+    Eigen::Index size       = cplData.at(id)->values().size();
+    auto         lowerBound = lowerBounds.at(id);
+    auto         upperBound = upperBounds.at(id);
+    if (lowerBound <= -1.0e16 && upperBound >= 1.0e16) { // do nothing
+    } else if (lowerBound > -1.0e16 && upperBound < 1.0e16) {
+      // when both sides are bounded
+      double delta       = 0.1;
+      double leftLimit   = lowerBound - delta;
+      double rightLimit  = upperBound + delta;
+      double intervalLen = rightLimit - leftLimit;
+      // double factor        = 1;
+      // int selectedTrans = 1; // 1: logTrans, 2: tanhTrans, else: noTrans
 
+      for (Eigen::Index i = 0; i < size; i++) {
+        double normOldValue = (_oldValues[i + offset] - leftLimit) / intervalLen;
+        double normValue    = (_values[i + offset] - leftLimit) / intervalLen;
+
+        _values[i + offset]    = log(normValue / (1.0 - normValue));
+        _oldValues[i + offset] = log(normOldValue / (1.0 - normOldValue));
+        /*
+        switch (selectedTrans) {
+        case 1:
+          _values[i + offset]    = factor * log(normValue / (1.0 - normValue));
+          _oldValues[i + offset] = factor * log(normOldValue / (1.0 - normOldValue));
+          break;
+        case 2:
+          _values[i + offset]    = factor * atanh(normValue);
+          _oldValues[i + offset] = factor * atanh(normOldValue);
+          break;
+        default:
+          _values[i + offset]    = _values[i + offset];
+          _oldValues[i + offset] = _oldValues[i + offset];
+          break;
+        }
+        */
+      }
+    } else {
+      // when only one side is bounded
+    }
+    offset += size;
+  }
+}
+void BaseQNAcceleration::projectBWInput(DataMap &cplData, const std::vector<DataID> &dataIDs, std::map<int, double> lowerBounds,
+                                        std::map<int, double> upperBounds)
+{
+  Eigen::Index offset = 0;
+  for (auto id : dataIDs) {
+    Eigen::Index size       = cplData.at(id)->values().size();
+    auto         lowerBound = lowerBounds.at(id);
+    auto         upperBound = upperBounds.at(id);
+    if (lowerBound <= -1.0e16 && upperBound >= 1.0e16) { // do nothing
+    } else if (lowerBound > -1.0e16 && upperBound < 1.0e16) {
+      // when both sides are bounded
+      double delta       = 0.1;
+      double leftLimit   = lowerBound - delta;
+      double rightLimit  = upperBound + delta;
+      double intervalLen = rightLimit - leftLimit;
+      // int    selectedTrans = 1; // 0:only crop, 1: logTrans, 2: tanhTrans, else: nothing
+      // double factor = 10;
+      for (Eigen::Index i = 0; i < size; i++) {
+        _values[i + offset] = 1 / (1 + exp(-_values[i + offset])) * intervalLen + leftLimit;
+        _values[i + offset] = fmin(fmax(lowerBound, _values[i + offset]), upperBound);
+        /*
+        switch (selectedTrans) {
+        case 0:
+          _values[i + offset] = fmin(fmax(lowerBound, _values[i + offset]), upperBound);
+          break;
+        case 1:
+          _values[i + offset] = 1 / (1 + exp(-_values[i + offset] / factor)) * intervalLen + leftLimit;
+          _values[i + offset] = fmin(fmax(lowerBound, _values[i + offset]), upperBound);
+          break;
+        case 2:
+          _values[i + offset] = tanh(_values[i + offset] / factor) * intervalLen + leftLimit;
+          _values[i + offset] = fmin(fmax(lowerBound, _values[i + offset]), upperBound);
+          break;
+        default:
+          _values[i + offset] = _values[i + offset];
+          break;
+        }
+        */
+
+        // TODO: when the cropped part is large, warn preCICE against fake convergence(accelerate to the boundary for consecutive time windows, thus residual is zero when it's actually not converged)
+      }
+    } else {
+      // TODO: when only one side is bounded
+    }
+    offset += size;
+  }
+}
 /** ---------------------------------------------------------------------------------------------
  *         updateDifferenceMatrices()
  *
@@ -290,6 +387,7 @@ void BaseQNAcceleration::performAcceleration(
 
   // scale data values (and secondary data values)
   concatenateCouplingData(cplData, _dataIDs, _values, _oldValues);
+  projectFWInput(cplData, _dataIDs, _lowerBounds, _upperBounds);
 
   /** update the difference matrices V,W  includes:
    * scaling of values
@@ -310,6 +408,7 @@ void BaseQNAcceleration::performAcceleration(
     _values = _residuals;
 
     computeUnderrelaxationSecondaryData(cplData);
+    projectBWInput(cplData, _dataIDs, _lowerBounds, _upperBounds);
   } else {
     PRECICE_DEBUG("   Performing quasi-Newton Step");
 
@@ -374,7 +473,7 @@ void BaseQNAcceleration::performAcceleration(
      * apply quasiNewton update
      */
     _values = _oldValues + xUpdate + _residuals; // = x^k + delta_x + r^k - q^k
-
+    projectBWInput(cplData, _dataIDs, _lowerBounds, _upperBounds);
     // pending deletion: delete old V, W matrices if timeWindowsReused = 0
     // those were only needed for the first iteration (instead of underrelax.)
     if (_firstIteration && _timeWindowsReused == 0 && not _forceInitialRelaxation) {
@@ -477,7 +576,9 @@ void BaseQNAcceleration::iterationsConverged(
   // this has to be done in iterations converged, as PP won't be called any more if
   // convergence was achieved
   concatenateCouplingData(cplData, _dataIDs, _values, _oldValues);
-  updateDifferenceMatrices(cplData);
+  auto cplDataCopy = cplData;
+  projectFWInput(cplDataCopy, _dataIDs, _lowerBounds, _upperBounds);
+  updateDifferenceMatrices(cplDataCopy);
 
   if (not _matrixCols.empty() && _matrixCols.front() == 0) { // Did only one iteration
     _matrixCols.pop_front();

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -70,6 +70,8 @@ public:
       int                     filter,
       double                  singularityLimit,
       std::vector<int>        dataIDs,
+      std::map<int, double>   lowerBounds,
+      std::map<int, double>   upperBounds,
       impl::PtrPreconditioner preconditioner);
 
   /**
@@ -104,7 +106,16 @@ public:
    * Has to be called after every implicit coupling iteration.
    */
   virtual void performAcceleration(DataMap &cplData);
-
+  /**
+   * @brief Transform the bounded input data into the inf range.
+   */
+  virtual void projectFWInput(DataMap &cplData, const std::vector<DataID> &dataIDs, std::map<int, double> lowerBounds,
+                              std::map<int, double> upperBounds);
+  /**
+   * @brief Trandform the output data backward from inf to certain range.
+   */
+  virtual void projectBWInput(DataMap &cplData, const std::vector<DataID> &dataIDs, std::map<int, double> lowerBounds,
+                              std::map<int, double> upperBounds);
   /**
    * @brief Marks a iteration sequence as converged.
    *
@@ -215,6 +226,12 @@ protected:
    * and the corresponding (older) iteration is removed.
    */
   double _singularityLimit;
+
+  /// @brief store the lower limit for each dataID
+  std::map<int, double> _lowerBounds;
+
+  /// @brief store the upper limit for each dataID
+  std::map<int, double> _upperBounds;
 
   /** @brief Indices (of columns in W, V matrices) of 1st iterations of time windows.
    *

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -32,9 +32,11 @@ IQNILSAcceleration::IQNILSAcceleration(
     int                     filter,
     double                  singularityLimit,
     std::vector<int>        dataIDs,
+    std::map<int, double>   lowerBounds,
+    std::map<int, double>   upperBounds,
     impl::PtrPreconditioner preconditioner)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, std::move(dataIDs), std::move(preconditioner))
+                         filter, singularityLimit, std::move(dataIDs), lowerBounds, upperBounds, move(preconditioner))
 {
 }
 

--- a/src/acceleration/IQNILSAcceleration.hpp
+++ b/src/acceleration/IQNILSAcceleration.hpp
@@ -33,6 +33,8 @@ public:
       int                     filter,
       double                  singularityLimit,
       std::vector<int>        dataIDs,
+      std::map<int, double>   lowerBounds,
+      std::map<int, double>   upperBounds,
       impl::PtrPreconditioner preconditioner);
 
   virtual ~IQNILSAcceleration() {}

--- a/src/acceleration/IQNIMVJAcceleration.cpp
+++ b/src/acceleration/IQNIMVJAcceleration.cpp
@@ -36,6 +36,8 @@ IQNIMVJAcceleration::IQNIMVJAcceleration(
     int                            filter,
     double                         singularityLimit,
     std::vector<int>               dataIDs,
+    std::map<int, double>          lowerBounds,
+    std::map<int, double>          upperBounds,
     const impl::PtrPreconditioner &preconditioner,
     bool                           alwaysBuildJacobian,
     int                            imvjRestartType,
@@ -43,7 +45,7 @@ IQNIMVJAcceleration::IQNIMVJAcceleration(
     int                            RSLSreusedTimeWindows,
     double                         RSSVDtruncationEps)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, std::move(dataIDs), preconditioner),
+                         filter, singularityLimit, std::move(dataIDs), lowerBounds, upperBounds, preconditioner),
       //  _secondaryOldXTildes(),
       _invJacobian(),
       _oldInvJacobian(),

--- a/src/acceleration/IQNIMVJAcceleration.hpp
+++ b/src/acceleration/IQNIMVJAcceleration.hpp
@@ -49,6 +49,8 @@ public:
       int                            filter,
       double                         singularityLimit,
       std::vector<int>               dataIDs,
+      std::map<int, double>          lowerBounds,
+      std::map<int, double>          upperBounds,
       const impl::PtrPreconditioner &preconditioner,
       bool                           alwaysBuildJacobian,
       int                            imvjRestartType,

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -57,6 +57,8 @@ private:
   const std::string ATTR_MESH;
   const std::string ATTR_SCALING;
   const std::string ATTR_VALUE;
+  const std::string ATTR_MIN;
+  const std::string ATTR_MAX;
   const std::string ATTR_ENFORCE;
   const std::string ATTR_SINGULARITYLIMIT;
   const std::string ATTR_TYPE;
@@ -99,6 +101,8 @@ private:
   struct ConfigurationData {
     std::vector<int>      dataIDs;
     std::map<int, double> scalings;
+    std::map<int, double> lowerBounds;
+    std::map<int, double> upperBounds;
     std::string           type;
     double                relaxationFactor           = 0;
     bool                  forceInitialRelaxation     = false;

--- a/src/acceleration/test/AccelerationIntraCommTest.cpp
+++ b/src/acceleration/test/AccelerationIntraCommTest.cpp
@@ -52,6 +52,12 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
+  std::map<int, double> lowerBounds;
+  lowerBounds.insert(std::make_pair(dataIDs[0], -1.0e16));
+  lowerBounds.insert(std::make_pair(dataIDs[1], -1.0e16));
+  std::map<int, double> upperBounds;
+  upperBounds.insert(std::make_pair(dataIDs[0], 1.0e16));
+  upperBounds.insert(std::make_pair(dataIDs[1], 1.0e16));
   std::vector<double> factors;
   factors.resize(2, 1.0);
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
@@ -61,7 +67,7 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                        timeWindowsReused, filter, singularityLimit, dataIDs, prec);
+                        timeWindowsReused, filter, singularityLimit, dataIDs, lowerBounds, upperBounds, prec);
 
   Eigen::VectorXd dcol1;
   Eigen::VectorXd fcol1;
@@ -289,6 +295,12 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
+  std::map<int, double> lowerBounds;
+  lowerBounds.insert(std::make_pair(dataIDs[0], -1.0e16));
+  lowerBounds.insert(std::make_pair(dataIDs[1], -1.0e16));
+  std::map<int, double> upperBounds;
+  upperBounds.insert(std::make_pair(dataIDs[0], 1.0e16));
+  upperBounds.insert(std::make_pair(dataIDs[1], 1.0e16));
   std::vector<double> factors;
   factors.resize(2, 1.0);
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
@@ -298,7 +310,7 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                         timeWindowsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
+                         timeWindowsReused, filter, singularityLimit, dataIDs, lowerBounds, upperBounds, prec, alwaysBuildJacobian,
                          restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps);
 
   Eigen::VectorXd dcol1;
@@ -575,6 +587,12 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   std::vector<int> dataIDs;
   dataIDs.push_back(4);
   dataIDs.push_back(5);
+  std::map<int, double> lowerBounds;
+  lowerBounds.insert(std::make_pair(dataIDs[0], -1.0e16));
+  lowerBounds.insert(std::make_pair(dataIDs[1], -1.0e16));
+  std::map<int, double> upperBounds;
+  upperBounds.insert(std::make_pair(dataIDs[0], 1.0e16));
+  upperBounds.insert(std::make_pair(dataIDs[1], 1.0e16));
   PtrPreconditioner _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(-1));
   std::vector<int>  vertexOffsets{0, 11, 22, 22};
 
@@ -582,7 +600,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                         timeWindowsReused, filter, singularityLimit, dataIDs, _preconditioner, alwaysBuildJacobian,
+                         timeWindowsReused, filter, singularityLimit, dataIDs, lowerBounds, upperBounds, _preconditioner, alwaysBuildJacobian,
                          restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps);
 
   mesh::PtrData displacements(new mesh::Data("dvalues", -1, 2));
@@ -1048,6 +1066,10 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   bool             enforceInitialRelaxation = false;
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
+  std::map<int, double> lowerBounds;
+  lowerBounds.insert(std::make_pair(dataIDs[0], -1.0e16));
+  std::map<int, double> upperBounds;
+  upperBounds.insert(std::make_pair(dataIDs[0], 1.0e16));
   std::vector<double> factors;
   factors.resize(1.0, 1.0);
   PtrPreconditioner prec(new ConstantPreconditioner(factors));
@@ -1057,7 +1079,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration acc(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                         timeWindowsReused, filter, singularityLimit, dataIDs, prec);
+                         timeWindowsReused, filter, singularityLimit, dataIDs, lowerBounds, upperBounds, prec);
 
   mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
 

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -53,13 +53,19 @@ void testIQNIMVJPP(bool exchangeSubsteps)
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
+  std::map<int, double> lowerBounds;
+  lowerBounds.insert(std::make_pair(0, -1.0e16));
+  lowerBounds.insert(std::make_pair(1, -1.0e16));
+  std::map<int, double> upperBounds;
+  upperBounds.insert(std::make_pair(0, 1.0e16));
+  upperBounds.insert(std::make_pair(1, 1.0e16));
   std::vector<double> factors;
   factors.resize(2, 1.0);
   impl::PtrPreconditioner prec(new impl::ConstantPreconditioner(factors));
   mesh::PtrMesh           dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                         timeWindowsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
+                         timeWindowsReused, filter, singularityLimit, dataIDs, lowerBounds, upperBounds, prec, alwaysBuildJacobian,
                          restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps);
 
   Eigen::VectorXd fcol1;
@@ -147,6 +153,12 @@ void testVIQNPP(bool exchangeSubsteps)
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   dataIDs.push_back(1);
+  std::map<int, double> lowerBounds;
+  lowerBounds.insert(std::make_pair(0, -1.0e16));
+  lowerBounds.insert(std::make_pair(1, -1.0e16));
+  std::map<int, double> upperBounds;
+  upperBounds.insert(std::make_pair(0, 1.0e16));
+  upperBounds.insert(std::make_pair(1, 1.0e16));
   std::vector<double> factors;
   factors.resize(2, 1.0);
   acceleration::impl::PtrPreconditioner prec(new acceleration::impl::ConstantPreconditioner(factors));
@@ -157,7 +169,7 @@ void testVIQNPP(bool exchangeSubsteps)
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                        timeWindowsReused, filter, singularityLimit, dataIDs, prec);
+                        timeWindowsReused, filter, singularityLimit, dataIDs, lowerBounds, upperBounds, prec);
 
   mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
   mesh::PtrData forces(new mesh::Data("fvalues", -1, 1));

--- a/tests/quasi-newton/helpers.hpp
+++ b/tests/quasi-newton/helpers.hpp
@@ -11,4 +11,6 @@ void runTestQN(std::string const &config, TestContext const &context);
 
 void runTestQNEmptyPartition(std::string const &config, TestContext const &context);
 
+void runTestQNBoundedValue(std::string const &config, TestContext const &context);
+
 #endif

--- a/tests/quasi-newton/serial/TestQN11.cpp
+++ b/tests/quasi-newton/serial/TestQN11.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "../helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(QuasiNewton)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_CASE(TestQN11)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  runTestQNBoundedValue(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/quasi-newton/serial/TestQN11.xml
+++ b/tests/quasi-newton/serial/TestQN11.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data1" />
+  <data:scalar name="Data2" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data1" mesh="MeshOne" />
+    <read-data name="Data2" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor direction="read" from="MeshOne" to="MeshTwo" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshTwo" to="MeshOne" constraint="conservative" />
+    <write-data name="Data2" mesh="MeshTwo" />
+    <read-data name="Data1" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <max-iterations value="200" />
+    <absolute-convergence-measure limit="1e-8" data="Data1" mesh="MeshOne" />
+    <acceleration:IQN-IMVJ>
+      <data name="Data2" mesh="MeshOne" lower-bound="-1" upper-bound="1"/>
+      <filter type="QR2" limit="1e-3" />
+      <initial-relaxation value="0.2" />
+      <max-used-iterations value="2" />
+      <preconditioner type="residual-sum"/>
+      <time-windows-reused value="1" />
+      <imvj-restart-mode truncation-threshold="0.0001" chunk-size="8" reused-time-windows-at-restart="8" type="RS-SVD"/>
+    </acceleration:IQN-IMVJ>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -78,6 +78,7 @@ target_sources(testprecice
     tests/quasi-newton/serial/DefaultConfig.cpp
     tests/quasi-newton/serial/TestQN1.cpp
     tests/quasi-newton/serial/TestQN10.cpp
+    tests/quasi-newton/serial/TestQN11.cpp
     tests/quasi-newton/serial/TestQN2.cpp
     tests/quasi-newton/serial/TestQN3.cpp
     tests/quasi-newton/serial/TestQN4.cpp


### PR DESCRIPTION
## Main changes of this PR
Add cropping and (possible) transformations in acceleration methods, to limit the post-processed data inside the required range.

## Motivation and additional information
### Motivation
When we are modelling physical scenarios, we live with bounded values, such as concentration(in [0,1]) of phase etc. 

If the user involves these values into acceleration methods, there exists the possibility, that the output from acceleration methods would go beyond the certain range. Then we will send irrational input into the solver, which might result in an error info from solver.

### Ideas
Our basic idea is to transform the bounded data into infinity before they are post-processed, and do backward transformation after the acceleration. This is similar to pre-conditioning, but a non-linear one. 

To do the transformation from the actual interval is not possible when the interval is closed(e.g. for concentration), so I extend the interval at both sides a little bit further to execute the transformation and  after the backward transformation, I crop the part which exceed the actual interval. 
Currently, I have only implemented the transformation and cropping for QN-methods for both-sides bounded values, later I want to add the cropping for relaxation methods and extend the method for one-side bounded values.

I compared only cropping and transformation+cropping for IQN-IMVJ with simple test case `tests/quasi-newton/serial/TestQN11.xml`  and also with more complex multi-phase porous-media simulation. These two methods could both work for the test case, even when I adjusted the shape of the function. But for the porous-media case, I observed that the transformation+cropping helped with the convergence, when pure cropping couldn't do this (so it only stopped the solver from breaking down). But these are only data-based conclusions, not analytic ones.

Different transformation functions and extended interval widths are also compared. The logistic function with 0.1 extension on both sides works well for most occasions.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I removed the unnecessary code snippets in comments.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
