### PR TITLE
Refactor time processing

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -228,7 +228,7 @@ add_precice_test(
 add_precice_test(
   NAME cplscheme
   ARGUMENTS "--run_test=CplSchemeTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_NORMAL}
+  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
   )
 add_precice_test(
   NAME io

--- a/docs/changelog/1954.md
+++ b/docs/changelog/1954.md
@@ -1,0 +1,1 @@
+- Improved robustness of time handling for simulations with many time steps or time windows.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -433,7 +433,7 @@ bool BaseCouplingScheme::addComputedTime(
                 "in the remaining of this time window. "
                 "Did you restrict your time step size, \"dt = min(preciceDt, solverDt)\"? "
                 "For more information, consult the adapter example in the preCICE documentation.",
-                timeToAdd, getNextTimeWindowSize());
+                timeToAdd, getNextTimeStepMaxSize());
 
   // add time interval that has been computed in the solver to get the correct time remainder
   _time.progressBy(timeToAdd);

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -506,11 +506,7 @@ double BaseCouplingScheme::getNextTimeStepMaxSize() const
 bool BaseCouplingScheme::isCouplingOngoing() const
 {
   bool timestepsLeft = (_maxTimeWindows >= _timeWindows) || (_maxTimeWindows == UNDEFINED_TIME_WINDOWS);
-  bool timeLeft      = !_time.reachedEnd();
-  PRECICE_WARN("tsl:{} tl:{} t:{:e} mt:{:e} umt:{:e} is0:{} isabs0:{}", timestepsLeft, timeLeft, _time.time(), _maxTime, _time.untilTime(_maxTime),
-               math::equals(_time.untilTime(_maxTime), 0.0),
-               math::equals(std::abs(_time.untilTime(_maxTime)), 0.0));
-  return timestepsLeft && timeLeft;
+  return timestepsLeft && !_time.reachedEnd();
 }
 
 bool BaseCouplingScheme::isTimeWindowComplete() const

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -210,6 +210,7 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
 
 void BaseCouplingScheme::receiveDataForWindowEnd(const m2n::PtrM2N &m2n, const DataMap &receiveData)
 {
+  // @TODO This is a hack required until https://github.com/precice/precice/issues/1957
   // buffer current time
   const impl::TimeHandler oldTime = _time;
   // set _time state to point to end of this window such that _time in receiveData is at end of window

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -2,9 +2,6 @@
 
 #include <Eigen/Core>
 #include <algorithm>
-#include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics.hpp>
-#include <boost/accumulators/statistics/sum_kahan.hpp>
 #include <map>
 #include <memory>
 #include <set>
@@ -18,6 +15,7 @@
 #include "acceleration/SharedPointer.hpp"
 #include "impl/ConvergenceMeasure.hpp"
 #include "impl/SharedPointer.hpp"
+#include "impl/TimeHandler.hpp"
 #include "io/TXTTableWriter.hpp"
 #include "logging/Logger.hpp"
 #include "m2n/M2N.hpp"
@@ -414,11 +412,6 @@ private:
   /// Maximum time being computed. End of simulation is reached, if getTime() == _maxTime
   double _maxTime;
 
-  using KahanAccumulator = boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::sum_kahan>>;
-
-  /// time of beginning of the current time window
-  KahanAccumulator _timeWindowStartTime;
-
   /// Number of time windows that have to be computed. End of simulation is reached, if _timeWindows == _maxTimeWindows
   int _maxTimeWindows;
 
@@ -431,8 +424,8 @@ private:
   /// time window size of next window (acts as buffer for time windows size provided by first participant, if using first participant method)
   double _nextTimeWindowSize = UNDEFINED_TIME_WINDOW_SIZE;
 
-  /// Current time
-  KahanAccumulator _time;
+  /// Time handler
+  impl::TimeHandler _time;
 
   /// Lower limit of iterations during one time window. Prevents convergence if _iterations < _minIterations.
   int _minIterations = -1;

--- a/src/cplscheme/impl/TimeHandler.hpp
+++ b/src/cplscheme/impl/TimeHandler.hpp
@@ -91,7 +91,7 @@ public:
   bool reachedEnd() const
   {
     if (!_maxTime) {
-      return false;
+      return false; // Directly return preventing lossy computations
     }
     return math::equals(untilTime(*_maxTime), 0.0);
   }
@@ -105,7 +105,7 @@ public:
   {
     double maxDt = untilProgress(timeWindowSize);
     if (!_maxTime) {
-      return maxDt;
+      return maxDt; // Return to prevent further lossy computations
     }
     // Truncate by max Time
     return std::min(maxDt, untilEnd());
@@ -123,10 +123,10 @@ public:
     */
   double untilEnd() const
   {
-    if (_maxTime) {
-      return untilTime(*_maxTime);
+    if (!_maxTime) {
+      return std::numeric_limits<double>::max();
     }
-    return std::numeric_limits<double>::max();
+    return untilTime(*_maxTime);
   }
 
   /// Returns the window progress as a double

--- a/src/cplscheme/impl/TimeHandler.hpp
+++ b/src/cplscheme/impl/TimeHandler.hpp
@@ -148,7 +148,7 @@ public:
   /// Returns the current time as a double
   double time() const
   {
-    return (_windowStart + _windowProgress).value();
+    return (_windowStart + _windowProgress.value()).value();
   }
 
   /// @}

--- a/src/cplscheme/impl/TimeHandler.hpp
+++ b/src/cplscheme/impl/TimeHandler.hpp
@@ -1,12 +1,39 @@
 #pragma once
 
+#include <optional>
+
+#include "math/differences.hpp"
 #include "utils/DoubleAggregator.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice::cplscheme::impl {
 
-/// Handler for stepping forward in time using time windows
+/** Handler for stepping forward in time using time windows
+ *
+ * The handler respects a maximum time if it was set in the constructor.
+ *
+ * The goal of this class is to handle all computation around time and time steps
+ * with maximizing accuracy and simplifying calling code.
+ */
 class TimeHandler {
 public:
+  TimeHandler() = default;
+
+  /// Constructor for setting an optional maximum time
+  TimeHandler(std::optional<double> maxTime)
+      : _maxTime(maxTime)
+  {
+  }
+
+  TimeHandler(const TimeHandler &) = default;
+  TimeHandler(TimeHandler &&)      = default;
+
+  TimeHandler &operator=(const TimeHandler &) = default;
+  TimeHandler &operator=(TimeHandler &&) = default;
+
+  /// @name State altering functions
+  /// @{
+
   /// Resets the handler to the given time
   void resetTo(double timeStart)
   {
@@ -20,39 +47,86 @@ public:
     _windowProgress.add(dt);
   }
 
-  /// Complete the time window, but use the exact progress instead of the accumulated one
-  void completeTimeWindowExact(double exactProgress)
-  {
-    // @TODO prevent major differences
-    _windowStart.add(exactProgress);
-    resetProgress();
-  }
-
-  /// Complete the time window using the accumulated progress
-  void completeTimeWindow()
-  {
-    _windowStart.add(_windowProgress);
-    resetProgress();
-  }
-
   /// Resets the progress of the time window back to 0
   void resetProgress()
   {
     _windowProgress = 0.0;
   }
 
-  /// Returns the time difference until the progress reaches the given window size
-  double untilProgress(double windowSize) const
+  /** Complete the time window moving the start of the time window
+   *
+   * The given exact time window size will be used if it is approximately equal to
+   * the accumulated progress.
+   */
+  void completeTimeWindow(double timeWindowSize)
   {
-    // rearranged version of: windowSize - _windowProgress
-    return -(_windowProgress - windowSize).value();
+    // Use the exact time window if possible
+    if (math::equals(windowProgress(), timeWindowSize)) {
+      _windowStart.add(timeWindowSize);
+    } else {
+      // Handle truncated time windows in case of reaching the end of the simulation
+      // This only happens when the final time window is truncated due
+      // time window size not being a divider of max-time.
+      PRECICE_ASSERT(reachedEnd(), "This can only happened if we reach max-time", timeWindowSize, time(), _maxTime.value_or(-1));
+      _windowStart.add(_windowProgress);
+    }
+    resetProgress();
+  }
+
+  /// @}
+  /// @name Queries about reaching ends
+  /// @{
+
+  /** Has the end of the time window been reached?
+   * This respects max time.
+   */
+  bool reachedEndOfWindow(double timeWindowSize) const
+  {
+    return math::equals(untilWindowEnd(timeWindowSize), 0.0);
+  }
+
+  /** Has the end of the overall time been reached?
+   * This is always false if no max time has been defined.
+   */
+  bool reachedEnd() const
+  {
+    if (!_maxTime) {
+      return false;
+    }
+    return math::equals(untilTime(*_maxTime), 0.0);
+  }
+
+  /// @}
+  /// @name Time differences
+  /// @{
+
+  /// Returns the time distance to the possibly truncated end of the current time window
+  double untilWindowEnd(double timeWindowSize) const
+  {
+    double maxDt = untilProgress(timeWindowSize);
+    if (!_maxTime) {
+      return maxDt;
+    }
+    // Truncate by max Time
+    return std::min(maxDt, untilEnd());
   }
 
   /// Returns the time difference until the overall time reaches the given time
-  double untilTime(double maxTime) const
+  double untilTime(double t) const
   {
     // rearranged version of: maxtime - windowStart - windowProgress
-    return -(_windowStart + _windowProgress.value() - maxTime).value();
+    return -(_windowStart + _windowProgress.value() - t).value();
+  }
+
+  /** Returns the time difference until the end of the overall time.
+    * This returns infinity if there is no maximum time defined.
+    */
+  double untilEnd() const
+  {
+    if (_maxTime) {
+      return untilTime(*_maxTime);
+    }
+    return std::numeric_limits<double>::max();
   }
 
   /// Returns the window progress as a double
@@ -60,6 +134,10 @@ public:
   {
     return _windowProgress.value();
   }
+
+  /// @}
+  /// @name Time points
+  /// @{
 
   /// Returns the window start as a double
   double windowStart() const
@@ -73,9 +151,22 @@ public:
     return (_windowStart + _windowProgress).value();
   }
 
+  /// @}
+
 private:
+  /// The optional maximum time
+  std::optional<double> _maxTime = std::nullopt;
+  /// The aggregator for the start of a time window, handles timestep.
   utils::DoubleAggregator _windowStart;
+  /// The aggregator progress inside a time window, handles substeps.
   utils::DoubleAggregator _windowProgress;
+
+  /// Returns the time difference until the progress reaches the given window size
+  double untilProgress(double windowSize) const
+  {
+    // rearranged version of: windowSize - _windowProgress
+    return -(_windowProgress - windowSize).value();
+  }
 };
 
 } // namespace precice::cplscheme::impl

--- a/src/cplscheme/impl/TimeHandler.hpp
+++ b/src/cplscheme/impl/TimeHandler.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "utils/DoubleAggregator.hpp"
+
+namespace precice::cplscheme::impl {
+
+/// Handler for stepping forward in time using time windows
+class TimeHandler {
+public:
+  /// Resets the handler to the given time
+  void resetTo(double timeStart)
+  {
+    _windowStart = timeStart;
+    resetProgress();
+  }
+
+  /// Progress the time window by the given amount
+  void progressBy(double dt)
+  {
+    _windowProgress.add(dt);
+  }
+
+  /// Complete the time window, but use the exact progress instead of the accumulated one
+  void completeTimeWindowExact(double exactProgress)
+  {
+    // @TODO prevent major differences
+    _windowStart.add(exactProgress);
+    resetProgress();
+  }
+
+  /// Complete the time window using the accumulated progress
+  void completeTimeWindow()
+  {
+    _windowStart.add(_windowProgress);
+    resetProgress();
+  }
+
+  /// Resets the progress of the time window back to 0
+  void resetProgress()
+  {
+    _windowProgress = 0.0;
+  }
+
+  /// Returns the time difference until the progress reaches the given window size
+  double untilProgress(double windowSize) const
+  {
+    // rearranged version of: windowSize - _windowProgress
+    return -(_windowProgress - windowSize).value();
+  }
+
+  /// Returns the time difference until the overall time reaches the given time
+  double untilTime(double maxTime) const
+  {
+    // rearranged version of: maxtime - windowStart - windowProgress
+    return -(_windowStart + _windowProgress.value() - maxTime).value();
+  }
+
+  /// Returns the window progress as a double
+  double windowProgress() const
+  {
+    return _windowProgress.value();
+  }
+
+  /// Returns the window start as a double
+  double windowStart() const
+  {
+    return _windowStart.value();
+  }
+
+  /// Returns the current time as a double
+  double time() const
+  {
+    return (_windowStart + _windowProgress).value();
+  }
+
+private:
+  utils::DoubleAggregator _windowStart;
+  utils::DoubleAggregator _windowProgress;
+};
+
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/tests/TimeHandlerTests.cpp
+++ b/src/cplscheme/tests/TimeHandlerTests.cpp
@@ -137,8 +137,7 @@ BOOST_AUTO_TEST_CASE(LargeTWNormalTS)
       BOOST_TEST(th.time() == (i - 1) * tws + j * dt);
       BOOST_TEST(th.untilWindowEnd(tws) == tws - dt * j);
     }
-    BOOST_TEST(th.untilWindowEnd(tws) == 0, boost::test_tools::tolerance(1e-13));
-    //BOOST_TEST(th.reachedEndOfWindow(tws)); This currently fails
+    BOOST_TEST(th.reachedEndOfWindow(tws));
     BOOST_TEST(th.time() == tws * i);
     th.completeTimeWindow(tws);
     BOOST_TEST(th.time() == tws * i);

--- a/src/cplscheme/tests/TimeHandlerTests.cpp
+++ b/src/cplscheme/tests/TimeHandlerTests.cpp
@@ -11,18 +11,24 @@ BOOST_AUTO_TEST_CASE(ManyTinyTimesteps)
   PRECICE_TEST(1_rank);
   TimeHandler th;
 
-  double tws = 1e-7;
-  int    twc = 1'000'000;
+  double tws        = 1e-7;
+  int    twc        = 1'000'000;
+  int    checkEvery = 1000;
 
   for (int tw = 1; tw <= twc; ++tw) {
-    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     th.progressBy(tws);
-    BOOST_TEST(th.time() == tws * tw);
-    BOOST_TEST(th.reachedEndOfWindow(tws));
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST(th.time() == tws * tw);
+      BOOST_TEST(th.reachedEndOfWindow(tws));
+    }
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * tw);
-    BOOST_TEST(!th.reachedEndOfWindow(tws));
-    BOOST_TEST(th.windowProgress() == 0.0);
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST(th.time() == tws * tw);
+      BOOST_TEST(!th.reachedEndOfWindow(tws));
+      BOOST_TEST(th.windowProgress() == 0.0);
+    }
   }
 }
 
