### PR TITLE
Porting ConfigParser to use std::string_view wherever possible

### DIFF
--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -64,7 +64,7 @@ void OnStartElementNs(
 
   auto pParser = static_cast<ConfigParser *>(ctx);
 
-  std::string sPrefix(prefix == nullptr ? "" : reinterpret_cast<const char *>(prefix));
+  std::string_view sPrefix(prefix == nullptr ? "" : reinterpret_cast<const char *>(prefix));
 
   pParser->OnStartElement(reinterpret_cast<const char *>(localname), sPrefix, attributesMap);
 }
@@ -210,7 +210,7 @@ auto gatherCandidates(const std::vector<std::shared_ptr<XMLTag>> &DefTags, std::
 
 void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<std::shared_ptr<XMLTag>> &DefTags, CTagPtrVec &SubTags)
 {
-  std::unordered_set<std::string> usedTags;
+  std::unordered_set<std::string_view> usedTags;
 
   for (auto &subtag : SubTags) {
     std::string expectedName = (subtag->m_Prefix.length() ? subtag->m_Prefix + ":" : "") + subtag->m_Name;
@@ -259,8 +259,8 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 }
 
 void ConfigParser::OnStartElement(
-    std::string         localname,
-    std::string         prefix,
+    std::string_view    localname,
+    std::string_view    prefix,
     CTag::AttributePair attributes)
 {
   auto pTag = std::make_shared<CTag>();

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -228,7 +228,7 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
       auto matches = utils::computeMatches(expectedName, names);
       if (!matches.empty() && matches.front().distance < 3) {
         matches.erase(std::remove_if(matches.begin(), matches.end(), [](auto &m) { return m.distance > 2; }), matches.end());
-        std::vector<std::string> stringMatches;
+        std::vector<std::string_view> stringMatches;
         std::transform(matches.begin(), matches.end(), std::back_inserter(stringMatches), [](auto &m) { return m.name; });
         PRECICE_ERROR("The configuration contains an unknown tag <{}>. Did you mean <{}>?", expectedName, fmt::join(stringMatches, ">,<"));
       } else {

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -122,7 +122,7 @@ precice::logging::Logger ConfigParser::_log("xml::XMLParser");
 ConfigParser::ConfigParser(std::string_view filePath, const ConfigurationContext &context, std::shared_ptr<precice::xml::XMLTag> pXmlTag)
     : m_pXmlTag(std::move(pXmlTag))
 {
-  readXmlFile(filePath);
+  readXmlFile(std::string(filePath));
 
   std::vector<std::shared_ptr<XMLTag>> DefTags{m_pXmlTag};
   CTagPtrVec                           SubTags;
@@ -139,7 +139,7 @@ ConfigParser::ConfigParser(std::string_view filePath, const ConfigurationContext
 
 ConfigParser::ConfigParser(std::string_view filePath)
 {
-  readXmlFile(filePath);
+  readXmlFile(std::string(filePath));
 }
 
 void ConfigParser::MessageProxy(int level, std::string_view mess)
@@ -157,7 +157,7 @@ void ConfigParser::MessageProxy(int level, std::string_view mess)
   }
 }
 
-int ConfigParser::readXmlFile(std::string_view filePath)
+int ConfigParser::readXmlFile(std::string const &filePath)
 {
   xmlSAXHandler SAXHandler;
 
@@ -171,7 +171,7 @@ int ConfigParser::readXmlFile(std::string_view filePath)
   SAXHandler.error          = OnErrorFunc;
   SAXHandler.fatalError     = OnFatalErrorFunc;
 
-  std::ifstream ifs{std::string(filePath).c_str()};
+  std::ifstream ifs{filePath};
   PRECICE_CHECK(ifs, "XML parser was unable to open configuration file \"{}\"", filePath);
 
   std::string content{std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>()};

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -87,7 +87,7 @@ void OnCharacters(void *ctx, const xmlChar *ch, int len)
 
 void OnStructuredErrorFunc(void *userData, const xmlError *error)
 {
-  const std::string message{error->message};
+  const std::string_view message{error->message};
 
   // Ignore all namespace-related messages
   if (message.find("Namespace") != std::string::npos) {
@@ -117,10 +117,10 @@ void OnFatalErrorFunc(void *userData, const char *error, ...)
 
 precice::logging::Logger ConfigParser::_log("xml::XMLParser");
 
-ConfigParser::ConfigParser(const std::string &filePath, const ConfigurationContext &context, std::shared_ptr<precice::xml::XMLTag> pXmlTag)
+ConfigParser::ConfigParser(std::string_view filePath, const ConfigurationContext &context, std::shared_ptr<precice::xml::XMLTag> pXmlTag)
     : m_pXmlTag(std::move(pXmlTag))
 {
-  readXmlFile(filePath);
+  readXmlFile(std::string(filePath));
 
   std::vector<std::shared_ptr<XMLTag>> DefTags{m_pXmlTag};
   CTagPtrVec                           SubTags;
@@ -135,12 +135,12 @@ ConfigParser::ConfigParser(const std::string &filePath, const ConfigurationConte
   }
 }
 
-ConfigParser::ConfigParser(const std::string &filePath)
+ConfigParser::ConfigParser(std::string_view filePath)
 {
-  readXmlFile(filePath);
+  readXmlFile(std::string(filePath));
 }
 
-void ConfigParser::MessageProxy(int level, const std::string &mess)
+void ConfigParser::MessageProxy(int level, std::string_view mess)
 {
   switch (level) {
   case (XML_ERR_FATAL):

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -20,7 +20,7 @@ namespace precice::xml {
 
 std::string decodeXML(std::string xml)
 {
-  static const std::map<std::string, char> escapes{{"&lt;", '<'}, {"&gt;", '>'}, {"&amp;", '&'}, {"&quot;", '"'}, {"&apos;", '\''}};
+  static const std::map<std::string_view, char> escapes{{"&lt;", '<'}, {"&gt;", '>'}, {"&amp;", '&'}, {"&quot;", '"'}, {"&apos;", '\''}};
   while (true) {
     bool changes{false};
     for (const auto &kv : escapes) {
@@ -59,14 +59,14 @@ void OnStartElementNs(
     auto        valueEnd   = reinterpret_cast<const char *>(attributes[index + 4]);
     std::string value(valueBegin, valueEnd);
 
-    attributesMap[attributeName] = decodeXML(value);
+    attributesMap[attributeName] = decodeXML(std::move(value));
   }
 
   auto pParser = static_cast<ConfigParser *>(ctx);
 
-  std::string_view sPrefix(prefix == nullptr ? "" : reinterpret_cast<const char *>(prefix));
+  std::string sPrefix(prefix == nullptr ? "" : reinterpret_cast<const char *>(prefix));
 
-  pParser->OnStartElement(reinterpret_cast<const char *>(localname), sPrefix, attributesMap);
+  pParser->OnStartElement(std::move(reinterpret_cast<const char *>(localname)), std::move(sPrefix), attributesMap);
 }
 
 void OnEndElementNs(
@@ -259,8 +259,8 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 }
 
 void ConfigParser::OnStartElement(
-    std::string_view    localname,
-    std::string_view    prefix,
+    std::string         localname,
+    std::string         prefix,
     CTag::AttributePair attributes)
 {
   auto pTag = std::make_shared<CTag>();

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -44,10 +44,10 @@ private:
 
 public:
   /// Parser ctor for Callback init
-  ConfigParser(const std::string &filePath, const ConfigurationContext &context, std::shared_ptr<XMLTag> pXmlTag);
+  ConfigParser(std::string_view filePath, const ConfigurationContext &context, std::shared_ptr<XMLTag> pXmlTag);
 
   /// Parser ctor without Callbacks
-  ConfigParser(const std::string &filePath);
+  ConfigParser(std::string_view filePath);
 
   /// Reads the xml file
   int readXmlFile(std::string const &filePath);
@@ -72,7 +72,7 @@ public:
   void OnTextSection(const std::string &ch);
 
   /// Proxy for error and warning messages from libxml2
-  static void MessageProxy(int level, const std::string &mess);
+  static void MessageProxy(int level, std::string_view mess);
 };
 } // namespace xml
 } // namespace precice

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -61,8 +61,8 @@ public:
 
   /// Callback for Start-Tag
   void OnStartElement(
-      std::string_view    localname,
-      std::string_view    prefix,
+      std::string         localname,
+      std::string         prefix,
       CTag::AttributePair attributes);
 
   /// Callback for End-Tag

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -61,8 +61,8 @@ public:
 
   /// Callback for Start-Tag
   void OnStartElement(
-      std::string         localname,
-      std::string         prefix,
+      std::string_view    localname,
+      std::string_view    prefix,
       CTag::AttributePair attributes);
 
   /// Callback for End-Tag

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -50,7 +50,7 @@ public:
   ConfigParser(std::string_view filePath);
 
   /// Reads the xml file
-  int readXmlFile(std::string_view filePath);
+  int readXmlFile(std::string const &filePath);
 
   /**
    * @brief Connects the actual tags of an xml layer with the predefined tags

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -17,7 +17,7 @@ class XMLTag; // forward declaration to resolve circular import
 struct ConfigurationContext;
 
 /// Decodes escape sequences of a given xml
-std::string decodeXML(std::string xml);
+std::string decodeXML(std::string_view xml);
 
 class ConfigParser {
 public:
@@ -50,7 +50,7 @@ public:
   ConfigParser(std::string_view filePath);
 
   /// Reads the xml file
-  int readXmlFile(std::string const &filePath);
+  int readXmlFile(std::string_view filePath);
 
   /**
    * @brief Connects the actual tags of an xml layer with the predefined tags
@@ -61,8 +61,8 @@ public:
 
   /// Callback for Start-Tag
   void OnStartElement(
-      std::string         localname,
-      std::string         prefix,
+      std::string_view    localname,
+      std::string_view    prefix,
       CTag::AttributePair attributes);
 
   /// Callback for End-Tag

--- a/src/xml/Printer.cpp
+++ b/src/xml/Printer.cpp
@@ -318,13 +318,13 @@ std::ostream &printMD(std::ostream &out, const XMLTag &tag, int level, std::map<
         out << fmt::format("[* {}]({}) `{}`",
                            heading,
                            link,
-                           std::string(subtag->getOccurrenceString(subtag->getOccurrence())));
+                           subtag->getOccurrenceString(subtag->getOccurrence()));
       } else {
         auto &tags = groupedTags[ns];
         tags.emplace_back(fmt::format("[{}]({}) `{}`",
                                       subtag->getName(),
                                       link,
-                                      std::string(subtag->getOccurrenceString(subtag->getOccurrence()))));
+                                      subtag->getOccurrenceString(subtag->getOccurrence())));
       }
     }
     for (const auto &kv : groupedTags) {

--- a/src/xml/Printer.cpp
+++ b/src/xml/Printer.cpp
@@ -317,7 +317,7 @@ std::ostream &printMD(std::ostream &out, const XMLTag &tag, int level, std::map<
         out << "* [" << heading << "](" << link << ") `" << subtag->getOccurrenceString(subtag->getOccurrence()) << "`\n";
       } else {
         auto &tags = groupedTags[ns];
-        tags.emplace_back("[" + subtag->getName() + "](" + link + ") `" + subtag->getOccurrenceString(subtag->getOccurrence()) + "`");
+        tags.emplace_back("[" + subtag->getName() + "](" + link + ") `" + std::string(subtag->getOccurrenceString(subtag->getOccurrence())) + "`");
       }
     }
     for (const auto &kv : groupedTags) {

--- a/src/xml/Printer.cpp
+++ b/src/xml/Printer.cpp
@@ -2,6 +2,7 @@
 #include <Eigen/Core>
 #include <algorithm>
 #include <cctype>
+#include <fmt/format.h>
 #include <map>
 #include <memory>
 #include <regex>
@@ -314,10 +315,16 @@ std::ostream &printMD(std::ostream &out, const XMLTag &tag, int level, std::map<
 
       const auto ns = subtag->getNamespace();
       if (ns.empty()) {
-        out << "* [" << heading << "](" << link << ") `" << subtag->getOccurrenceString(subtag->getOccurrence()) << "`\n";
+        out << fmt::format("[* {}]({}) `{}`",
+                           heading,
+                           link,
+                           std::string(subtag->getOccurrenceString(subtag->getOccurrence())));
       } else {
         auto &tags = groupedTags[ns];
-        tags.emplace_back("[" + subtag->getName() + "](" + link + ") `" + std::string(subtag->getOccurrenceString(subtag->getOccurrence())) + "`");
+        tags.emplace_back(fmt::format("[{}]({}) `{}`",
+                                      subtag->getName(),
+                                      link,
+                                      std::string(subtag->getOccurrenceString(subtag->getOccurrence()))));
       }
     }
     for (const auto &kv : groupedTags) {

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -34,7 +34,7 @@ public:
   XMLAttribute &operator=(const XMLAttribute<ATTRIBUTE_T> &other) = default;
 
   /// Sets a documentation string for the attribute.
-  XMLAttribute &setDocumentation(std::string documentation);
+  XMLAttribute &setDocumentation(std::string_view documentation);
 
   const std::string &getUserDocumentation() const
   {
@@ -127,9 +127,9 @@ private:
 };
 
 template <typename ATTRIBUTE_T>
-XMLAttribute<ATTRIBUTE_T> &XMLAttribute<ATTRIBUTE_T>::setDocumentation(std::string documentation)
+XMLAttribute<ATTRIBUTE_T> &XMLAttribute<ATTRIBUTE_T>::setDocumentation(std::string_view documentation)
 {
-  _doc = std::move(documentation);
+  _doc = documentation;
   return *this;
 }
 

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -403,7 +403,7 @@ void configure(
   NoPListener nopListener;
   XMLTag      root(nopListener, "", XMLTag::OCCUR_ONCE);
 
-  precice::xml::ConfigParser p(std::string(configurationFilename), context, std::make_shared<XMLTag>(tag));
+  precice::xml::ConfigParser p(configurationFilename, context, std::make_shared<XMLTag>(tag));
 
   root.addSubtag(tag);
 }

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -26,7 +26,7 @@ XMLTag::XMLTag(
   }
 }
 
-XMLTag &XMLTag::setDocumentation(const std::string &documentation)
+XMLTag &XMLTag::setDocumentation(std::string_view documentation)
 {
   _doc = documentation;
   return *this;
@@ -408,18 +408,18 @@ void configure(
   root.addSubtag(tag);
 }
 
-std::string XMLTag::getOccurrenceString(XMLTag::Occurrence occurrence)
+std::string_view XMLTag::getOccurrenceString(XMLTag::Occurrence occurrence)
 {
   if (occurrence == XMLTag::OCCUR_ARBITRARY) {
-    return std::string("0..*");
+    return ("0..*");
   } else if (occurrence == XMLTag::OCCUR_NOT_OR_ONCE) {
-    return std::string("0..1");
+    return ("0..1");
   } else if (occurrence == XMLTag::OCCUR_ONCE) {
-    return std::string("1");
+    return ("1");
   } else if (occurrence == XMLTag::OCCUR_ONCE_OR_MORE) {
-    return std::string("1..*");
+    return ("1..*");
   }
-  return "";
+  return ("");
 }
 } // namespace precice::xml
 

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -411,15 +411,15 @@ void configure(
 std::string_view XMLTag::getOccurrenceString(XMLTag::Occurrence occurrence)
 {
   if (occurrence == XMLTag::OCCUR_ARBITRARY) {
-    return ("0..*");
+    return "0..*";
   } else if (occurrence == XMLTag::OCCUR_NOT_OR_ONCE) {
-    return ("0..1");
+    return "0..1";
   } else if (occurrence == XMLTag::OCCUR_ONCE) {
-    return ("1");
+    return "1";
   } else if (occurrence == XMLTag::OCCUR_ONCE_OR_MORE) {
-    return ("1..*");
+    return "1..*";
   }
-  return ("");
+  return "";
 }
 } // namespace precice::xml
 

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -72,7 +72,7 @@ public:
     OCCUR_ARBITRARY_NESTED
   };
 
-  static std::string getOccurrenceString(Occurrence occurrence);
+  static std::string_view getOccurrenceString(Occurrence occurrence);
 
   /**
    * @brief Standard constructor
@@ -93,7 +93,7 @@ public:
    *
    * The description and more information is printed with printDocumentation().
    */
-  XMLTag &setDocumentation(const std::string &documentation);
+  XMLTag &setDocumentation(std::string_view documentation);
 
   std::string getDocumentation() const
   {


### PR DESCRIPTION
## Main changes of this PR

The ConfigParser bridges the call-back-based C-library libxml2 to the C++ XMLTag and XMLAttribute of preCICE. This PR ports ConfigParser to use std::string_view instead of std::string where the components don't own data. This leads to less casting, fewer copies, and potentially better performance.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

See #1926.
## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
