### PR TITLE
Upgrade baseline to Ubuntu 22.04 LTS

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Short rational why preCICE needs this change. If this is already described in an
 * [ ] I added a test to cover the proposed changes in our test suite.
 * [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
 * [ ] I sticked to C++17 features.
-* [ ] I sticked to CMake version 3.16.3.
+* [ ] I sticked to CMake version 3.22.1.
 * [ ] I squashed / am about to squash all commits that should be seen as one.
 
 ## Reviewers' checklist

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,6 @@
 name: Build and Test
 # Builds preCICE inside various docker containers and runs the tests.
 # Ubuntu-based cases additionally build the Debian package and test it using lintian.
-# The debug builds of Ubuntu 18.04 LTS are additionally used for code coverage.
 #
 # See https://github.com/precice/ci-images
 on:
@@ -39,37 +38,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - IMAGE: 'ubuntu-2004'
+          - IMAGE: 'ubuntu-2204'
             CONFIG: Bare
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-2004'
+          - IMAGE: 'ubuntu-2204'
             CONFIG: MPI
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-2004'
+          - IMAGE: 'ubuntu-2204'
             CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-2004'
+          - IMAGE: 'ubuntu-2204'
             CONFIG: Bare
-            CXX: 'g++'
-            TYPE: Release
-          - IMAGE: 'ubuntu-2004'
-            CONFIG: MPI
-            CXX: 'g++'
-            TYPE: Release
-          - IMAGE: 'ubuntu-2004'
-            CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Release
           - IMAGE: 'ubuntu-2204'
-            CONFIG: MPIPETScGinkgo
+            CONFIG: MPI
             CXX: 'g++'
-            TYPE: Debug
+            TYPE: Release
+          - IMAGE: 'ubuntu-2204'
+            CONFIG: MPIPETSc
+            CXX: 'g++'
+            TYPE: Release
           - IMAGE: 'ubuntu-2404'
             CONFIG: MPIPETScGinkgo
             CXX: 'g++'

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   latest:
     runs-on: ubuntu-latest
-    container: 'precice/ci-ubuntu-2004:latest'
+    container: 'precice/ci-ubuntu-2204:latest'
     steps:
       - name: Download Coverity Build Tool
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TARGET: ["ubuntu:20.04", "ubuntu:22.04", "debian:11", "debian:12"]
+        TARGET: ["ubuntu:22.04", "ubuntu:24.04", "debian:11", "debian:12"]
     steps:
       - uses: actions/checkout@v4
       - name: Generate build directory

--- a/.github/workflows/request-deb-package.yml
+++ b/.github/workflows/request-deb-package.yml
@@ -6,7 +6,7 @@ name: Request Deb Package
 # - Select the "Request Package" workflow
 # - On the top of the list, select "Run workflow"
 # - Select the release tag to generate the package for. Example: v2.3.0
-# - Select the ubuntu version >18.04 to generate the package for. Example: 21.10
+# - Select the ubuntu version to generate the package for. Example: 21.10
 # - Click "Run Workflow"
 #
 # This workflow uses the official ubuntu docker images.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.16.3)
+cmake_minimum_required (VERSION 3.22.1)
 project(preCICE VERSION 3.0.0 LANGUAGES CXX)
 set(preCICE_SOVERSION ${preCICE_VERSION_MAJOR})
 
@@ -184,7 +184,7 @@ if(TPL_ENABLE_BOOST)
   set(Boost_NO_SYSTEM_PATHS ON CACHE BOOL "" FORCE)
   unset(ENV{BOOST_ROOT})
 endif()
-find_package(Boost 1.71.0 REQUIRED
+find_package(Boost 1.74.0 REQUIRED
   COMPONENTS filesystem log log_setup program_options system thread unit_test_framework
   )
 mark_as_advanced(Boost_FILESYSTEM_LIBRARY_RELEASE Boost_INCLUDE_DIR Boost_LOG_LIBRARY_RELEASE Boost_LOG_SETUP_LIBRARY_RELEASE Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE Boost_SYSTEM_LIBRARY_RELEASE Boost_THREAD_LIBRARY_RELEASE Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE)
@@ -196,12 +196,7 @@ if(TPL_ENABLE_EIGEN3)
   # Use EIGEN3_ROOT to set the directory
   xsdk_tpl_require(EIGEN3 EIGEN3_INCLUDE_DIR)
 endif()
-# We need Eigen 3.4.0 such that Eigen deals properly with cuda
-if(PRECICE_FEATURE_GINKGO_MAPPING)
-  find_package(Eigen3 3.4.0 REQUIRED)
-else()
-  find_package(Eigen3 3.3.7 REQUIRED)
-endif()
+find_package(Eigen3 3.4.0 REQUIRED)
 message(STATUS "Found Eigen ${EIGEN3_VERSION}")
 precice_validate_eigen()
 
@@ -237,7 +232,7 @@ if (PRECICE_FEATURE_PETSC_MAPPING)
     xsdk_tpl_require(PETSC PETSC_DIR PETSC_ARCH)
     # PETSc detection uses primarily these ENVs
   endif()
-  find_package(PETSc 3.12 REQUIRED)
+  find_package(PETSc 3.15 REQUIRED)
   # No validation required as PETSc does this internally
   message(STATUS "Found PETSc ${PETSc_VERSION}")
 else()


### PR DESCRIPTION
## Main changes of this PR

**On hold until the release of Ubuntu 24.04 LTS**

This PR upgrades the baseline versions from Ubuntu 20.04 LTS to 22.04 LTS in CMake and the workflows.

## Motivation and additional information

Part of #1961

Untouched are C++ version and internal changes.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
