### PR TITLE
Fix skipping initial mappings in parallel

### DIFF
--- a/docs/changelog/1999.md
+++ b/docs/changelog/1999.md
@@ -1,0 +1,1 @@
+- Fixed skipping initial mapping when data contains only zeros in parallel.

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -4,7 +4,7 @@
 
 #include "precice/impl/DataContext.hpp"
 #include "utils/EigenHelperFunctions.hpp"
-
+#include "utils/IntraComm.hpp"
 namespace precice::impl {
 
 logging::Logger DataContext::_log{"impl::DataContext"};
@@ -126,7 +126,7 @@ int DataContext::mapData(std::optional<double> after, bool skipZero)
           dataDims,
           Eigen::VectorXd::Zero(dataDims * mapping.getOutputMesh()->nVertices())};
 
-      bool skipMapping = skipZero && stample.sample.values.isZero();
+      bool skipMapping = skipZero && (utils::IntraComm::l2norm(stample.sample.values) < math::NUMERICAL_ZERO_DIFFERENCE);
 
       PRECICE_INFO("Mapping \"{}\" for t={} from \"{}\" to \"{}\"{}",
                    getDataName(), stample.timestamp, mapping.getInputMesh()->getName(), mapping.getOutputMesh()->getName(),

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -126,6 +126,7 @@ int DataContext::mapData(std::optional<double> after, bool skipZero)
           dataDims,
           Eigen::VectorXd::Zero(dataDims * mapping.getOutputMesh()->nVertices())};
 
