### PR TITLE
Hide boost.aggregator using pimpl

### DIFF
--- a/src/cplscheme/impl/TimeHandler.cpp
+++ b/src/cplscheme/impl/TimeHandler.cpp
@@ -1,0 +1,156 @@
+#include "TimeHandler.hpp"
+
+#include <optional>
+
+#include "math/differences.hpp"
+#include "utils/DoubleAggregator.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice::cplscheme::impl {
+
+struct TimeHandler::Impl {
+
+  /// The optional maximum time
+  std::optional<double> _maxTime = std::nullopt;
+
+  /// The aggregator for the start of a time window, handles timestep.
+  utils::DoubleAggregator _windowStart;
+
+  /// The aggregator progress inside a time window, handles substeps.
+  utils::DoubleAggregator _windowProgress;
+};
+
+// TimeHandler implementation
+
+TimeHandler::TimeHandler()
+    : _impl(std::make_unique<TimeHandler::Impl>())
+{
+}
+
+// Required by unique_ptr
+TimeHandler::~TimeHandler() = default;
+
+TimeHandler::TimeHandler(std::optional<double> maxTime)
+    : _impl(std::make_unique<TimeHandler::Impl>())
+{
+  _impl->_maxTime = maxTime;
+}
+
+TimeHandler::TimeHandler(const TimeHandler &other)
+    : _impl(std::make_unique<TimeHandler::Impl>(*other._impl))
+{
+}
+
+TimeHandler::TimeHandler(TimeHandler &&other)
+    : _impl(std::exchange(other._impl, nullptr))
+{
+}
+
+TimeHandler &TimeHandler::operator=(const TimeHandler &other)
+{
+  _impl = std::make_unique<TimeHandler::Impl>(*other._impl);
+  return *this;
+}
+
+TimeHandler &TimeHandler::operator=(TimeHandler &&other)
+{
+  _impl = std::exchange(other._impl, nullptr);
+  return *this;
+}
+
+void TimeHandler::resetTo(double timeStart)
+{
+  _impl->_windowStart = timeStart;
+  resetProgress();
+}
+
+void TimeHandler::progressBy(double dt)
+{
+  _impl->_windowProgress.add(dt);
+}
+
+void TimeHandler::resetProgress()
+{
+  _impl->_windowProgress = 0.0;
+}
+
+void TimeHandler::completeTimeWindow(double timeWindowSize)
+{
+  // Use the exact time window if possible
+  if (math::equals(windowProgress(), timeWindowSize)) {
+    _impl->_windowStart.add(timeWindowSize);
+  } else {
+    // Handle truncated time windows in case of reaching the end of the simulation
+    // This only happens when the final time window is truncated due
+    // time window size not being a divider of max-time.
+    PRECICE_ASSERT(reachedEnd(), "This can only happened if we reach max-time", timeWindowSize, time(), _impl->_maxTime.value_or(-1));
+    _impl->_windowStart.add(_impl->_windowProgress);
+  }
+  resetProgress();
+}
+
+// Queries about reaching ends
+
+bool TimeHandler::reachedEndOfWindow(double timeWindowSize) const
+{
+  return math::equals(untilWindowEnd(timeWindowSize), 0.0);
+}
+
+bool TimeHandler::reachedEnd() const
+{
+  if (!_impl->_maxTime) {
+    return false; // Directly return preventing lossy computations
+  }
+  return math::equals(untilTime(*_impl->_maxTime), 0.0);
+}
+
+// Time differences
+
+double TimeHandler::untilWindowEnd(double timeWindowSize) const
+{
+  double maxDt = untilProgress(timeWindowSize);
+  if (!_impl->_maxTime) {
+    return maxDt; // Return to prevent further lossy computations
+  }
+  // Truncate by max Time
+  return std::min(maxDt, untilEnd());
+}
+
+double TimeHandler::untilTime(double t) const
+{
+  // rearranged version of: maxtime - windowStart - windowProgress
+  return -(_impl->_windowStart + _impl->_windowProgress.value() - t).value();
+}
+
+double TimeHandler::untilEnd() const
+{
+  if (!_impl->_maxTime) {
+    return std::numeric_limits<double>::max();
+  }
+  return untilTime(_impl->_maxTime.value());
+}
+
+double TimeHandler::windowProgress() const
+{
+  return _impl->_windowProgress.value();
+}
+
+// Time points
+
+double TimeHandler::windowStart() const
+{
+  return _impl->_windowStart.value();
+}
+
+double TimeHandler::time() const
+{
+  return (_impl->_windowStart + _impl->_windowProgress.value()).value();
+}
+
+double TimeHandler::untilProgress(double windowSize) const
+{
+  // rearranged version of: windowSize - _windowProgress
+  return -(_impl->_windowProgress - windowSize).value();
+}
+
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/impl/TimeHandler.hpp
+++ b/src/cplscheme/impl/TimeHandler.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
+#include <memory>
 #include <optional>
