### PR TITLE
Fix log config reader

### DIFF
--- a/docs/changelog/1956.md
+++ b/docs/changelog/1956.md
@@ -1,0 +1,2 @@
+- Fixed bug when using log configuration files with invalid options.
+- Added warnings when using invalid options inside log configuration files.

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -1,6 +1,7 @@
 #include "LogConfiguration.hpp"
 #include <algorithm>
 #include <boost/core/null_deleter.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/log/attributes/mutable_constant.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
@@ -123,6 +124,10 @@ public:
 /// Reads a log file, returns a logging configuration.
 LoggingConfiguration readLogConfFile(std::string const &filename)
 {
+  if (!boost::filesystem::exists(filename)) {
+    return {};
+  }
+
   namespace po = boost::program_options;
   po::options_description desc;
   std::ifstream           ifs(filename);

--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -132,17 +132,18 @@ LoggingConfiguration readLogConfFile(std::string const &filename)
   po::options_description desc;
   std::ifstream           ifs(filename);
 
-  po::variables_map vm;
-
   std::map<std::string, BackendConfiguration> configs;
   try {
     po::parsed_options parsed = parse_config_file(ifs, desc, true);
-    po::store(parsed, vm);
-    po::notify(vm);
     for (auto const &opt : parsed.options) {
       std::string section = opt.string_key.substr(0, opt.string_key.find('.'));
       std::string key     = opt.string_key.substr(opt.string_key.find('.') + 1);
-      configs[section].setOption(key, opt.value[0]);
+      if (BackendConfiguration::isValidOption(key)) {
+        PRECICE_ASSERT(!opt.value.empty());
+        configs[section].setOption(key, opt.value[0]);
+      } else {
+        std::cerr << "WARNING: section [" << section << "] in configuration file \"" << filename << "\" contains invalid key \"" << key << "\"\n";
+      }
     }
   } catch (po::error &e) {
     std::cout << "ERROR reading logging configuration: " << e.what() << "\n\n";
@@ -177,6 +178,12 @@ void BackendConfiguration::setOption(std::string key, std::string value)
     filter = value;
   if (key == "format")
     format = value;
+}
+
+bool BackendConfiguration::isValidOption(std::string key)
+{
+  boost::algorithm::to_lower(key);
+  return key == "output" || key == "filter" || key == "format" || key == "type";
 }
 
 void BackendConfiguration::setEnabled(bool enabled)

--- a/src/logging/LogConfiguration.hpp
+++ b/src/logging/LogConfiguration.hpp
@@ -22,6 +22,9 @@ struct BackendConfiguration {
   /// Sets on option, overwrites default values.
   void setOption(std::string key, std::string value);
 
+  /// Checks if an option is usable
+  static bool isValidOption(std::string key);
+
   /// Sets weather the sink is enabled or disabled
   void setEnabled(bool enabled);
 };


### PR DESCRIPTION
## Main changes of this PR

This PR removes dead code, ensures that log config files exist before attempting to load them, and prevents SEGFAULTs when handling options.

## Motivation and additional information

I ran into a SEGFAULT when using a glibc++ in debug mode originated by the options handling.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