@@ -31,18 +37,24 @@ BOOST_AUTO_TEST_CASE(ManyBigTimesteps)
   PRECICE_TEST(1_rank);
   TimeHandler th;
 
-  double tws = 1000.0;
-  int    twc = 1'000'000;
+  double tws        = 1000.0;
+  int    twc        = 1'000'000;
+  int    checkEvery = 1000;
 
   for (int tw = 1; tw <= twc; ++tw) {
-    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     th.progressBy(tws);
-    BOOST_TEST(th.time() == tws * tw);
-    BOOST_TEST(th.reachedEndOfWindow(tws));
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST(th.time() == tws * tw);
+      BOOST_TEST(th.reachedEndOfWindow(tws));
+    }
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * tw);
-    BOOST_TEST(!th.reachedEndOfWindow(tws));
-    BOOST_TEST(th.windowProgress() == 0.0);
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST(th.time() == tws * tw);
+      BOOST_TEST(!th.reachedEndOfWindow(tws));
+      BOOST_TEST(th.windowProgress() == 0.0);
+    }
   }
 }
 
@@ -51,13 +63,13 @@ BOOST_AUTO_TEST_CASE(ManyMixedTimesteps)
   PRECICE_TEST(1_rank);
   TimeHandler th;
 
-  double tws1 = 0.01;
-  double tws2 = 0.005;
-  int    twc  = 1'000'000;
+  double tws1       = 0.01;
+  double tws2       = 0.005;
+  int    twc        = 1'000'000;
+  int    checkEvery = 1000;
 
   int n1 = 0, n2 = 0;
   for (int tw = 1; tw <= twc; ++tw) {
-    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     double tws;
     if (tw % 2 == 1) {
       tws = tws1;
@@ -66,16 +78,22 @@ BOOST_AUTO_TEST_CASE(ManyMixedTimesteps)
       tws = tws2;
       ++n2;
     }
-    BOOST_TEST_INFO_SCOPE("this time-window size is " << tws);
-
     th.progressBy(tws);
     double t = n1 * tws1 + n2 * tws2;
-    BOOST_TEST(th.time() == t);
-    BOOST_TEST(th.reachedEndOfWindow(tws));
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST_INFO_SCOPE("this time-window size is " << tws);
+      BOOST_TEST(th.time() == t);
+      BOOST_TEST(th.reachedEndOfWindow(tws));
+    }
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == t);
-    BOOST_TEST(th.windowProgress() == 0.0);
-    BOOST_TEST(!th.reachedEndOfWindow(tws));
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST_INFO_SCOPE("this time-window size is " << tws);
+      BOOST_TEST(th.time() == t);
+      BOOST_TEST(th.windowProgress() == 0.0);
+      BOOST_TEST(!th.reachedEndOfWindow(tws));
+    }
   }
 }
 
