### PR TITLE
Migrate Actions and exports to samples

### DIFF
--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -28,10 +28,8 @@ void ScaleByAreaAction::performAction()
   PRECICE_TRACE();
   const int meshDimensions = getMesh()->getDimensions();
 
-  for (auto &targetStample : _targetData->stamples()) {
-
-    auto &targetValues              = _targetData->values();
-    targetValues                    = targetStample.sample.values;
+  for (auto &targetStample : _targetData->timeStepsStorage().stamples()) {
+    auto &          targetValues    = targetStample.sample.values;
     const int       valueDimensions = _targetData->getDimensions();
     Eigen::VectorXd areas           = Eigen::VectorXd::Zero(getMesh()->vertices().size());
     PRECICE_ASSERT(targetValues.size() / valueDimensions == areas.size());
@@ -67,8 +65,8 @@ void ScaleByAreaAction::performAction()
         }
       }
     }
-    _targetData->setSampleAtTime(targetStample.timestamp, _targetData->sample());
   }
+  _targetData->updateSample();
 }
 
 } // namespace precice::action

--- a/src/action/ScaleByAreaAction.cpp
+++ b/src/action/ScaleByAreaAction.cpp
@@ -28,28 +28,31 @@ void ScaleByAreaAction::performAction()
   PRECICE_TRACE();
   const int meshDimensions = getMesh()->getDimensions();
 
