### PR TITLE
Use fastcov for coverage support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -163,8 +163,9 @@ jobs:
         working-directory: build
         if: ${{ matrix.COVFLAGS }}
         run: |
-          lcov --capture --directory . --output-file coverage.info
-          lcov --remove coverage.info '/usr/*' "/opt/*" --output-file coverage.info # filter system-files and local-dependencies
+          . ../venv/bin/activate
+          pip install fastcov
+          fastcov --lcov -e '/usr/' -e '/opt/'
       - uses: codecov/codecov-action@v4
         with:
           files: ./build/coverage.info


### PR DESCRIPTION
## Main changes of this PR

This PR switches from lcov to fastcov for generating the coverage support.

## Motivation and additional information

Installing fastcov and running it completes in under 10 second which used to be 40-120 seconds.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