@@ -86,26 +104,35 @@ BOOST_AUTO_TEST_CASE(NormalTWSmallTS)
   PRECICE_TEST(1_rank);
   TimeHandler th;
 
-  double tws = 10.0;
-  double tss = 0.1;
-  int    twc = 10'000;
-  int    tsc = 100;
+  double tws        = 10.0;
+  double tss        = 0.1;
+  int    twc        = 10'000;
+  int    tsc        = 100;
+  int    checkEvery = 1000;
 
   for (int tw = 1; tw <= twc; ++tw) {
-    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
 
     for (int ts = 1; ts <= tsc; ++ts) {
-      BOOST_TEST_INFO_SCOPE("time-step " << ts << "/" << tsc);
       th.progressBy(tss);
-      BOOST_TEST(th.time() == (tw - 1) * tws + ts * tss);
-      BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * ts);
+      if (tw % checkEvery == 0) {
+        BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+        BOOST_TEST_INFO_SCOPE("time-step " << ts << "/" << tsc);
+        BOOST_TEST(th.time() == (tw - 1) * tws + ts * tss);
+        BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * ts);
+      }
     }
-    BOOST_TEST(th.reachedEndOfWindow(tws));
-    BOOST_TEST(th.time() == tws * tw);
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST(th.reachedEndOfWindow(tws));
+      BOOST_TEST(th.time() == tws * tw);
+    }
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * tw);
-    BOOST_TEST(!th.reachedEndOfWindow(tws));
-    BOOST_TEST(th.windowProgress() == 0.0);
+    if (tw % checkEvery == 0) {
+      BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+      BOOST_TEST(th.time() == tws * tw);
+      BOOST_TEST(!th.reachedEndOfWindow(tws));
+      BOOST_TEST(th.windowProgress() == 0.0);
+    }
   }
 }
 