-
-#include "math/differences.hpp"
-#include "utils/DoubleAggregator.hpp"
-#include "utils/assertion.hpp"
 
 namespace precice::cplscheme::impl {
 
@@ -17,61 +14,36 @@ namespace precice::cplscheme::impl {
  */
 class TimeHandler {
 public:
-  TimeHandler() = default;
+  TimeHandler();
+  ~TimeHandler();
 
   /// Constructor for setting an optional maximum time
-  TimeHandler(std::optional<double> maxTime)
-      : _maxTime(maxTime)
-  {
-  }
+  TimeHandler(std::optional<double> maxTime);
 
-  TimeHandler(const TimeHandler &) = default;
-  TimeHandler(TimeHandler &&)      = default;
+  TimeHandler(const TimeHandler &);
+  TimeHandler(TimeHandler &&);
 
-  TimeHandler &operator=(const TimeHandler &) = default;
-  TimeHandler &operator=(TimeHandler &&) = default;
+  TimeHandler &operator=(const TimeHandler &);
+  TimeHandler &operator=(TimeHandler &&);
 
   /// @name State altering functions
   /// @{
 
   /// Resets the handler to the given time
-  void resetTo(double timeStart)
-  {
-    _windowStart = timeStart;
-    resetProgress();
-  }
+  void resetTo(double timeStart);
 
   /// Progress the time window by the given amount
-  void progressBy(double dt)
-  {
-    _windowProgress.add(dt);
-  }
+  void progressBy(double dt);
 
   /// Resets the progress of the time window back to 0
-  void resetProgress()
-  {
-    _windowProgress = 0.0;
-  }
+  void resetProgress();
 
   /** Complete the time window moving the start of the time window
    *
    * The given exact time window size will be used if it is approximately equal to
    * the accumulated progress.
    */
-  void completeTimeWindow(double timeWindowSize)
-  {
-    // Use the exact time window if possible
-    if (math::equals(windowProgress(), timeWindowSize)) {
-      _windowStart.add(timeWindowSize);
-    } else {
-      // Handle truncated time windows in case of reaching the end of the simulation
-      // This only happens when the final time window is truncated due
-      // time window size not being a divider of max-time.
-      PRECICE_ASSERT(reachedEnd(), "This can only happened if we reach max-time", timeWindowSize, time(), _maxTime.value_or(-1));
-      _windowStart.add(_windowProgress);
-    }
-    resetProgress();
-  }
+  void completeTimeWindow(double timeWindowSize);
 
   /// @}
   /// @name Queries about reaching ends
@@ -80,93 +52,50 @@ public:
   /** Has the end of the time window been reached?
    * This respects max time.
    */
-  bool reachedEndOfWindow(double timeWindowSize) const
-  {
-    return math::equals(untilWindowEnd(timeWindowSize), 0.0);
-  }
+  bool reachedEndOfWindow(double timeWindowSize) const;
 
   /** Has the end of the overall time been reached?
    * This is always false if no max time has been defined.
    */
-  bool reachedEnd() const
-  {
-    if (!_maxTime) {
-      return false; // Directly return preventing lossy computations
-    }
-    return math::equals(untilTime(*_maxTime), 0.0);
-  }
+  bool reachedEnd() const;
 
   /// @}
   /// @name Time differences
   /// @{
 
   /// Returns the time distance to the possibly truncated end of the current time window
-  double untilWindowEnd(double timeWindowSize) const
-  {
-    double maxDt = untilProgress(timeWindowSize);
-    if (!_maxTime) {
-      return maxDt; // Return to prevent further lossy computations
-    }
-    // Truncate by max Time
-    return std::min(maxDt, untilEnd());
-  }
+  double untilWindowEnd(double timeWindowSize) const;
 
   /// Returns the time difference until the overall time reaches the given time
-  double untilTime(double t) const
-  {
-    // rearranged version of: maxtime - windowStart - windowProgress
-    return -(_windowStart + _windowProgress.value() - t).value();
-  }
+  double untilTime(double t) const;
 
   /** Returns the time difference until the end of the overall time.
     * This returns infinity if there is no maximum time defined.
     */
-  double untilEnd() const
-  {
-    if (!_maxTime) {
-      return std::numeric_limits<double>::max();
-    }
-    return untilTime(*_maxTime);
-  }
+  double untilEnd() const;
 
   /// Returns the window progress as a double
-  double windowProgress() const
-  {
-    return _windowProgress.value();
-  }
+  double windowProgress() const;
 
   /// @}
   /// @name Time points
   /// @{
 
   /// Returns the window start as a double
-  double windowStart() const
-  {
-    return _windowStart.value();
-  }
+  double windowStart() const;
 
   /// Returns the current time as a double
-  double time() const
-  {
-    return (_windowStart + _windowProgress.value()).value();
-  }
+  double time() const;
 
   /// @}
 
 private:
-  /// The optional maximum time
-  std::optional<double> _maxTime = std::nullopt;
-  /// The aggregator for the start of a time window, handles timestep.
-  utils::DoubleAggregator _windowStart;
-  /// The aggregator progress inside a time window, handles substeps.
-  utils::DoubleAggregator _windowProgress;
+  /// Impl to hide aggregator details
+  struct Impl;
 
-  /// Returns the time difference until the progress reaches the given window size
-  double untilProgress(double windowSize) const
-  {
-    // rearranged version of: windowSize - _windowProgress
-    return -(_windowProgress - windowSize).value();
-  }
+  std::unique_ptr<Impl> _impl;
+
+  double untilProgress(double windowSize) const;
 };
 
 } // namespace precice::cplscheme::impl

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -122,6 +122,7 @@ target_sources(preciceCore
     src/cplscheme/impl/ResidualRelativeConvergenceMeasure.cpp
     src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
     src/cplscheme/impl/SharedPointer.hpp
+    src/cplscheme/impl/TimeHandler.cpp
     src/cplscheme/impl/TimeHandler.hpp
     src/io/Export.hpp
     src/io/ExportCSV.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR hides the Boost.Aggregator library from the CouplingSchemes by using a Pimpl in TimeHandler.
This reduces total compile time by around 30 seconds.

## Motivation and additional information

Pimpl wasn't used in DoubleAggregator to simplify changeing the implementation for future experiments and to keep the entire time-based numerics in a single compilation unit.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
