### PR TITLE
Check participants in M2N and coupling-scheme tags

### DIFF
--- a/docs/changelog/1995.md
+++ b/docs/changelog/1995.md
@@ -1,0 +1,1 @@
+- Added missing checks for incorrect Participant names in M2N and coupling-scheme.

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -111,12 +111,10 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
 
 m2n::PtrM2N M2NConfiguration::getM2N(const std::string &acceptor, const std::string &connector)
 {
-  using std::get;
-  for (M2NTuple &tuple : _m2ns) {
-    if ((get<1>(tuple) == acceptor) && (get<2>(tuple) == connector)) {
-      return get<0>(tuple);
-    } else if ((get<2>(tuple) == acceptor) && (get<1>(tuple) == connector)) {
-      return get<0>(tuple);
+  for (M2NTuple &conf : _m2ns) {
+    if ((conf.acceptor == acceptor && conf.connector == connector) ||
+        (conf.connector == acceptor && conf.acceptor == connector)) {
+      return conf.m2n;
     }
   }
   PRECICE_ERROR("There is no m2n communication configured between participants \"" + acceptor + "\" and \"" + connector + "\". Please add an appropriate \"<m2n />\" tag.");
@@ -125,8 +123,8 @@ m2n::PtrM2N M2NConfiguration::getM2N(const std::string &acceptor, const std::str
 bool M2NConfiguration::isM2NConfigured(const std::string &acceptor, const std::string &connector)
 {
   return std::any_of(std::begin(_m2ns), std::end(_m2ns),
-                     [acceptor, connector](const auto &m2nTuple) {
-                       return ((std::get<1>(m2nTuple) == acceptor) && (std::get<2>(m2nTuple) == connector)) || ((std::get<1>(m2nTuple) == connector) && (std::get<2>(m2nTuple) == acceptor));
+                     [acceptor, connector](const auto &conf) {
+                       return (conf.acceptor == acceptor && conf.connector == connector) || (conf.connector == acceptor && conf.acceptor == connector);
                      });
 }
 
@@ -196,8 +194,10 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
     }
     PRECICE_ASSERT(distrFactory.get() != nullptr);
 
-    auto m2n = std::make_shared<m2n::M2N>(com, distrFactory, false, useTwoLevelInit);
-    _m2ns.emplace_back(m2n, acceptor, connector);
+    _m2ns.emplace_back(M2NTuple{
+        std::make_shared<m2n::M2N>(com, distrFactory, false, useTwoLevelInit),
+        acceptor,
+        connector});
   }
 }
 
@@ -207,9 +207,9 @@ void M2NConfiguration::checkDuplicates(
 {
   using std::get;
   bool alreadyAdded = false;
-  for (M2NTuple &tuple : _m2ns) {
-    alreadyAdded |= (get<1>(tuple) == acceptor) && (get<2>(tuple) == connector);
-    alreadyAdded |= (get<2>(tuple) == acceptor) && (get<1>(tuple) == connector);
+  for (M2NTuple &conf : _m2ns) {
+    alreadyAdded |= conf.acceptor == acceptor && conf.connector == connector;
+    alreadyAdded |= conf.connector == acceptor && conf.acceptor == connector;
   }
   PRECICE_CHECK(!alreadyAdded, "Multiple m2n communications between participant \"" + acceptor + "\" and \"" + connector + "\" are not allowed. Please remove redundant <m2n /> tags between them.");
 }

--- a/src/m2n/config/M2NConfiguration.cpp
+++ b/src/m2n/config/M2NConfiguration.cpp
@@ -111,7 +111,7 @@ M2NConfiguration::M2NConfiguration(xml::XMLTag &parent)
 
 m2n::PtrM2N M2NConfiguration::getM2N(const std::string &acceptor, const std::string &connector)
 {
-  for (M2NTuple &conf : _m2ns) {
+  for (ConfiguredM2N &conf : _m2ns) {
     if ((conf.acceptor == acceptor && conf.connector == connector) ||
         (conf.connector == acceptor && conf.acceptor == connector)) {
       return conf.m2n;
@@ -194,7 +194,7 @@ void M2NConfiguration::xmlTagCallback(const xml::ConfigurationContext &context, 
     }
     PRECICE_ASSERT(distrFactory.get() != nullptr);
 
-    _m2ns.emplace_back(M2NTuple{
+    _m2ns.emplace_back(ConfiguredM2N{
         std::make_shared<m2n::M2N>(com, distrFactory, false, useTwoLevelInit),
         acceptor,
         connector});
@@ -207,7 +207,7 @@ void M2NConfiguration::checkDuplicates(
 {
   using std::get;
   bool alreadyAdded = false;
-  for (M2NTuple &conf : _m2ns) {
+  for (ConfiguredM2N &conf : _m2ns) {
     alreadyAdded |= conf.acceptor == acceptor && conf.connector == connector;
     alreadyAdded |= conf.connector == acceptor && conf.acceptor == connector;
   }

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -17,7 +17,11 @@ namespace m2n {
 class M2NConfiguration : public xml::XMLTag::Listener {
 public:
   using SharedPointer = std::shared_ptr<M2NConfiguration>;
-  using M2NTuple      = std::tuple<m2n::PtrM2N, std::string, std::string>;
+  struct M2NTuple {
+    m2n::PtrM2N m2n;
+    std::string acceptor;
+    std::string connector;
+  };
 
 public:
   explicit M2NConfiguration(xml::XMLTag &parent);

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -17,9 +17,12 @@ namespace m2n {
 class M2NConfiguration : public xml::XMLTag::Listener {
 public:
   using SharedPointer = std::shared_ptr<M2NConfiguration>;
-  struct M2NTuple {
+  struct ConfiguredM2N {
+    /// The configured M2N
     m2n::PtrM2N m2n;
+    /// The name of the acceptor
     std::string acceptor;
+    /// The name of the connector
     std::string connector;
   };
 
@@ -39,7 +42,7 @@ public:
       const std::string &connector);
 
   /// Returns all configured communication objects.
-  std::vector<M2NTuple> &m2ns()
+  std::vector<ConfiguredM2N> &m2ns()
   {
     return _m2ns;
   }
@@ -58,7 +61,7 @@ private:
   const std::string ATTR_ENFORCE_GATHER_SCATTER = "enforce-gather-scatter";
   const std::string ATTR_USE_TWO_LEVEL_INIT     = "use-two-level-initialization";
 
-  std::vector<M2NTuple> _m2ns;
+  std::vector<ConfiguredM2N> _m2ns;
 
   void checkDuplicates(
       const std::string &acceptor,

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -76,25 +76,25 @@ void Configuration::xmlEndTagCallback(
     xml::XMLTag &                    tag)
 {
   PRECICE_TRACE(tag.getName());
-  if (tag.getName() == "precice-configuration") {
-    //test if both participants do have the exchange meshes
-    typedef std::map<std::string, std::vector<std::string>>::value_type neededMeshPair;
-    for (const neededMeshPair &neededMeshes : _meshConfiguration->getNeededMeshes()) {
-      bool participantFound = false;
-      for (const impl::PtrParticipant &participant : _participantConfiguration->getParticipants()) {
-        if (participant->getName() == neededMeshes.first) {
-          for (const std::string &neededMesh : neededMeshes.second) {
-            PRECICE_CHECK(participant->isMeshUsed(neededMesh),
-                          "Participant \"{}\" needs to use the mesh \"{}\" to be able to use it in the coupling scheme. "
-                          "Please either add a provide-mesh or a receive-mesh tag in this participant's configuration, or use a different mesh in the coupling scheme.",
-                          neededMeshes.first, neededMesh);
-          }
-          participantFound = true;
-          break;
+  PRECICE_ASSERT(tag.getName() == "precice-configuration");
+
+  //test if both participants do have the exchange meshes
+  typedef std::map<std::string, std::vector<std::string>>::value_type neededMeshPair;
+  for (const neededMeshPair &neededMeshes : _meshConfiguration->getNeededMeshes()) {
+    bool participantFound = false;
+    for (const impl::PtrParticipant &participant : _participantConfiguration->getParticipants()) {
+      if (participant->getName() == neededMeshes.first) {
+        for (const std::string &neededMesh : neededMeshes.second) {
+          PRECICE_CHECK(participant->isMeshUsed(neededMesh),
+                        "Participant \"{}\" needs to use the mesh \"{}\" to be able to use it in the coupling scheme. "
+                        "Please either add a provide-mesh or a receive-mesh tag in this participant's configuration, or use a different mesh in the coupling scheme.",
+                        neededMeshes.first, neededMesh);
         }
+        participantFound = true;
+        break;
       }
-      PRECICE_ASSERT(participantFound);
     }
+    PRECICE_ASSERT(participantFound);
   }
 }
 

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -96,6 +96,17 @@ void Configuration::xmlEndTagCallback(
     }
     PRECICE_ASSERT(participantFound);
   }
+
+  // test if all M2Ns use participants that exist
+  for (const auto &m2n : _m2nConfiguration->m2ns()) {
+    PRECICE_CHECK(_participantConfiguration->hasParticipant(m2n.acceptor),
+                  "The acceptor in <m2n:... acceptor=\"{}\" connector=\"{}\" /> is an unknown. {}",
+                  m2n.acceptor, m2n.connector, _participantConfiguration->hintFor(m2n.acceptor));
+
+    PRECICE_CHECK(_participantConfiguration->hasParticipant(m2n.connector),
+                  "The connector in <m2n:... acceptor=\"{}\" connector=\"{}\" /> is an unknown. {}",
+                  m2n.acceptor, m2n.connector, _participantConfiguration->hintFor(m2n.connector));
+  }
 }
 
 const PtrParticipantConfiguration &

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -348,6 +348,40 @@ const impl::PtrParticipant ParticipantConfiguration::getParticipant(const std::s
   return *participant;
 }
 
+std::set<std::string> ParticipantConfiguration::knownParticipants() const
+{
+  std::set<std::string> names;
+  for (const auto &p : _participants) {
+    names.insert(p->getName());
+  }
+  return names;
+}
+
+bool ParticipantConfiguration::hasParticipant(std::string_view name) const
+{
+  for (const auto &p : _participants) {
+    if (p->getName() == name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string ParticipantConfiguration::hintFor(std::string_view wrongName) const
+{
+  PRECICE_ASSERT(!hasParticipant(wrongName));
+
+  const auto partNames = knownParticipants();
+  const auto matches   = utils::computeMatches(wrongName, partNames);
+
+  // Typo detection
+  if (matches.front().distance < 3) {
+    return fmt::format("Did you mean: \"{}\"?", matches.front().name);
+  }
+
+  return fmt::format("Available participants are: {}.", fmt::join(partNames, ", "));
+}
+
 partition::ReceivedPartition::GeometricFilter ParticipantConfiguration::getGeoFilter(const std::string &geoFilter) const
 {
   if (geoFilter == VALUE_FILTER_ON_PRIMARY_RANK) {

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -54,6 +54,12 @@ public:
   /// Returns a participant with the given name
   const impl::PtrParticipant getParticipant(const std::string &participantName) const;
 
+  std::set<std::string> knownParticipants() const;
+
+  bool hasParticipant(std::string_view name) const;
+
+  std::string hintFor(std::string_view wrongName) const;
+
 private:
   struct WatchPointConfig {
     std::string     name;

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1228,18 +1228,18 @@ void ParticipantImpl::configureM2Ns(
     const m2n::M2NConfiguration::SharedPointer &config)
 {
   PRECICE_TRACE();
-  for (const auto &m2nTuple : config->m2ns()) {
-    if (m2nTuple.acceptor != _accessorName && m2nTuple.connector != _accessorName) {
+  for (const auto &m2nConf : config->m2ns()) {
+    if (m2nConf.acceptor != _accessorName && m2nConf.connector != _accessorName) {
       continue;
     }
 
     std::string comPartner("");
     bool        isRequesting;
-    if (m2nTuple.acceptor == _accessorName) {
-      comPartner   = m2nTuple.connector;
+    if (m2nConf.acceptor == _accessorName) {
+      comPartner   = m2nConf.connector;
       isRequesting = true;
     } else {
-      comPartner   = m2nTuple.acceptor;
+      comPartner   = m2nConf.acceptor;
       isRequesting = false;
     }
 
@@ -1247,11 +1247,11 @@ void ParticipantImpl::configureM2Ns(
     for (const impl::PtrParticipant &participant : _participants) {
       if (participant->getName() == comPartner) {
         PRECICE_ASSERT(not utils::contained(comPartner, _m2ns), comPartner);
-        PRECICE_ASSERT(m2nTuple.m2n);
+        PRECICE_ASSERT(m2nConf.m2n);
 
         _m2ns[comPartner] = [&] {
           m2n::BoundM2N bound;
-          bound.m2n          = m2nTuple.m2n;
+          bound.m2n          = m2nConf.m2n;
           bound.localName    = _accessorName;
           bound.remoteName   = comPartner;
           bound.isRequesting = isRequesting;

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1229,29 +1229,34 @@ void ParticipantImpl::configureM2Ns(
 {
   PRECICE_TRACE();
   for (const auto &m2nTuple : config->m2ns()) {
-    std::string comPartner("");
-    bool        isRequesting = false;
-    if (std::get<1>(m2nTuple) == _accessorName) {
-      comPartner   = std::get<2>(m2nTuple);
-      isRequesting = true;
-    } else if (std::get<2>(m2nTuple) == _accessorName) {
-      comPartner = std::get<1>(m2nTuple);
+    if (m2nTuple.acceptor != _accessorName && m2nTuple.connector != _accessorName) {
+      continue;
     }
-    if (not comPartner.empty()) {
-      for (const impl::PtrParticipant &participant : _participants) {
-        if (participant->getName() == comPartner) {
-          PRECICE_ASSERT(not utils::contained(comPartner, _m2ns), comPartner);
-          PRECICE_ASSERT(std::get<0>(m2nTuple));
 
-          _m2ns[comPartner] = [&] {
-            m2n::BoundM2N bound;
-            bound.m2n          = std::get<0>(m2nTuple);
-            bound.localName    = _accessorName;
-            bound.remoteName   = comPartner;
-            bound.isRequesting = isRequesting;
-            return bound;
-          }();
-        }
+    std::string comPartner("");
+    bool        isRequesting;
+    if (m2nTuple.acceptor == _accessorName) {
+      comPartner   = m2nTuple.connector;
+      isRequesting = true;
+    } else {
+      comPartner   = m2nTuple.acceptor;
+      isRequesting = false;
+    }
+
+    PRECICE_ASSERT(!comPartner.empty());
+    for (const impl::PtrParticipant &participant : _participants) {
+      if (participant->getName() == comPartner) {
+        PRECICE_ASSERT(not utils::contained(comPartner, _m2ns), comPartner);
+        PRECICE_ASSERT(m2nTuple.m2n);
+
+        _m2ns[comPartner] = [&] {
+          m2n::BoundM2N bound;
+          bound.m2n          = m2nTuple.m2n;
+          bound.localName    = _accessorName;
+          bound.remoteName   = comPartner;
+          bound.isRequesting = isRequesting;
+          return bound;
+        }();
       }
     }
   }


### PR DESCRIPTION
## Main changes of this PR

This PR:
* added infrastructure to check participant names and get hints for wrong participants
* checks acceptors and connectors in defined M2Ns at the end of the `precice-configuration`
* checks `first`, `second`, and `name` (multi) in coupling-scheme `<participant ... />` tags

## Motivation and additional information

Solves #1993

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