@@ -114,24 +141,28 @@ BOOST_AUTO_TEST_CASE(SmallTWTinyTS)
   PRECICE_TEST(1_rank);
   TimeHandler th;
 
-  double tws = 0.001;
-  double tss = 1e-7;
-  int    twc = 1'000;
-  int    tsc = 10'000;
+  double tws        = 0.001;
+  double tss        = 1e-7;
+  int    twc        = 100;
+  int    tsc        = 10'000;
+  int    checkEvery = 1000;
 
-  for (int i = 1; i <= twc; ++i) {
-    BOOST_TEST_INFO_SCOPE("time-window " << i << "/" << twc);
-
-    for (int j = 1; j <= tsc; ++j) {
-      BOOST_TEST_INFO_SCOPE("time-step " << j << "/" << tsc);
+  for (int tw = 1; tw <= twc; ++tw) {
+    for (int ts = 1; ts <= tsc; ++ts) {
       th.progressBy(tss);
-      BOOST_TEST(th.time() == (i - 1) * tws + j * tss);
-      BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * j);
+      if (ts % checkEvery == 0) {
+        BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+        BOOST_TEST_INFO_SCOPE("time-step " << ts << "/" << tsc);
+        BOOST_TEST(th.time() == (tw - 1) * tws + ts * tss);
+        BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * ts);
+      }
     }
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     BOOST_TEST(th.reachedEndOfWindow(tws));
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+    BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(!th.reachedEndOfWindow(tws));
     BOOST_TEST(th.windowProgress() == 0.0);
   }