+  // precompute areas
+  Eigen::VectorXd areas = Eigen::VectorXd::Zero(getMesh()->vertices().size());
+  if (meshDimensions == 2) {
+    PRECICE_CHECK(!getMesh()->edges().empty(),
+                  "The multiply/divide-by-area actions require meshes with connectivity information. In 2D, please ensure that the mesh {} contains edges.", getMesh()->getName());
+    for (mesh::Edge &edge : getMesh()->edges()) {
+      areas[edge.vertex(0).getID()] += edge.getEnclosingRadius();
+      areas[edge.vertex(1).getID()] += edge.getEnclosingRadius();
+    }
+  } else {
+    PRECICE_CHECK(!getMesh()->triangles().empty(),
+                  "The multiply/divide-by-area actions require meshes with connectivity information. In 3D, please ensure that the mesh {} contains triangles.", getMesh()->getName());
+    for (mesh::Triangle &face : getMesh()->triangles()) {
+      areas[face.vertex(0).getID()] += face.getArea() / 3.0;
+      areas[face.vertex(1).getID()] += face.getArea() / 3.0;
+      areas[face.vertex(2).getID()] += face.getArea() / 3.0;
+    }
+  }
+
+  // Process samples
   for (auto &targetStample : _targetData->timeStepsStorage().stamples()) {
-    auto &          targetValues    = targetStample.sample.values;
-    const int       valueDimensions = _targetData->getDimensions();
-    Eigen::VectorXd areas           = Eigen::VectorXd::Zero(getMesh()->vertices().size());
+    auto &    targetValues    = targetStample.sample.values;
+    const int valueDimensions = _targetData->getDimensions();
     PRECICE_ASSERT(targetValues.size() / valueDimensions == areas.size());
 
-    if (meshDimensions == 2) {
-      PRECICE_CHECK(getMesh()->edges().size() != 0,
-                    "The multiply/divide-by-area actions require meshes with connectivity information. In 2D, please ensure that the mesh {} contains edges.", getMesh()->getName());
-      for (mesh::Edge &edge : getMesh()->edges()) {
-        areas[edge.vertex(0).getID()] += edge.getEnclosingRadius();
-        areas[edge.vertex(1).getID()] += edge.getEnclosingRadius();
-      }
-    } else {
-      PRECICE_CHECK(getMesh()->triangles().size() != 0,
-                    "The multiply/divide-by-area actions require meshes with connectivity information. In 3D, please ensure that the mesh {} contains triangles.", getMesh()->getName());
-      for (mesh::Triangle &face : getMesh()->triangles()) {
-        areas[face.vertex(0).getID()] += face.getArea() / 3.0;
-        areas[face.vertex(1).getID()] += face.getArea() / 3.0;
-        areas[face.vertex(2).getID()] += face.getArea() / 3.0;
-      }
-    }
     if (_scaling == SCALING_DIVIDE_BY_AREA) {
       for (int i = 0; i < areas.size(); i++) {
         for (int dim = 0; dim < valueDimensions; dim++) {

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -77,7 +77,6 @@ void ExportCSV::doExport(
   for (const auto &data : mesh.data()) {
     auto dataName = data->getName();
     auto dim      = data->getDimensions();
-    PRECICE_ASSERT(static_cast<std::size_t>(data->values().size()) == mesh.vertices().size() * dim);
     outFile << ';' << dataName;
     if (dim == 2) {
       outFile << "X;" << dataName << 'Y';
@@ -90,8 +89,8 @@ void ExportCSV::doExport(
   // Prepare writing data
   std::vector<StridedAccess> dataColumns;
   for (const auto &data : mesh.data()) {
-    auto    dim    = data->getDimensions();
-    double *values = data->values().data();
+    auto          dim    = data->getDimensions();
+    const double *values = data->lastStample().sample.values.data();
     for (int i = 0; i < dim; ++i) {
       dataColumns.push_back({std::next(values, i), dim});
     }

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -129,7 +129,7 @@ void ExportVTK::exportData(
   outFile << "\n\n";
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
-    Eigen::VectorXd &values = data->values();
+    const Eigen::VectorXd &values = data->lastStample().sample.values;
     if (data->getDimensions() > 1) {
       Eigen::VectorXd viewTemp(data->getDimensions());
       outFile << "VECTORS " << data->getName() << " double\n";
@@ -164,7 +164,7 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
   const int spaceDim = mesh.getDimensions();
   for (const mesh::PtrData &data : mesh.data()) {
     if (data->hasGradient()) { // Check whether this data has gradient
-      auto &gradients = data->gradients();
+      const auto &gradients = data->lastStample().sample.gradients;
       if (data->getDimensions() == 1) { // Scalar data, create a vector <dataname>_gradient
         outFile << "VECTORS " << data->getName() << "_gradient"
                 << " double\n";

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -156,7 +156,7 @@ void ExportXML::writeSubFile(
 
 void ExportXML::exportGradient(const mesh::PtrData data, const int spaceDim, std::ostream &outFile) const
 {
-  const auto &             gradients      = data->gradients();
+  const auto &             gradients      = data->lastStample().sample.gradients;
   const int                dataDimensions = data->getDimensions();
   std::vector<std::string> suffices;
   if (dataDimensions == 1) {
@@ -212,11 +212,11 @@ void ExportXML::exportData(
   outFile << "\n            </DataArray>\n";
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
-    Eigen::VectorXd &values         = data->values();
-    int              dataDimensions = data->getDimensions();
-    std::string      dataName(data->getName());
-    int              numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
-    const bool       hasGradient        = data->hasGradient();
+    const Eigen::VectorXd &values         = data->lastStample().sample.values;
+    int                    dataDimensions = data->getDimensions();
+    std::string            dataName(data->getName());
+    int                    numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
+    const bool             hasGradient        = data->hasGradient();
     outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
     outFile << "\" format=\"ascii\">\n";
     outFile << "               ";

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -34,16 +34,8 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
 
   // Create data
   mesh.allocateDataValues();
-  Eigen::VectorXd &valuesScalar = dataScalar->values();
-  Eigen::VectorXd &valuesVector = dataVector->values();
-  valuesScalar << 1.0, 2.0;
-  valuesVector << 1.0, 2.0, 3.0, 4.0;
-
-  // Create corresponding gradient data (all gradients = const = 1)
-  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
-  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
-  gradientsScalar.setOnes();
-  gradientsVector.setOnes();
+  dataScalar->setSampleAtTime(0.0, {1, {1.0, 2.0}, Eigen::MatrixXd::Ones(2, 2)});
+  dataVector->setSampleAtTime(0.0, {2, {1.0, 2.0, 3.0, 4.0}, Eigen::MatrixXd::Ones(2, 4)});
   io::ExportVTK exportVTK;
   std::string   filename = "io-VTKExport-ExportDatawithGradient";
   std::string   location = "";

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -51,7 +51,7 @@ void Data::updateSample()
     return;
   }
 
-  _sample = _waveform.timeStepsStorage().getSampleAtEnd();
+  _sample = lastStample().sample;
 }
 
 time::Sample &Data::sample()

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -45,6 +45,15 @@ const Eigen::MatrixXd &Data::gradients() const
   return _sample.gradients;
 }
 
+void Data::updateSample()
+{
+  if (_waveform.timeStepsStorage().empty()) {
+    return;
+  }
+
+  _sample = _waveform.timeStepsStorage().getSampleAtEnd();
+}
+
 time::Sample &Data::sample()
 {
   return _sample;
@@ -81,8 +90,8 @@ void Data::moveToNextWindow()
 
 void Data::setSampleAtTime(double time, const time::Sample &sample)
 {
-  _sample = sample; // @todo at some point we should not need this anymore, when mapping, acceleration ... directly work on _timeStepsStorage
   _waveform.timeStepsStorage().setSampleAtTime(time, sample);
+  updateSample();
 }
 
 const std::string &Data::getName() const

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -64,6 +64,12 @@ const time::Sample &Data::sample() const
   return _sample;
 }
 
+const time::Stample &Data::lastStample() const
+{
+  PRECICE_ASSERT(!_waveform.timeStepsStorage().empty());
+  return _waveform.timeStepsStorage().stamples().back();
+}
+
 Eigen::VectorXd Data::sampleAtTime(double time) const
 {
   return _waveform.sample(time);

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -58,6 +58,9 @@ public:
       int         spatialDimensions = -1,
       int         waveformDegree    = time::Time::DEFAULT_WAVEFORM_DEGREE);
 
+  /// @name Deprecated global sample stuff
+  /// @{
+
   /// Returns a reference to the data values.
   Eigen::VectorXd &values();
 
@@ -70,11 +73,16 @@ public:
   /// Returns a const reference to the gradient data values.
   const Eigen::MatrixXd &gradients() const;
 
+  /// Sets _sample to the last sample in the storage
+  void updateSample();
+
   /// Returns a reference to the _sample.
   time::Sample &sample();
 
   /// Returns a const reference to the _sample.
   const time::Sample &sample() const;
+
+  /// @}
 
   /**
    * @brief Samples _waveform at given time

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -92,6 +92,9 @@ public:
    */
   Eigen::VectorXd sampleAtTime(double time) const;
 
+  /// Get a reference to the lasts stample of the data.
+  const time::Stample &lastStample() const;
+
   /**
    * @brief get degree of _waveform.
    *

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -326,6 +326,7 @@ target_sources(preciceCore
     src/utils/ignore.hpp
     src/utils/networking.cpp
     src/utils/networking.hpp
+    src/utils/ranges.hpp
     src/utils/span_tools.hpp
     src/utils/stacktrace.cpp
     src/utils/stacktrace.hpp

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -233,11 +233,13 @@ int Storage::computeUsedDegree(int requestedDegree, int numberOfAvailableSamples
 
 time::Sample Storage::getSampleAtBeginning()
 {
+  PRECICE_ASSERT(!_stampleStorage.empty());
   return _stampleStorage.front().sample;
 }
 
 time::Sample Storage::getSampleAtEnd()
 {
+  PRECICE_ASSERT(!_stampleStorage.empty());
   return _stampleStorage.back().sample;
 }
 

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -138,6 +138,8 @@ public:
 
   Eigen::MatrixXd sampleGradients(double time) const;
 
+  time::Sample getSampleAtEnd();
+
 private:
   /// Stores Stamples on the current window
   std::vector<Stample> _stampleStorage;
@@ -161,8 +163,6 @@ private:
   int computeUsedDegree(int requestedDegree, int numberOfAvailableSamples) const;
 
   time::Sample getSampleAtBeginning();
-
-  time::Sample getSampleAtEnd();
 
   int findTimeId(double time) const;
 };

--- a/src/utils/ranges.hpp
+++ b/src/utils/ranges.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <boost/range/iterator_range_core.hpp>
+#include <iterator>
+
+namespace precice::utils::ranges {
+
+// Given a range, returns the tail of the range. Must not be empty
+template <class Range>
+auto tail(Range &range)
+{
+  return boost::make_iterator_range(++(std::begin(range)), std::end(range));
+}
+
+} // namespace precice::utils::ranges


### PR DESCRIPTION
## Main changes of this PR

This PR migrates actions and exports to samples.

Actions now directly work on the sample values and only create new samples when necessary.
Exporters now export the `Data::lastStample()` instead of `Data::values()` and `Data::gradients()`

## Motivation and additional information

This is yet another step to remove the old `Data::values()` and the global sample.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