+      // Note that the l2norm is only computed during initialization due to short-circuit evaluation in C++
       bool skipMapping = skipZero && (utils::IntraComm::l2norm(stample.sample.values) < math::NUMERICAL_ZERO_DIFFERENCE);
 
       PRECICE_INFO("Mapping \"{}\" for t={} from \"{}\" to \"{}\"{}",

--- a/tests/parallel/map-initial-data/NonZeroData.cpp
+++ b/tests/parallel/map-initial-data/NonZeroData.cpp
@@ -1,0 +1,20 @@
+#ifndef PRECICE_NO_MPI
+
+#include "helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_CASE(NonZeroData)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(2_ranks));
+
+  testMapInitialData(context, 1.0, 1.0, 2, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/map-initial-data/NonZeroData.xml
+++ b/tests/parallel/map-initial-data/NonZeroData.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <receive-mesh name="MeshOne" from="One" />
+    <read-data name="Data" mesh="MeshTwo" />
+    <mapping:rbf-global-direct direction="read" from="MeshOne" to="MeshTwo" constraint="consistent">
+      <basis-function:thin-plate-splines />
+    </mapping:rbf-global-direct>
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshOne" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/map-initial-data/ZeroData.cpp
+++ b/tests/parallel/map-initial-data/ZeroData.cpp
@@ -1,0 +1,20 @@
+#ifndef PRECICE_NO_MPI
+
+#include "helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(MapInitialData)
+BOOST_AUTO_TEST_CASE(ZeroData)
+{
+  PRECICE_TEST("One"_on(1_rank), "Two"_on(2_ranks));
+
+  testMapInitialData(context, 0.0, 0.0, 1, 0); // End of time window is not zero
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MapInitialData
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/map-initial-data/ZeroData.xml
+++ b/tests/parallel/map-initial-data/ZeroData.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data" />
+  </mesh>
+
+  <participant name="One">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data" mesh="MeshOne" />
+  </participant>
+
+  <participant name="Two">
+    <provide-mesh name="MeshTwo" />
+    <receive-mesh name="MeshOne" from="One" />
+    <read-data name="Data" mesh="MeshTwo" />
+    <mapping:rbf-global-direct direction="read" from="MeshOne" to="MeshTwo" constraint="consistent">
+      <basis-function:thin-plate-splines />
+    </mapping:rbf-global-direct>
+  </participant>
+
+  <m2n:sockets acceptor="One" connector="Two" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="One" second="Two" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="MeshOne" from="One" to="Two" initialize="true" substeps="false" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/map-initial-data/helper.hpp
+++ b/tests/parallel/map-initial-data/helper.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <precice/precice.hpp>
+
+#include "precice/impl/ParticipantImpl.hpp"
+#include "testing/Testing.hpp"
+
+/** Test for mappings mapping initial data when initialize="true"
+ * One writes data (dataToWrite to initialize and 1 at the end of the time window)
+ * Two runs on two ranks, of which only one (rank 0) participates in the coupling.
+ *
+ * Two reada data and compares initial data to dataToExpect.
+ * This is where read mappings are tested. The configured mappings are explicitly
+ * global RBF mappings, to test for consistent decisions of skipping the zero sample
+ * or not. In case the decision is inconsistent, the configuration runs into a deadlock,
+ * as the mapping methods employ collective MPI operations.
+ *
+ * The mapping is either a read or a write mapping.
+ */
+inline void testMapInitialData(
+    precice::testing::TestContext &context,
+    double                         dataToWrite,
+    double                         dataToExpect,
+    int                            readMappingsToExpect,
+    int                            writeMappingsToExpect)
+{
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+
+  std::vector<double>            coord;
+  std::vector<double>            readData;
+  std::vector<precice::VertexID> vid;
+  std::array<double, 2>          writeData{dataToWrite, dataToWrite * 7};
+  std::string                    mesh = "Mesh" + context.name;
+
+  // Only one of the two ranks, participates in the coupling
+  if (context.rank == 0) {
+    coord    = std::vector<double>{0.0, 0.0, 1.0, 1.0};
+    readData = std::vector<double>{0.0, 0.0};
+    vid.resize(2);
+  }
+
+  p.setMeshVertices(mesh, coord, vid);
+
+  // Initialize data
+  if (context.isNamed("One") && p.requiresInitialData()) {
+    p.writeData(mesh, "Data", vid, writeData);
+  }
+  p.initialize();
+
+  // Check mappings in initialize of Two
+  auto mapped = precice::testing::WhiteboxAccessor::impl(p).mappedSamples();
+  if (context.isNamed("One")) {
+    BOOST_TEST(mapped.write == writeMappingsToExpect);
+  } else {
+    BOOST_TEST(mapped.read == readMappingsToExpect);
+
+    p.readData(mesh, "Data", vid, 0.0, readData);
+    if (context.rank == 0) {
+      BOOST_TEST(readData[0] == dataToExpect);
+      BOOST_TEST(readData[1] == dataToExpect * 7);
+    }
+  }
+
+  if (context.isNamed("One")) {
+    // This is required to test the second participant in serial coupling schemes
+    writeData.fill(1.0);
+    p.writeData(mesh, "Data", vid, writeData);
+  }
+  p.advance(p.getMaxTimeStepSize());
+  BOOST_REQUIRE(!p.isCouplingOngoing());
+}

--- a/tests/parallel/map-initial-data/helper.hpp
+++ b/tests/parallel/map-initial-data/helper.hpp
@@ -6,10 +6,10 @@
 #include "testing/Testing.hpp"
 
 /** Test for mappings mapping initial data when initialize="true"
- * One writes data (dataToWrite to initialize and 1 at the end of the time window)
- * Two runs on two ranks, of which only one (rank 0) participates in the coupling.
+ * Participant one writes data (dataToWrite to initialize and 1 at the end of the time window)
+ * Participant two runs on two ranks, of which only one (rank 0) participates in the coupling.
  *
- * Two reada data and compares initial data to dataToExpect.
+ * Participant two reads data and compares initial data to dataToExpect.
  * This is where read mappings are tested. The configured mappings are explicitly
  * global RBF mappings, to test for consistent decisions of skipping the zero sample
  * or not. In case the decision is inconsistent, the configuration runs into a deadlock,

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -45,6 +45,9 @@ target_sources(testprecice
     tests/parallel/lifecycle/ConstructOnly.cpp
     tests/parallel/lifecycle/Full.cpp
     tests/parallel/lifecycle/ImplicitFinalize.cpp
+    tests/parallel/map-initial-data/NonZeroData.cpp
+    tests/parallel/map-initial-data/ZeroData.cpp
+    tests/parallel/map-initial-data/helper.hpp
     tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelScalar.cpp
     tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelVector.cpp
     tests/parallel/mapping-nearest-neighbor-gradient/GradientTestParallelWriteVector.cpp


### PR DESCRIPTION
## Main changes of this PR

Fixes the decision for skipping initial data containing only zero data in parallel runs by making the decision consistent across ranks. 

## Motivation and additional information

Provided in #1998 and resolves #1998

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