@@ -142,22 +173,27 @@ BOOST_AUTO_TEST_CASE(LargeTWNormalTS)
   PRECICE_TEST(1_rank);
   TimeHandler th;
 
-  double tws = 1000;
-  double tss = 0.1;
-  int    twc = 100;
-  int    tsc = 10'000;
+  double tws        = 1000;
+  double tss        = 0.1;
+  int    twc        = 100;
+  int    tsc        = 10'000;
+  int    checkEvery = 1000;
 
   for (int tw = 1; tw <= twc; ++tw) {
-    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
-
     for (int ts = 1; ts <= tsc; ++ts) {
       th.progressBy(tss);
-      BOOST_TEST(th.time() == (tw - 1) * tws + ts * tss);
-      BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * ts);
+      if (ts % checkEvery == 0) {
+        BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
+        BOOST_TEST_INFO_SCOPE("time-step " << ts << "/" << tsc);
+        BOOST_TEST(th.time() == (tw - 1) * tws + ts * tss);
+        BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * ts);
+      }
     }
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     BOOST_TEST(th.reachedEndOfWindow(tws));
     BOOST_TEST(th.time() == tws * tw);
     th.completeTimeWindow(tws);
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(!th.reachedEndOfWindow(tws));
     BOOST_TEST(th.windowProgress() == 0.0);

