### PR TITLE
refactoring and small corrections of the Quasi Newton Method

### DIFF
--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -34,7 +34,7 @@
  *
  * The third possibility was to separate the approximation of the Jacobian from
  * the common stuff like handling V,W matrices in the acceleration.
- * Here, we have a class QNAcceleration that handles the V,W stuff an d the basic
+ * Here, we have a class QNAcceleration that handles the V,W stuff and the basic
  * scheme of the QN update. Furthermore we have a base class (or rather interface)
  * JacobianApproximation with sub classes IQNIMVJAPX and IQNAPX that handle all the
  * specialized stuff like Jacobian approximation, handling of secondary data etc.

--- a/src/acceleration/IQNIMVJAcceleration.cpp
+++ b/src/acceleration/IQNIMVJAcceleration.cpp
@@ -95,7 +95,7 @@ void IQNIMVJAcceleration::initialize(
   }
 
   if (not _imvjRestart) {
-    // only need memory for Jacobain of not in restart mode
+    // only need memory for Jacobain if not in restart mode
     _invJacobian    = Eigen::MatrixXd::Zero(global_n, entries);
     _oldInvJacobian = Eigen::MatrixXd::Zero(global_n, entries);
   }

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -171,7 +171,7 @@ private:
   *   from v to range of Q, r and its corrections are computed in double
   *   precision.
   *   This method tries to re-orthogonalize the matrix Q for a maximum of 4 iterations
-  *   if ||v_orth|| / ||v|| <= 1/theta is toot small, i.e. the gram schmidt process is iterated.
+  *   if ||v_orth|| / ||v|| <= 1/theta is too small, i.e. the gram schmidt process is iterated.
   *   If ||v_orth|| / ||v|| <= std::numeric_limit, a unit vector that is orthogonal to Q is inserted
   *   and rho is set to 0. i.e., R has a zero on the diagonal in the respective column.
   */


### PR DESCRIPTION
## Main changes of this PR

Fixes small details, typos and wrong documentation in the Quasi Newton classes.

## Motivation and additional information

Moves the small changes made in #1834 into a own pull request.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
