### PR TITLE
Improve consistency of log and assertion macros

### DIFF
--- a/src/acceleration/IQNIMVJAcceleration.cpp
+++ b/src/acceleration/IQNIMVJAcceleration.cpp
@@ -664,7 +664,7 @@ void IQNIMVJAcceleration::restartIMVJ()
 
       // drop oldest pair Wtil_0 and Z_0
       PRECICE_ASSERT(not _WtilChunk.empty());
-      PRECICE_ASSERT(not _pseudoInverseChunk.empty())
+      PRECICE_ASSERT(not _pseudoInverseChunk.empty());
       _WtilChunk.erase(_WtilChunk.begin());
       _pseudoInverseChunk.erase(_pseudoInverseChunk.begin());
     }

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -129,7 +129,7 @@ void ConnectionInfoWriter::write(std::string_view info) const
                    "This is likely a leftover of a previous crash or stop during communication build-up. "
                    "Please remove the \"precice-run\" directory and restart the simulation.";
     PRECICE_CHECK(!bfs::exists(path), message, "", path);
-    PRECICE_CHECK(!bfs::exists(tmp), message, "temporary ")
+    PRECICE_CHECK(!bfs::exists(tmp), message, "temporary ");
   }
 
   PRECICE_DEBUG("Writing temporary connection file \"{}\"", tmp.generic_string());

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -480,7 +480,7 @@ void SocketCommunication::send(int itemToSend, Rank rankReceiver)
 
   rankReceiver = adjustRank(rankReceiver);
 
-  PRECICE_ASSERT(rankReceiver >= 0, rankReceiver)
+  PRECICE_ASSERT(rankReceiver >= 0, rankReceiver);
   PRECICE_ASSERT(isConnected());
 
   try {

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -706,7 +706,7 @@ bool BaseCouplingScheme::measureConvergence()
         PRECICE_CHECK(_iterations < _maxIterations,
                       "The strict convergence measure for data \"" + convMeasure.couplingData->getDataName() +
                           "\" did not converge within the maximum allowed iterations, which terminates the simulation. "
-                          "To avoid this forced termination do not mark the convergence measure as strict.")
+                          "To avoid this forced termination do not mark the convergence measure as strict.");
       }
     } else if (convMeasure.suffices == true) {
       oneSuffices = true;

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -19,9 +19,11 @@
   } while (false)
 
 #define PRECICE_CHECK(check, ...) \
-  if (!(check)) {                 \
-    PRECICE_ERROR(__VA_ARGS__);   \
-  }
+  do {                            \
+    if (!(check)) {               \
+      PRECICE_ERROR(__VA_ARGS__); \
+    }                             \
+  } while (false)
 
 // Debug logging is disabled in release (NDEBUG) builds by default.
 // To enable it anyhow, enable the CMake option PRECICE_RELEASE_WITH_DEBUG_LOG.
@@ -32,12 +34,13 @@
 
 #ifdef PRECICE_NO_DEBUG_LOG
 
+#include "utils/ignore.hpp"
+
 #define PRECICE_DEBUG(...) \
-  {                        \
-  }
+  ::precice::utils::ignore(__VA_ARGS__)
+
 #define PRECICE_TRACE(...) \
-  {                        \
-  }
+  ::precice::utils::ignore(__VA_ARGS__)
 
 #else // PRECICE_NO_DEBUG_LOG
 
@@ -56,9 +59,10 @@
 
 #ifdef PRECICE_NO_TRACE_LOG
 
+#include "utils/ignore.hpp"
+
 #define PRECICE_TRACE(...) \
-  {                        \
-  }
+  ::precice::utils::ignore(__VA_ARGS__)
 
 #else // PRECICE_NO_TRACE_LOG
 

--- a/src/mapping/AxialGeoMultiscaleMapping.cpp
+++ b/src/mapping/AxialGeoMultiscaleMapping.cpp
@@ -46,7 +46,7 @@ void AxialGeoMultiscaleMapping::computeMapping()
       PRECICE_ASSERT(effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::X) ||
                          effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::Y) ||
                          effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::Z),
-                     "Unknown multiscale axis type.")
+                     "Unknown multiscale axis type.");
 
       // compute distances between 1D vertex and 3D vertices
       mesh::Vertex &   v0                           = input()->vertices()[0];
@@ -105,7 +105,7 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
   PRECICE_ASSERT(effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::X) ||
                      effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::Y) ||
                      effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::Z),