--- a/src/cplscheme/tests/TimeHandlerTests.cpp
+++ b/src/cplscheme/tests/TimeHandlerTests.cpp
@@ -1,0 +1,153 @@
+#include "cplscheme/impl/TimeHandler.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(CplSchemeTests)
+BOOST_AUTO_TEST_SUITE(TimeHandler)
+
+using precice::cplscheme::impl::TimeHandler;
+
+BOOST_AUTO_TEST_CASE(ManyTinyTimesteps)
+{
+  PRECICE_TEST(1_rank);
+  TimeHandler th;
+
+  double tws = 1e-7;
+
+  for (int i = 1; i <= 1'000'000; ++i) {
+    th.progressBy(tws);
+    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.reachedEndOfWindow(tws));
+    th.completeTimeWindow(tws);
+    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(!th.reachedEndOfWindow(tws));
+    BOOST_TEST(th.windowProgress() == 0.0);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ManyBigTimesteps)
+{
+  PRECICE_TEST(1_rank);
+  TimeHandler th;
+
+  double tws = 1000.0;
+
+  for (int i = 1; i <= 1'000'000; ++i) {
+    th.progressBy(tws);
+    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.reachedEndOfWindow(tws));
+    th.completeTimeWindow(tws);
+    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(!th.reachedEndOfWindow(tws));
+    BOOST_TEST(th.windowProgress() == 0.0);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(ManyMixedTimesteps)
+{
+  PRECICE_TEST(1_rank);
+  TimeHandler th;
+
+  double tws1 = 0.01;
+  double tws2 = 0.005;
+
+  int n1 = 0, n2 = 0;
+  for (int i = 1; i <= 1'000'000; ++i) {
+    double tws;
+    if (i % 2 == 1) {
+      tws = tws1;
+      ++n1;
+    } else {
+      tws = tws2;
+      ++n2;
+    }
+
+    th.progressBy(tws);
+    double t = n1 * tws1 + n2 * tws2;
+    BOOST_TEST(th.time() == t);
+    BOOST_TEST(th.reachedEndOfWindow(tws));
+    th.completeTimeWindow(tws);
+    BOOST_TEST(th.time() == t);
+    BOOST_TEST(th.windowProgress() == 0.0);
+    BOOST_TEST(!th.reachedEndOfWindow(tws));
+  }
+}
+
+BOOST_AUTO_TEST_SUITE(Subcycling)
+
+BOOST_AUTO_TEST_CASE(NormalTWSmallTS)
+{
+  PRECICE_TEST(1_rank);
+  TimeHandler th;
+
+  double tws = 10.0;
+  double dt  = 0.1;
+
+  for (int i = 1; i <= 10'000; ++i) {
+
+    for (int j = 1; j <= 100; ++j) {
+      th.progressBy(dt);
+      BOOST_TEST(th.time() == (i - 1) * tws + j * dt);
+      BOOST_TEST(th.untilWindowEnd(tws) == tws - dt * j);
+    }
+    BOOST_TEST(th.reachedEndOfWindow(tws));
+    BOOST_TEST(th.time() == tws * i);
+    th.completeTimeWindow(tws);
+    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(!th.reachedEndOfWindow(tws));
+    BOOST_TEST(th.windowProgress() == 0.0);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(SmallTWTinyTS)
+{
+  PRECICE_TEST(1_rank);
+  TimeHandler th;
+
+  double tws = 0.001;
+  double dt  = 1e-7;
+
+  for (int i = 1; i <= 1'000; ++i) {
+
+    for (int j = 1; j <= 10'000; ++j) {
+      th.progressBy(dt);
+      BOOST_TEST(th.time() == (i - 1) * tws + j * dt);
+      BOOST_TEST(th.untilWindowEnd(tws) == tws - dt * j);
+    }
+    BOOST_TEST(th.reachedEndOfWindow(tws));
+    BOOST_TEST(th.time() == tws * i);
+    th.completeTimeWindow(tws);
+    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(!th.reachedEndOfWindow(tws));
+    BOOST_TEST(th.windowProgress() == 0.0);
+  }
+}
+
+BOOST_AUTO_TEST_CASE(LargeTWNormalTS)
+{
+  PRECICE_TEST(1_rank);
+  TimeHandler th;
+
+  double tws = 1000;
+  double dt  = 0.1;
+
+  for (int i = 1; i <= 100; ++i) {
+
+    for (int j = 1; j <= 10'000; ++j) {
+      th.progressBy(dt);
+      BOOST_TEST(th.time() == (i - 1) * tws + j * dt);
+      BOOST_TEST(th.untilWindowEnd(tws) == tws - dt * j);
+    }
+    BOOST_TEST(th.untilWindowEnd(tws) == 0, boost::test_tools::tolerance(1e-13));
+    //BOOST_TEST(th.reachedEndOfWindow(tws)); This currently fails
+    BOOST_TEST(th.time() == tws * i);
+    th.completeTimeWindow(tws);
+    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(!th.reachedEndOfWindow(tws));
+    BOOST_TEST(th.windowProgress() == 0.0);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/cplscheme/tests/TimeHandlerTests.cpp
+++ b/src/cplscheme/tests/TimeHandlerTests.cpp
@@ -12,13 +12,15 @@ BOOST_AUTO_TEST_CASE(ManyTinyTimesteps)
   TimeHandler th;
 
   double tws = 1e-7;
+  int    twc = 1'000'000;
 
-  for (int i = 1; i <= 1'000'000; ++i) {
+  for (int tw = 1; tw <= twc; ++tw) {
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     th.progressBy(tws);
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(th.reachedEndOfWindow(tws));
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(!th.reachedEndOfWindow(tws));
     BOOST_TEST(th.windowProgress() == 0.0);
   }
@@ -30,13 +32,15 @@ BOOST_AUTO_TEST_CASE(ManyBigTimesteps)
   TimeHandler th;
 
   double tws = 1000.0;
+  int    twc = 1'000'000;
 
-  for (int i = 1; i <= 1'000'000; ++i) {
+  for (int tw = 1; tw <= twc; ++tw) {
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     th.progressBy(tws);
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(th.reachedEndOfWindow(tws));
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(!th.reachedEndOfWindow(tws));
     BOOST_TEST(th.windowProgress() == 0.0);
   }
@@ -49,17 +53,20 @@ BOOST_AUTO_TEST_CASE(ManyMixedTimesteps)
 
   double tws1 = 0.01;
   double tws2 = 0.005;
+  int    twc  = 1'000'000;
 
   int n1 = 0, n2 = 0;
-  for (int i = 1; i <= 1'000'000; ++i) {
+  for (int tw = 1; tw <= twc; ++tw) {
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
     double tws;
-    if (i % 2 == 1) {
+    if (tw % 2 == 1) {
       tws = tws1;
       ++n1;
     } else {
       tws = tws2;
       ++n2;
     }
+    BOOST_TEST_INFO_SCOPE("this time-window size is " << tws);
 
     th.progressBy(tws);
     double t = n1 * tws1 + n2 * tws2;
@@ -80,19 +87,23 @@ BOOST_AUTO_TEST_CASE(NormalTWSmallTS)
   TimeHandler th;
 
   double tws = 10.0;
-  double dt  = 0.1;
+  double tss = 0.1;
+  int    twc = 10'000;
+  int    tsc = 100;
 
-  for (int i = 1; i <= 10'000; ++i) {
+  for (int tw = 1; tw <= twc; ++tw) {
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
 
-    for (int j = 1; j <= 100; ++j) {
-      th.progressBy(dt);
-      BOOST_TEST(th.time() == (i - 1) * tws + j * dt);
-      BOOST_TEST(th.untilWindowEnd(tws) == tws - dt * j);
+    for (int ts = 1; ts <= tsc; ++ts) {
+      BOOST_TEST_INFO_SCOPE("time-step " << ts << "/" << tsc);
+      th.progressBy(tss);
+      BOOST_TEST(th.time() == (tw - 1) * tws + ts * tss);
+      BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * ts);
     }
     BOOST_TEST(th.reachedEndOfWindow(tws));
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(!th.reachedEndOfWindow(tws));
     BOOST_TEST(th.windowProgress() == 0.0);
   }
@@ -104,14 +115,18 @@ BOOST_AUTO_TEST_CASE(SmallTWTinyTS)
   TimeHandler th;
 
   double tws = 0.001;
-  double dt  = 1e-7;
+  double tss = 1e-7;
+  int    twc = 1'000;
+  int    tsc = 10'000;
 
-  for (int i = 1; i <= 1'000; ++i) {
+  for (int i = 1; i <= twc; ++i) {
+    BOOST_TEST_INFO_SCOPE("time-window " << i << "/" << twc);
 
-    for (int j = 1; j <= 10'000; ++j) {
-      th.progressBy(dt);
-      BOOST_TEST(th.time() == (i - 1) * tws + j * dt);
-      BOOST_TEST(th.untilWindowEnd(tws) == tws - dt * j);
+    for (int j = 1; j <= tsc; ++j) {
+      BOOST_TEST_INFO_SCOPE("time-step " << j << "/" << tsc);
+      th.progressBy(tss);
+      BOOST_TEST(th.time() == (i - 1) * tws + j * tss);
+      BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * j);
     }
     BOOST_TEST(th.reachedEndOfWindow(tws));
     BOOST_TEST(th.time() == tws * i);
@@ -128,19 +143,22 @@ BOOST_AUTO_TEST_CASE(LargeTWNormalTS)
   TimeHandler th;
 
   double tws = 1000;
-  double dt  = 0.1;
+  double tss = 0.1;
+  int    twc = 100;
+  int    tsc = 10'000;
 
-  for (int i = 1; i <= 100; ++i) {
+  for (int tw = 1; tw <= twc; ++tw) {
+    BOOST_TEST_INFO_SCOPE("time-window " << tw << "/" << twc);
 
-    for (int j = 1; j <= 10'000; ++j) {
-      th.progressBy(dt);
-      BOOST_TEST(th.time() == (i - 1) * tws + j * dt);
-      BOOST_TEST(th.untilWindowEnd(tws) == tws - dt * j);
+    for (int ts = 1; ts <= tsc; ++ts) {
+      th.progressBy(tss);
+      BOOST_TEST(th.time() == (tw - 1) * tws + ts * tss);
+      BOOST_TEST(th.untilWindowEnd(tws) == tws - tss * ts);
     }
     BOOST_TEST(th.reachedEndOfWindow(tws));
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     th.completeTimeWindow(tws);
-    BOOST_TEST(th.time() == tws * i);
+    BOOST_TEST(th.time() == tws * tw);
     BOOST_TEST(!th.reachedEndOfWindow(tws));
     BOOST_TEST(th.windowProgress() == 0.0);
   }

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -122,6 +122,7 @@ target_sources(preciceCore
     src/cplscheme/impl/ResidualRelativeConvergenceMeasure.cpp
     src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
     src/cplscheme/impl/SharedPointer.hpp
+    src/cplscheme/impl/TimeHandler.hpp
     src/io/Export.hpp
     src/io/ExportCSV.cpp
     src/io/ExportCSV.hpp
@@ -294,6 +295,7 @@ target_sources(preciceCore
     src/utils/ArgumentFormatter.hpp
     src/utils/Dimensions.cpp
     src/utils/Dimensions.hpp
+    src/utils/DoubleAggregator.hpp
     src/utils/EigenHelperFunctions.cpp
     src/utils/EigenHelperFunctions.hpp
     src/utils/EigenIO.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -32,6 +32,7 @@ target_sources(testprecice
     src/cplscheme/tests/RelativeConvergenceMeasureTest.cpp
     src/cplscheme/tests/ResidualRelativeConvergenceMeasureTest.cpp
     src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+    src/cplscheme/tests/TimeHandlerTests.cpp
     src/io/tests/ExportCSVTest.cpp
     src/io/tests/ExportConfigurationTest.cpp
     src/io/tests/ExportVTKTest.cpp

--- a/src/utils/DoubleAggregator.hpp
+++ b/src/utils/DoubleAggregator.hpp
@@ -1,0 +1,72 @@
+#include <cmath>
+
+namespace precice::utils {
+
+/// A Kahan Babushka Neumaier Aggregator with usability in mind
+class DoubleAggregator {
+public:
+  /// Sets the aggregator to a value
+  void operator=(double d)
+  {
+    sum        = d;
+    correction = 0.0;
+  }
+
+  /// Adds a value to the aggregator
+  void add(double d)
+  {
+    double t = sum + d;
+    if (std::abs(sum) >= std::abs(d)) {
+      correction += (sum - t) + d;
+    } else {
+      correction += (d - t) + sum;
+    }
+    sum = t;
+  }
+
+  /// Natural version of adding a value
+  void operator+=(double d)
+  {
+    add(d);
+  }
+
+  /// Natural version of subtracting a value
+  void operator-=(double d)
+  {
+    add(-d);
+  }
+
+  /// Creates a new aggregator with a value added
+  [[nodiscard]] DoubleAggregator operator+(double d) const
+  {
+    auto tmp = *this;
+    tmp.add(d);
+    return tmp;
+  }
+
+  /// Creates a new aggregator with a value subtracted
+  [[nodiscard]] DoubleAggregator operator-(double d) const
+  {
+    auto tmp = *this;
+    tmp.add(-d);
+    return tmp;
+  }
+
+  /// Retrieves the corrected sum
+  double value() const
+  {
+    return sum + correction;
+  }
+
+  /// Allows implicit casting to a double
+  operator double() const
+  {
+    return value();
+  }
+
+private:
+  double sum{0.0};
+  double correction{0.0};
+};
+
+} // namespace precice::utils

--- a/src/utils/DoubleAggregator.hpp
+++ b/src/utils/DoubleAggregator.hpp
@@ -4,7 +4,7 @@
 
 namespace precice::utils {
 
-/// A Kahan Babushka Neumaier Aggregator with usability in mind
+/// An accurate aggregator for doubles with usability in mind
 class DoubleAggregator {
 private:
   using Acc = boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::sum_kahan>>;
@@ -35,22 +35,6 @@ public:
     add(-d);
   }
 
-  /// Creates a new aggregator with a value added
-  [[nodiscard]] DoubleAggregator operator+(double d) const
-  {
-    auto tmp = *this;
-    tmp.add(d);
-    return tmp;
-  }
-
-  /// Creates a new aggregator with a value subtracted
-  [[nodiscard]] DoubleAggregator operator-(double d) const
-  {
-    auto tmp = *this;
-    tmp.add(-d);
-    return tmp;
-  }
-
   /// Retrieves the corrected sum
   double value() const
   {
@@ -66,5 +50,23 @@ public:
 private:
   Acc acc;
 };
+
+[[nodiscard]] inline DoubleAggregator operator+(double lhs, DoubleAggregator rhs)
+{
+  rhs.add(lhs);
+  return rhs;
+}
+
+[[nodiscard]] inline DoubleAggregator operator+(DoubleAggregator lhs, double rhs)
+{
+  lhs.add(rhs);
+  return lhs;
+}
+
+[[nodiscard]] inline DoubleAggregator operator-(DoubleAggregator lhs, double rhs)
+{
+  lhs.add(-rhs);
+  return lhs;
+}
 
 } // namespace precice::utils

--- a/src/utils/DoubleAggregator.hpp
+++ b/src/utils/DoubleAggregator.hpp
@@ -7,6 +7,7 @@ namespace precice::utils {
 /// An accurate aggregator for doubles with usability in mind
 class DoubleAggregator {
 private:
+  /// This class is mainly a wrapper for boost's Kahan accumulator which implements the Kahan summation algorithm (see https://en.wikipedia.org/wiki/Kahan_summation_algorithm)
   using Acc = boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::sum_kahan>>;
 
 public:


### PR DESCRIPTION
## Main changes of this PR

This PR refactors the time processing into a separate class.

* the `DoubleAggregator` is an implementation of a Kahan Babushka Neumaier Aggregator with a bunch of quality of life improvments over our boost variant.
* the `TimeHandler` tracks the current time window

## TODOs

* [x] compute `nextTimeStepSize` in the TimeHandler
* [x] handle `maxTime` in the TimeHandler
* [ ] Add tests for double aggregator 
* [x] Add tests for TimeHandler

## Motivation and additional information

This allows us to test the time handling of very big cases.
This is too expensive to be run as integration tests.

Example:
* `time-window-size=1e-7 max-time=1`
* `time-window-size=0.01 max-time=1000`

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
