### PR TITLE
Enable oversubscribe for all platforms

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -58,7 +58,7 @@ jobs:
         PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPRECICE_CTEST_MPI_FLAGS="--map-by :OVERSUBSCRIBE" ..
     - uses: actions/upload-artifact@v4
       if: failure()
       with:

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -58,7 +58,7 @@ jobs:
         PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPRECICE_CTEST_MPI_FLAGS="--map-by :OVERSUBSCRIBE" ..
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPRECICE_CTEST_MPI_FLAGS="--map-by=:OVERSUBSCRIBE" ..
     - uses: actions/upload-artifact@v4
       if: failure()
       with:

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -58,7 +58,7 @@ jobs:
         PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DPRECICE_CTEST_MPI_FLAGS="--map-by=:OVERSUBSCRIBE" ..
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
     - uses: actions/upload-artifact@v4
       if: failure()
       with:

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -52,8 +52,8 @@ function(add_precice_test)
   endif()
 
   set(_extra_mpi_flags "")
-  if(MPI_CXX_LIBRARY_VERSION_STRING MATCHES "Open MPI: v5")
-    set(_extra_mpi_flags "--map-by=:OVERSUBSCRIBE")
+  if(PRECICE_MPI_OPENMPI)
+    set(_extra_mpi_flags "--oversubscribe")
   endif()
 
   # Assemble the command
@@ -69,7 +69,7 @@ function(add_precice_test)
   set_tests_properties(${PAT_FULL_NAME}
     PROPERTIES
     WORKING_DIRECTORY "${PAT_WDIR}"
-    ENVIRONMENT "OMPI_MCA_rmaps_base_oversubscribe=1;OMP_NUM_THREADS=2"
+    ENVIRONMENT "OMP_NUM_THREADS=2"
     )
   if(PAT_TIMEOUT)
     set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PAT_TIMEOUT} )

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -51,11 +51,17 @@ function(add_precice_test)
     return()
   endif()
 
+  set(_extra_mpi_flags "")
+  if(MPI_CXX_LIBRARY_VERSION_STRING MATCHES "Open MPI: v5")
+    set(_extra_mpi_flags "--map-by=:OVERSUBSCRIBE")
+  endif()
+
   # Assemble the command
   message(STATUS "Test ${PAT_FULL_NAME}")
   add_test(NAME ${PAT_FULL_NAME}
-    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${MPIEXEC_POSTFLAGS} ${PAT_ARGUMENTS}
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${_extra_mpi_flags} ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${MPIEXEC_POSTFLAGS} ${PAT_ARGUMENTS}
     )
+  unset(_extra_mpi_flags)
   # Generate working directory
   set(PAT_WDIR "${PRECICE_TEST_DIR}/${PAT_NAME}")
   file(MAKE_DIRECTORY "${PAT_WDIR}")

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -55,7 +55,7 @@ function(add_precice_test)
   # Note that --map-by=:OVERSUBSCRIBE work for OpenMPI(4+5), MPICH, and Intel MPI.
   message(STATUS "Test ${PAT_FULL_NAME}")
   add_test(NAME ${PAT_FULL_NAME}
-    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 --map-by=:OVERSUBSCRIBE ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${MPIEXEC_POSTFLAGS} ${PAT_ARGUMENTS}
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 --map-by :OVERSUBSCRIBE ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${MPIEXEC_POSTFLAGS} ${PAT_ARGUMENTS}
     )
   unset(_extra_mpi_flags)
   # Generate working directory

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -51,15 +51,11 @@ function(add_precice_test)
     return()
   endif()
 
-  set(_extra_mpi_flags "")
-  if(PRECICE_MPI_OPENMPI)
-    set(_extra_mpi_flags "--oversubscribe")
-  endif()
-
   # Assemble the command
+  # Note that --map-by=:OVERSUBSCRIBE work for OpenMPI(4+5), MPICH, and Intel MPI.
   message(STATUS "Test ${PAT_FULL_NAME}")
   add_test(NAME ${PAT_FULL_NAME}
-    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${_extra_mpi_flags} ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${MPIEXEC_POSTFLAGS} ${PAT_ARGUMENTS}
+    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 --map-by=:OVERSUBSCRIBE ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${MPIEXEC_POSTFLAGS} ${PAT_ARGUMENTS}
     )
   unset(_extra_mpi_flags)
   # Generate working directory

--- a/docs/changelog/1960.md
+++ b/docs/changelog/1960.md
@@ -1,0 +1,1 @@
+- Fixed oversubscription errors when running tests.


### PR DESCRIPTION
## Main changes of this PR

While debugging the MacOS workflow, I realised that OpenMPI 5 doesn't support the mca env for oversubscription anymore. After some digging I found out that `--map-by :OVERSUBSCRIBE` works for OpenMPI 4, OpenMPI 5, MPICH, and Intel MPI. This covers all implementations we need to support.

So, I hardcoded it now into the test runners.

## Motivation and additional information

No more oversubscription issues.

OpenMPI supports `--oversubscribe`, which is an alias for `--map-by=:OVERSUBSCRIBE` and not supported on all platforms.
OpenMPI 4 does not support the `=` format `--map-by=:OVERSUBSCRIBE`

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.