-                 "Unknown multiscale axis type.")
+                 "Unknown multiscale axis type.");
 
   // Check that the number of values for the input and output is right according to their dimensions
   PRECICE_ASSERT((inputValues.size() / static_cast<std::size_t>(inDataDimensions) == input()->vertices().size()),
@@ -140,7 +140,7 @@ void AxialGeoMultiscaleMapping::mapConsistent(const time::Sample &inData, Eigen:
     outputValues(effectiveCoordinate) = 0;
     size_t const inSize               = input()->vertices().size();
     for (size_t i = 0; i < inSize; i++) {
-      PRECICE_ASSERT(static_cast<size_t>((i * inDataDimensions) + effectiveCoordinate) < static_cast<size_t>(inputValues.size()), ((i * inDataDimensions) + effectiveCoordinate), inputValues.size())
+      PRECICE_ASSERT(static_cast<size_t>((i * inDataDimensions) + effectiveCoordinate) < static_cast<size_t>(inputValues.size()), ((i * inDataDimensions) + effectiveCoordinate), inputValues.size());
       outputValues(effectiveCoordinate) += inputValues((i * inDataDimensions) + effectiveCoordinate);
     }
     outputValues(effectiveCoordinate) = outputValues(effectiveCoordinate) / inSize;

--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -111,7 +111,7 @@ void LinearCellInterpolationMapping::computeMapping()
       PRECICE_INFO("All vertices are inside cells, no fallback required");
     } else {
       // No fallback and we have connectivity
-      PRECICE_ASSERT(hasConnectivity)
+      PRECICE_ASSERT(hasConnectivity);
       PRECICE_INFO("Successfully computed linear-cell-interpolation mapping.");
     }
   }

--- a/src/mapping/RadialGeoMultiscaleMapping.cpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.cpp
@@ -32,7 +32,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
   PRECICE_ASSERT(effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::X) ||
                      effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::Y) ||
                      effectiveCoordinate == static_cast<std::underlying_type_t<MultiscaleType>>(MultiscaleAxis::Z),
