### PR TITLE
Cleanup CI

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -82,7 +82,7 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
       working-directory: build
-      run: make test
+      run: ctest
     - uses: actions/upload-artifact@v4
       if: failure()
       with:

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install pip packages
       run: pip3 install numpy polars
     - name: Install preCICE dependencies
-      run: brew install cmake eigen libxml2 boost petsc openmpi pkg-config
+      run: brew install cmake eigen libxml2 boost petsc openmpi pkg-config ninja
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure
@@ -58,7 +58,7 @@ jobs:
         PETSc: ${{ contains(matrix.CONFIG, 'PETSc') }}
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+        cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -G Ninja ..
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
@@ -77,7 +77,7 @@ jobs:
     - name: Compile
       working-directory: build
       run: |
-        make -j $(sysctl -n hw.ncpu)
+        cmake --build .
     - name: Tests
       env:
         CTEST_OUTPUT_ON_FAILURE: 1

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -43,8 +43,8 @@ jobs:
       with:
        python-version: '3.10'
        check-latest: true
-    - name: Install numpy
-      run: pip3 install numpy
+    - name: Install pip packages
+      run: pip3 install numpy polars
     - name: Install preCICE dependencies
       run: brew install cmake eigen libxml2 boost petsc openmpi pkg-config
     - name: Generate build directory

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,8 +98,6 @@ jobs:
             CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Release
-    env:
-      OMPI_MCA_rmaps_base_oversubscribe: 1
     steps:
       - uses: actions/checkout@v4
       - name: Generate build directory

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -99,14 +99,8 @@ jobs:
             CXX: 'g++'
             TYPE: Release
     env:
-      CCACHE_DIR: "$GITHUB_WORKSPACE/ccache"
       OMPI_MCA_rmaps_base_oversubscribe: 1
     steps:
-      - name: Restore ccache
-        uses: actions/cache@v4
-        with:
-          path: ccache
-          key: precice-ccache-${{ runner.IMAGE }}-${{ matrix.CONFIG }}-${{ matrix.CXX }}-${{ matrix.TYPE }}
       - uses: actions/checkout@v4
       - name: Generate build directory
         run: mkdir -p build
@@ -126,7 +120,7 @@ jobs:
         run: |
           . ../venv/bin/activate # There is always a venv present
           cmake --version
-          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DPRECICE_FEATURE_GINKGO_MAPPING=${{ env.Ginkgo }} -DPRECICE_FEATURE_LIBBACKTRACE_STACKTRACES=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.COVFLAGS }}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+          cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ matrix.TYPE }} -DPRECICE_FEATURE_MPI_COMMUNICATION=${{ env.MPI }} -DPRECICE_FEATURE_PETSC_MAPPING=${{ env.PETSc }} -DPRECICE_FEATURE_GINKGO_MAPPING=${{ env.Ginkgo }} -DPRECICE_FEATURE_LIBBACKTRACE_STACKTRACES=ON -DCMAKE_EXE_LINKER_FLAGS="${{ matrix.COVFLAGS }}" -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
       - uses: actions/upload-artifact@v4
         if: failure()
         with:


### PR DESCRIPTION
## Main changes of this PR

This PR removes ccache, obsolete oversubscription envs, adds polars to MacOS, and used Ninja on MacOS to avoid having to ask for core count.

## Motivation and additional information

Simpler CI, more consistent feature tests.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
