### PR TITLE
Always clamp relative time when interpolating

### DIFF
--- a/docs/changelog/1982.md
+++ b/docs/changelog/1982.md
@@ -1,0 +1,1 @@
+- Fixed a bug where reading from the end of the time window can trigger an assertion.

--- a/src/math/Bspline.cpp
+++ b/src/math/Bspline.cpp
@@ -57,16 +57,8 @@ Bspline::Bspline(Eigen::VectorXd ts, const Eigen::MatrixXd &xs, int splineDegree
 
 Eigen::VectorXd Bspline::interpolateAt(double t) const
 {
-  if (math::equals(t, _tsMax)) {
-    t = _tsMax; // set t exactly to _tsMax, to avoid artifacts originating from floating-point arithmetic
-  } else if (math::equals(t, _tsMin)) {
-    t = _tsMin; // set t exactly to _tsMin, to avoid artifacts originating from floating-point arithmetic
-  }
-
   // transform t to the relative interval [0; 1]
-  const double tRelative = (t - _tsMin) / (_tsMax - _tsMin);
-  PRECICE_ASSERT(math::greaterEquals(tRelative, 0.0), "t is before the first sample!", tRelative, 0.0, _tsMin); // Only allowed to use BSpline for interpolation, not extrapolation.
-  PRECICE_ASSERT(math::smallerEquals(tRelative, 1.0), "t is after the last sample!", tRelative, 1.0, _tsMax);   // Only allowed to use BSpline for interpolation, not extrapolation.
+  const double tRelative = std::clamp((t - _tsMin) / (_tsMax - _tsMin), 0.0, 1.0);
 
   Eigen::VectorXd interpolated(_ndofs);
   constexpr int   splineDimension = 1;

--- a/src/math/tests/BSplineTest.cpp
+++ b/src/math/tests/BSplineTest.cpp
@@ -123,5 +123,20 @@ BOOST_AUTO_TEST_CASE(ThreePointsQuadraticNonEquidistant)
   BOOST_TEST(equals(bspline.interpolateAt(2.0), Eigen::Vector3d(8.0 / 3, 80.0 / 3, 800.0 / 3), 1e-13));
 }
 
+BOOST_AUTO_TEST_CASE(FloatingPointAccuracy) // see https://github.com/precice/precice/issues/1981
+{
+  PRECICE_TEST(1_rank);
+  Eigen::Vector2d ts;
+  ts << 256.1, 256.2;
+  Eigen::MatrixXd xs(3, 2);
+  xs << 1, 2, 10, 20, 100, 200;
+  precice::math::Bspline bspline(ts, xs, 1);
+  // Points
+  BOOST_TEST(equals(bspline.interpolateAt(256.1), Eigen::Vector3d(1, 10, 100)));
+  BOOST_TEST(equals(bspline.interpolateAt(256.2), Eigen::Vector3d(2, 20, 200)));
+  // 256.1 + 0.1 > 256.2 in floating point numbers!
+  BOOST_TEST(equals(bspline.interpolateAt(256.1 + 0.1), Eigen::Vector3d(2, 20, 200)));
+}
+
 BOOST_AUTO_TEST_SUITE_END() // BSpline
 BOOST_AUTO_TEST_SUITE_END() // Math


### PR DESCRIPTION
## Main changes of this PR

This PR will always clamp the relative time to `[0;1]` in the BSpline interpolation.
This prevents dealing with rounding errors at a point, where all other scenarios should have been handled.

## Motivation and additional information

Solves #1981

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
