### PR TITLE
Add more tests for precice::span

### DIFF
--- a/src/precice/tests/SpanTests.cpp
+++ b/src/precice/tests/SpanTests.cpp
@@ -1,5 +1,7 @@
+#include <array>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "precice/span.hpp"
 #include "testing/Testing.hpp"
@@ -37,7 +39,76 @@ BOOST_AUTO_TEST_CASE(FromString)
   BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
 }
 
+BOOST_AUTO_TEST_CASE(FromCharVec)
+{
+  PRECICE_TEST(1_rank);
+  std::vector<char> s{'h', 'e', 'l', 'l', 'o', ' ', 't', 'h', 'e', 'r', 'e'};
+  span<const char>  const_span{s};
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+      s.begin(), s.end(),
+      const_span.begin(), const_span.end());
+}
+
+BOOST_AUTO_TEST_CASE(FromLiteral)
+{
+  PRECICE_TEST(1_rank);
+  std::string      s = "hello there";
+  span<const char> const_span{"hello there"}; // Includes the NULL byte
+
+  BOOST_CHECK_EQUAL_COLLECTIONS(s.begin(), ++s.end(),
+                                const_span.begin(), const_span.end());
+}
+
+BOOST_AUTO_TEST_CASE(FromStdArray)
+{
+  PRECICE_TEST(1_rank);
+  std::array<char, 11> s{'h', 'e', 'l', 'l', 'o', ' ', 't', 'h', 'e', 'r', 'e'};
+  span<const char>     const_span{s};
+
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+      s.begin(), s.end(),
+      const_span.begin(), const_span.end());
+}
+
+BOOST_AUTO_TEST_CASE(FromCArray)
+{
+  PRECICE_TEST(1_rank);
+  char             s[] = "hello there";
+  span<const char> const_span{s}; // Includes the NULL byte
+
+  BOOST_CHECK_EQUAL_COLLECTIONS(
+      s, s + 12,
+      const_span.begin(), const_span.end());
+}
+
+BOOST_AUTO_TEST_CASE(FromStringRef)
+{
+  PRECICE_TEST(1_rank);
+  std::string      s  = "hello there";
+  std::string &    sr = s;
+  span<const char> const_span{sr};
+  BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
+}
+
+BOOST_AUTO_TEST_CASE(FromConstStringRef)
+{
+  PRECICE_TEST(1_rank);
+  std::string        s   = "hello there";
+  const std::string &scr = s;
+  span<const char>   const_span{scr};
+  BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
+}
+
 BOOST_AUTO_TEST_CASE(FromCString)
+{
+  PRECICE_TEST(1_rank);
+  std::string      s  = "hello there";
+  char *           sp = s.data();
+  span<const char> const_span{sp};
+  BOOST_TEST(s == std::string(const_span.data(), const_span.size()));
+}
+
+BOOST_AUTO_TEST_CASE(FromConstCString)
 {
   PRECICE_TEST(1_rank);
   const char *     s = "hello there";


### PR DESCRIPTION
## Main changes of this PR

Add more tests for `precice::span`.

## Motivation and additional information

There seem to be ambiguity problems with `span<const char>`.

Triggered by https://precice.discourse.group/t/precice-span-instead-of-string-in-an-adapter/1801/2

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