-                 "Unknown multiscale axis type.")
+                 "Unknown multiscale axis type.");
 
   if (getConstraint() == CONSISTENT) {
     PRECICE_DEBUG("Compute consistent mapping");
@@ -71,7 +71,7 @@ void RadialGeoMultiscaleMapping::computeMapping()
         _vertexIndicesSpread.push_back(index);
       }
     } else {
-      PRECICE_ASSERT(_type == MultiscaleType::COLLECT)
+      PRECICE_ASSERT(_type == MultiscaleType::COLLECT);
       /*
         3D vertices are projected onto the 1D axis and the data is then mapped
         to (and averaged at) the nearest 1D vertex in projection space.

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -390,7 +390,7 @@ void MappingConfiguration::xmlTagCallback(
     double      multiscaleRadius  = tag.getDoubleAttributeValue(ATTR_GEOMETRIC_MULTISCALE_RADIUS, 1.0);
 
     if (type == TYPE_AXIAL_GEOMETRIC_MULTISCALE || type == TYPE_RADIAL_GEOMETRIC_MULTISCALE) {
-      PRECICE_CHECK(_experimental, "Axial geometric multiscale is experimental and the configuration can change between minor releases. Set experimental=\"on\" in the precice-configuration tag.")
+      PRECICE_CHECK(_experimental, "Axial geometric multiscale is experimental and the configuration can change between minor releases. Set experimental=\"on\" in the precice-configuration tag.");
     }
 
     if (type == TYPE_AXIAL_GEOMETRIC_MULTISCALE && context.size > 1) {

--- a/src/mapping/impl/SphericalVertexCluster.hpp
+++ b/src/mapping/impl/SphericalVertexCluster.hpp
@@ -135,7 +135,7 @@ SphericalVertexCluster<RADIAL_BASIS_FUNCTION_T>::SphericalVertexCluster(
 {
   PRECICE_TRACE(_center.getCoords(), _radius);
   // Disable integrated polynomial, as it might cause locally singular matrices
-  PRECICE_ASSERT(_polynomial != Polynomial::ON, "Integrated polynomial is not supported for partition of unity data mappings.")
+  PRECICE_ASSERT(_polynomial != Polynomial::ON, "Integrated polynomial is not supported for partition of unity data mappings.");
 
   // Get vertices to be mapped
   // Subtract a safety margin to exclude the vertices at the edge

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -60,8 +60,6 @@ private:
   const std::string VALUE_VECTOR = "vector";
   const std::string VALUE_SCALAR = "scalar";
 
-  const Data::typeName _dataTypeName{};
-
   std::vector<ConfiguredData> _data;
 
   int _indexLastConfigured = -1;

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -163,14 +163,14 @@ void MeshConfiguration::insertMeshToMeshDimensionsMap(
     const std::string &mesh,
     int                dimensions)
 {
-  PRECICE_ASSERT(_meshDimensionsMap.count(mesh) == 0, "Mesh {} already exists in the mesh-dimensions map.", mesh)
+  PRECICE_ASSERT(_meshDimensionsMap.count(mesh) == 0, "Mesh {} already exists in the mesh-dimensions map.", mesh);
   _meshDimensionsMap.insert(std::pair<std::string, int>(mesh, dimensions));
 }
 
 int MeshConfiguration::getDataDimensions(const std::string &meshName, const Data::typeName dataTypeName) const
 {
   if (dataTypeName == Data::typeName::VECTOR) {
-    PRECICE_ASSERT(_meshDimensionsMap.count(meshName) > 0, "Mesh {} does not exist in the mesh-dimensions map.", meshName)
+    PRECICE_ASSERT(_meshDimensionsMap.count(meshName) > 0, "Mesh {} does not exist in the mesh-dimensions map.", meshName);
     return _meshDimensionsMap.at(meshName);
   } else if (dataTypeName == Data::typeName::SCALAR) {
     return 1;

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -274,7 +274,7 @@ void ParticipantConfiguration::xmlTagCallback(
     PRECICE_CHECK(!from.empty(),
                   R"(Participant "{}" receives mesh "{}", but doesn't specify where from. )"
                   "Please add the name of the other participant to the receive-mesh tag: <receive-mesh name=\"{}\" from=\"(other participant)\" ... />",
-                  context.name, name, name)
+                  context.name, name, name);
 
     PRECICE_CHECK(_participants.back()->getName() != from,
                   "Participant \"{}\" cannot receive mesh \"{}\" from itself. "

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -242,7 +242,7 @@ void ParticipantImpl::configure(
 void ParticipantImpl::initialize()
 {
   PRECICE_TRACE();
-  PRECICE_CHECK(_state != State::Finalized, "initialize() cannot be called after finalize().")
+  PRECICE_CHECK(_state != State::Finalized, "initialize() cannot be called after finalize().");
   PRECICE_CHECK(_state != State::Initialized, "initialize() may only be called once.");
   PRECICE_ASSERT(not _couplingScheme->isInitialized());
 
@@ -358,8 +358,8 @@ void ParticipantImpl::advance(
   profiling::ScopedEventPrefix sep("advance/");
 
   PRECICE_CHECK(_state != State::Constructed, "initialize() has to be called before advance().");
-  PRECICE_CHECK(_state != State::Finalized, "advance() cannot be called after finalize().")
-  PRECICE_CHECK(_state == State::Initialized, "initialize() has to be called before advance().")
+  PRECICE_CHECK(_state != State::Finalized, "advance() cannot be called after finalize().");
+  PRECICE_CHECK(_state == State::Initialized, "initialize() has to be called before advance().");
   PRECICE_ASSERT(_couplingScheme->isInitialized());
   PRECICE_CHECK(isCouplingOngoing(), "advance() cannot be called when isCouplingOngoing() returns false.");
   PRECICE_CHECK(!math::equals(computedTimeStepSize, 0.0), "advance() cannot be called with a time step size of 0.");
@@ -1144,7 +1144,7 @@ void ParticipantImpl::setMeshAccessRegion(
 {
   PRECICE_TRACE(meshName, boundingBox.size());
   PRECICE_REQUIRE_MESH_USE(meshName);
-  PRECICE_CHECK(_state != State::Finalized, "setMeshAccessRegion() cannot be called after finalize().")
+  PRECICE_CHECK(_state != State::Finalized, "setMeshAccessRegion() cannot be called after finalize().");
   PRECICE_CHECK(_state != State::Initialized, "setMeshAccessRegion() needs to be called before initialize().");
   PRECICE_CHECK(!_accessRegionDefined, "setMeshAccessRegion may only be called once.");
 

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -149,7 +149,6 @@ ReadDataContext &ParticipantState::readDataContext(std::string_view mesh, std::s
 
 mesh::PtrMesh ParticipantState::findMesh(std::string_view data) const
 {
-  bool foundReadDataContextForAnyMesh = false;
   for (const auto &meshContext : _meshContexts) {
     const auto &             mesh = meshContext.second->mesh->getName();
     MeshDataKey<std::string> key{mesh, std::string{data}};

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -164,14 +164,14 @@ mesh::PtrMesh ParticipantState::findMesh(std::string_view data) const
 const WriteDataContext &ParticipantState::writeDataContext(std::string_view mesh, std::string_view data) const
 {
   auto it = _writeDataContexts.find(MeshDataKey{mesh, data});
-  PRECICE_CHECK(it != _writeDataContexts.end(), "Data \"{}\" does not exist in write direction.", data)
+  PRECICE_CHECK(it != _writeDataContexts.end(), "Data \"{}\" does not exist in write direction.", data);
   return it->second;
 }
 
 WriteDataContext &ParticipantState::writeDataContext(std::string_view mesh, std::string_view data)
 {
   auto it = _writeDataContexts.find(MeshDataKey{mesh, data});
-  PRECICE_CHECK(it != _writeDataContexts.end(), "Data \"{}\" does not exist in write direction.", data)
+  PRECICE_CHECK(it != _writeDataContexts.end(), "Data \"{}\" does not exist in write direction.", data);
   return it->second;
 }
 

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -13,7 +13,7 @@ ReadDataContext::ReadDataContext(
 
 void ReadDataContext::appendMappingConfiguration(MappingContext &mappingContext, const MeshContext &meshContext)
 {
-  PRECICE_ASSERT(!hasReadMapping(), "The read data context must be unique. Otherwise we would have an ambiguous read data operation on the user side.")
+  PRECICE_ASSERT(!hasReadMapping(), "The read data context must be unique. Otherwise we would have an ambiguous read data operation on the user side.");
   PRECICE_ASSERT(meshContext.mesh->hasDataName(getDataName()));
   mesh::PtrData data = meshContext.mesh->data(getDataName());
   PRECICE_ASSERT(data != _providedData, "Data the read mapping is mapping from needs to be different from _providedData");

--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -191,7 +191,7 @@ void EventRegistry::clear()
 
 void EventRegistry::put(PendingEntry pe)
 {
-  PRECICE_ASSERT(_mode != Mode::Off, "The profiling is off.")
+  PRECICE_ASSERT(_mode != Mode::Off, "The profiling is off.");
   _writeQueue.emplace_back(std::move(pe));
   if (_writeQueueMax > 0 && _writeQueue.size() > _writeQueueMax) {
     flush();

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -321,6 +321,7 @@ target_sources(preciceCore
     src/utils/fmt.hpp
     src/utils/fmtEigen.hpp
     src/utils/fmtSTL.hpp
+    src/utils/ignore.hpp
     src/utils/networking.cpp
     src/utils/networking.hpp
     src/utils/span_tools.hpp

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -58,19 +58,21 @@ static constexpr std::string_view ASSERT_FMT =
  * @param[in] check the expression which needs to evaluate to true for the assertion to pass
  * @param[in] args the expression which evaluates to the formatted arguments
  */
-#define PRECICE_ASSERT_IMPL(check, args)                         \
-  if (!(check)) {                                                \
-    std::cerr << precice::utils::format_or_error(                \
-                     precice::utils::ASSERT_FMT,                 \
-                     BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, \
-                     BOOST_PP_STRINGIZE(check),                  \
-                     precice::utils::Parallel::getProcessRank(), \
-                     args,                                       \
-                     getStacktrace())                            \
-              << std::flush;                                     \
-    std::cout.flush();                                           \
-    PRECICE_ASSERT_WRAPPER();                                    \
-  }
+#define PRECICE_ASSERT_IMPL(check, args)                           \
+  do {                                                             \
+    if (!(check)) {                                                \
+      std::cerr << precice::utils::format_or_error(                \
+                       precice::utils::ASSERT_FMT,                 \
+                       BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, \
+                       BOOST_PP_STRINGIZE(check),                  \
+                       precice::utils::Parallel::getProcessRank(), \
+                       args,                                       \
+                       getStacktrace())                            \
+                << std::flush;                                     \
+      std::cout.flush();                                           \
+      PRECICE_ASSERT_WRAPPER();                                    \
+    }                                                              \
+  } while (false)
 
 #define PRECICE_ASSERT_IMPL_N(check, ...) \
   PRECICE_ASSERT_IMPL(check, PRECICE_LOG_ARGUMENTS(__VA_ARGS__))

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -15,9 +15,10 @@
 
 #ifdef PRECICE_NO_ASSERTIONS
 
+#include "utils/ignore.hpp"
+
 #define PRECICE_ASSERT(...) \
-  {                         \
-  }
+  ::precice::utils::ignore(__VA_ARGS__)
 
 #else
 

--- a/src/utils/ignore.hpp
+++ b/src/utils/ignore.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace precice::utils {
+
+/** Ignores all inputs to prevent warnings about unused variables
+ *
+  * Don't worry compiers will optimize this and unneeded arguments away even at -O1.
+  */
+template <class... Arguments>
+void ignore(Arguments &&...) {}
+
+} // namespace precice::utils


### PR DESCRIPTION
## Main changes of this PR

This PR aims to improve robustness working with log and assertion macros:

* Arguments of PRECICE_DEBUG, _TRACE, and _ASSERT will no longer trigger `-Wunused-variable` in release builds.
* All log and assertion macros now require to be followed by a semicolon in all builds

## Motivation and additional information

Prevents errors when programming in Release and switching to Debug.
Prevents warnings when programming in Debug and switching to Release.
These are normally shown in the CI, but it is better to prevent them altogether.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
