### PR TITLE
Extend QN acceleration to waveform iterations

### DIFF
--- a/docs/changelog/2005.md
+++ b/docs/changelog/2005.md
@@ -1,0 +1,1 @@
+- Added support for waveform iterations in Quasi-Newton acceleration

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -48,10 +48,6 @@ protected:
 
   /// performs a relaxation given a relaxation factor omega
   static void applyRelaxation(double omega, DataMap &cplData);
-
-  /// @brief Concatenates the data and old data in cplData into two long vectors
-  virtual void concatenateCouplingData(
-      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const = 0;
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -36,12 +36,11 @@ public:
   virtual void iterationsConverged(
       const DataMap &cpldata) override final;
 
-protected:
-  /// @copydoc acceleration::Acceleration::concatenateCouplingData
-  void concatenateCouplingData(
-      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final;
-
 private:
+  /// @brief Concatenates the data and old data in cplData into two long vectors
+  void concatenateCouplingData(
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const;
+
   logging::Logger _log{"acceleration::AitkenAcceleration"};
 
   const double _initialRelaxation;

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -14,6 +14,7 @@
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
 #include "profiling/Event.hpp"
+#include "time/TimeGrids.hpp"
 #include "utils/EigenHelperFunctions.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/IntraComm.hpp"
@@ -38,13 +39,15 @@ BaseQNAcceleration::BaseQNAcceleration(
     int                     filter,
     double                  singularityLimit,
     std::vector<int>        dataIDs,
-    impl::PtrPreconditioner preconditioner)
+    impl::PtrPreconditioner preconditioner,
+    bool                    reducedTimeGrid)
     : _preconditioner(std::move(preconditioner)),
       _initialRelaxation(initialRelaxation),
       _maxIterationsUsed(maxIterationsUsed),
       _timeWindowsReused(timeWindowsReused),
       _primaryDataIDs(std::move(dataIDs)),
       _forceInitialRelaxation(forceInitialRelaxation),
+      _reducedTimeGrid(reducedTimeGrid),
       _qrV(filter),
       _filter(filter),
       _singularityLimit(singularityLimit),
@@ -95,17 +98,10 @@ void BaseQNAcceleration::initialize(
     _dataIDs.push_back(pair.first);
   }
 
-  for (const auto &data : cplData | boost::adaptors::map_values) {
-    PRECICE_CHECK(!data->exchangeSubsteps(),
-                  "Quasi-Newton acceleration does not yet support using data from all substeps. Please set substeps=\"false\" in the exchange tag of data \"{}\".", data->getDataName());
-  }
-
   _matrixCols.clear();
   _matrixCols.push_front(0);
   _firstIteration  = true;
   _firstTimeWindow = true;
-
-  initializeVectorsAndPreconditioner(cplData);
 }
 
 /** ---------------------------------------------------------------------------------------------
@@ -220,15 +216,25 @@ void BaseQNAcceleration::performAcceleration(
 
   profiling::Event e("cpl.computeQuasiNewtonUpdate", profiling::Synchronize);
 
+  // We can only initialize here since we need to know the time grid already.
+  if (_firstTimeWindow and _firstIteration) {
+    initializeVectorsAndPreconditioner(cplData);
+  }
+
   PRECICE_ASSERT(_oldPrimaryResiduals.size() == _oldPrimaryXTilde.size(), _oldPrimaryResiduals.size(), _oldPrimaryXTilde.size());
   PRECICE_ASSERT(_primaryValues.size() == _oldPrimaryXTilde.size(), _primaryValues.size(), _oldPrimaryXTilde.size());
   PRECICE_ASSERT(_oldPrimaryValues.size() == _oldPrimaryXTilde.size(), _oldPrimaryValues.size(), _oldPrimaryXTilde.size());
   PRECICE_ASSERT(_primaryResiduals.size() == _oldPrimaryXTilde.size(), _primaryResiduals.size(), _oldPrimaryXTilde.size());
 
-  // assume data structures associated with the LS system can be updated easily.
+  // Needs to be called in the first iteration of each time window.
+  if (_firstIteration) {
+    _timeGrids->moveTimeGridToNewWindow(cplData);
+    _primaryTimeGrids->moveTimeGridToNewWindow(cplData);
+  }
 
-  concatenateCouplingData(cplData, _primaryDataIDs, _primaryValues, _oldPrimaryValues);
-  concatenateCouplingData(cplData, _dataIDs, _values, _oldValues);
+  /// Sample all the data to the corresponding time grid in _timeGrids and concatenate everything into a long vector
+  concatenateCouplingData(_values, _oldValues, cplData, _dataIDs, _timeGrids);
+  concatenateCouplingData(_primaryValues, _oldPrimaryValues, cplData, _primaryDataIDs, _primaryTimeGrids);
 
   /** update the difference matrices V,W  includes:
    * scaling of values
@@ -276,8 +282,8 @@ void BaseQNAcceleration::performAcceleration(
      * The preconditioner is only applied to the matrix V and the columns that are inserted into the
      * QR-decomposition of V.
      */
-
     _preconditioner->update(false, _primaryValues, _primaryResiduals);
+
     // apply scaling to V, V' := P * V (only needed to reset the QR-dec of V)
     _preconditioner->apply(_matrixV);
 
@@ -309,9 +315,7 @@ void BaseQNAcceleration::performAcceleration(
     Eigen::VectorXd xUpdate = Eigen::VectorXd::Zero(_values.size());
     computeQNUpdate(xUpdate);
 
-    /**
-     * apply quasiNewton update
-     */
+    // Apply the quasi-Newton update
     _values += xUpdate;
 
     // pending deletion: delete old V, W matrices if timeWindowsReused = 0
@@ -348,7 +352,9 @@ void BaseQNAcceleration::performAcceleration(
         "filter or increase its threshold (larger epsilon).");
   }
 
-  splitCouplingData(cplData); // split the primary and secondary coupling data back into the individual data objects
+  // updates the waveform and values in coupling data by splitting the primary and secondary data back into the individual data objects
+  updateCouplingData(cplData);
+
   // number of iterations (usually equals number of columns in LS-system)
   its++;
   _firstIteration = false;
@@ -376,19 +382,32 @@ void BaseQNAcceleration::applyFilter()
   }
 }
 
-void BaseQNAcceleration::splitCouplingData(
+void BaseQNAcceleration::updateCouplingData(
     const DataMap &cplData)
 {
-  PRECICE_TRACE();
 
-  int offset = 0;
+  PRECICE_TRACE();
+  // offset to keep track of the position in xUpdate
+  Eigen::Index offset = 0;
+
   for (int id : _dataIDs) {
-    int   size       = cplData.at(id)->getSize();
-    auto &valuesPart = cplData.at(id)->values();
-    for (int i = 0; i < size; i++) {
-      valuesPart(i) = _values(i + offset);
+
+    auto & couplingData = *cplData.at(id);
+    size_t dataSize     = couplingData.getSize();
+
+    Eigen::VectorXd timeGrid = _timeGrids->getTimeGrid(id);
+    couplingData.timeStepsStorage().clear();
+    for (int i = 0; i < timeGrid.size(); i++) {
+
+      Eigen::VectorXd temp = Eigen::VectorXd::Zero(dataSize);
+      for (size_t j = 0; j < dataSize; j++) {
+        temp(j) = _values(offset + j);
+      }
+      offset += dataSize;
+
+      couplingData.sample().values = temp;
+      couplingData.setSampleAtTime(timeGrid(i), couplingData.sample());
     }
-    offset += size;
   }
 }
 
@@ -415,8 +434,20 @@ void BaseQNAcceleration::iterationsConverged(
   // the most recent differences for the V, W matrices have not been added so far
   // this has to be done in iterations converged, as PP won't be called any more if
   // convergence was achieved
-  concatenateCouplingData(cplData, _primaryDataIDs, _primaryValues, _oldPrimaryValues);
-  concatenateCouplingData(cplData, _dataIDs, _values, _oldValues);
+
+  // If, in the first time window, we converge already in the first iteration, we have not yet initialized. Then, we need to do it here.
+  if (_firstTimeWindow and _firstIteration) {
+    initializeVectorsAndPreconditioner(cplData);
+  }
+
+  // Needs to be called in the first iteration of each time window.
+  if (_firstIteration) {
+    _timeGrids->moveTimeGridToNewWindow(cplData);
+    _primaryTimeGrids->moveTimeGridToNewWindow(cplData);
+  }
+  /// Sample all the data to the corresponding time grid in _timeGrids and concatenate everything into a long vector
+  concatenateCouplingData(_values, _oldValues, cplData, _dataIDs, _timeGrids);
+  concatenateCouplingData(_primaryValues, _oldPrimaryValues, cplData, _primaryDataIDs, _primaryTimeGrids);
   updateDifferenceMatrices(cplData);
 
   if (not _matrixCols.empty() && _matrixCols.front() == 0) { // Did only one iteration
@@ -588,41 +619,67 @@ void BaseQNAcceleration::writeInfo(
   _infostringstream << std::flush;
 }
 
-void BaseQNAcceleration::concatenateCouplingData(
-    const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const
+void BaseQNAcceleration::concatenateCouplingData(Eigen::VectorXd &data, Eigen::VectorXd &oldData, const DataMap &cplData, std::vector<int> dataIDs, std::unique_ptr<precice::time::TimeGrids> &timeGrids) const
 {
   Eigen::Index offset = 0;
-  for (auto id : dataIDs) {
-    Eigen::Index size      = cplData.at(id)->values().size();
-    auto &       values    = cplData.at(id)->values();
-    const auto & oldValues = cplData.at(id)->previousIteration();
-    PRECICE_ASSERT(targetValues.size() >= offset + size, "Target vector was not initialized.", targetValues.size(), offset + size);
-    PRECICE_ASSERT(targetOldValues.size() >= offset + size, "Target vector was not initialized.");
-    for (Eigen::Index i = 0; i < size; i++) {
-      targetValues(i + offset)    = values(i);
-      targetOldValues(i + offset) = oldValues(i);
+  for (int id : dataIDs) {
+    Eigen::Index    dataSize = cplData.at(id)->getSize();
+    Eigen::VectorXd timeGrid = timeGrids->getTimeGrid(id);
+
+    for (int i = 0; i < timeGrid.size(); i++) {
+
+      Eigen::VectorXd values    = cplData.at(id)->timeStepsStorage().sample(timeGrid(i));
+      Eigen::VectorXd oldValues = cplData.at(id)->getPreviousValuesAtTime(timeGrid(i));
+
+      PRECICE_ASSERT(data.size() >= offset + dataSize, "the values were not initialized correctly");
+      PRECICE_ASSERT(oldData.size() >= offset + dataSize, "the values were not initialized correctly");
+
+      for (Eigen::Index i = 0; i < dataSize; i++) {
+        data(i + offset)    = values(i);
+        oldData(i + offset) = oldValues(i);
+      }
+      offset += dataSize;
     }
-    offset += size;
   }
 }
 
 void BaseQNAcceleration::initializeVectorsAndPreconditioner(const DataMap &cplData)
 {
-  auto         addCplDataSize  = [&](size_t sum, int id) { return sum + cplData.at(id)->getSize(); };
-  const size_t primaryDataSize = std::accumulate(_primaryDataIDs.begin(), _primaryDataIDs.end(), (size_t) 0, addCplDataSize);
-  const size_t dataSize        = std::accumulate(_dataIDs.begin(), _dataIDs.end(), (size_t) 0, addCplDataSize);
 
-  _oldPrimaryXTilde    = Eigen::VectorXd::Zero(primaryDataSize);
-  _oldPrimaryResiduals = Eigen::VectorXd::Zero(primaryDataSize);
-  _primaryResiduals    = Eigen::VectorXd::Zero(primaryDataSize);
-  _primaryValues       = Eigen::VectorXd::Zero(primaryDataSize);
-  _oldPrimaryValues    = Eigen::VectorXd::Zero(primaryDataSize);
+  // If we are not subcycling then we only want to use the last time step in the QN system
+  bool subcycling = false;
+  for (const auto &data : cplData | boost::adaptors::map_values) {
+    if (data->exchangeSubsteps()) {
+      subcycling = true;
+    }
+  }
+
+  // Saves the time grid of each waveform in the data field to be used in the QN method
+  _timeGrids        = std::make_unique<time::TimeGrids>(cplData, _dataIDs, !subcycling);
+  _primaryTimeGrids = std::make_unique<time::TimeGrids>(cplData, _primaryDataIDs, !(subcycling and !_reducedTimeGrid));
+
+  // Helper function
+  auto addTimeSliceSize = [&](size_t sum, int id, std::unique_ptr<precice::time::TimeGrids> &timeGrids) { return sum + timeGrids->getTimeGrid(id).size() * cplData.at(id)->getSize(); };
+
+  // Size of primary data
+  const size_t primaryDataSize = std::accumulate(_primaryDataIDs.begin(), _primaryDataIDs.end(), (size_t) 0, [&](size_t sum, int id) { return addTimeSliceSize(sum, id, _primaryTimeGrids); });
+
+  // Size of values
+  const size_t dataSize = std::accumulate(_dataIDs.begin(), _dataIDs.end(), (size_t) 0, [&](size_t sum, int id) { return addTimeSliceSize(sum, id, _timeGrids); });
+
   _values              = Eigen::VectorXd::Zero(dataSize);
   _oldValues           = Eigen::VectorXd::Zero(dataSize);
   _oldXTilde           = Eigen::VectorXd::Zero(dataSize);
   _residuals           = Eigen::VectorXd::Zero(dataSize);
-  _matrixV.resize(0, 0);
+  _primaryValues       = Eigen::VectorXd::Zero(primaryDataSize);
+  _oldPrimaryValues    = Eigen::VectorXd::Zero(primaryDataSize);
+  _oldPrimaryXTilde    = Eigen::VectorXd::Zero(primaryDataSize);
+  _primaryResiduals    = Eigen::VectorXd::Zero(primaryDataSize);
+  _oldPrimaryResiduals = Eigen::VectorXd::Zero(primaryDataSize);
+
+  // Also clear the matrices, since the initialization phase will be called more than once when using remeshing
   _matrixW.resize(0, 0);
+  _matrixV.resize(0, 0);
 
   /**
    *  make dimensions public to all procs,
@@ -652,14 +709,17 @@ void BaseQNAcceleration::initializeVectorsAndPreconditioner(const DataMap &cplDa
 
       for (auto &elem : _dataIDs) {
         const auto &offsets = cplData.at(elem)->getVertexOffsets();
-        accumulatedNumberOfUnknowns += offsets[i] * cplData.at(elem)->getDimensions();
+
+        accumulatedNumberOfUnknowns += offsets[i] * cplData.at(elem)->getDimensions() * _timeGrids->getTimeGrid(elem).size();
+
         if (utils::contained(elem, _primaryDataIDs)) {
-          accumulatedNumberOfPrimaryUnknowns += offsets[i] * cplData.at(elem)->getDimensions();
+          accumulatedNumberOfPrimaryUnknowns += offsets[i] * cplData.at(elem)->getDimensions() * _primaryTimeGrids->getTimeGrid(elem).size();
         }
       }
       _dimOffsets[i + 1]        = accumulatedNumberOfUnknowns;
       _dimOffsetsPrimary[i + 1] = accumulatedNumberOfPrimaryUnknowns;
     }
+
     PRECICE_DEBUG("Number of unknowns at the interface (global): {}", _dimOffsets.back());
     if (utils::IntraComm::isPrimary()) {
       _infostringstream << fmt::format("\n--------\n DOFs (global): {}\n offsets: {}\n", _dimOffsets.back(), _dimOffsets);
@@ -679,7 +739,7 @@ void BaseQNAcceleration::initializeVectorsAndPreconditioner(const DataMap &cplDa
   _qrV.setGlobalRows(getPrimaryLSSystemRows());
 
   std::vector<size_t> subVectorSizes; // needed for preconditioner
-  std::transform(_primaryDataIDs.cbegin(), _primaryDataIDs.cend(), std::back_inserter(subVectorSizes), [&cplData](const auto &d) { return cplData.at(d)->getSize(); });
+  std::transform(_primaryDataIDs.cbegin(), _primaryDataIDs.cend(), std::back_inserter(subVectorSizes), [&cplData, this](const auto &d) { return _primaryTimeGrids->getTimeGrid(d).size() * cplData.at(d)->getSize(); });
   _preconditioner->initialize(subVectorSizes);
 
   specializedInitializeVectorsAndPreconditioner(cplData);

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -275,10 +275,6 @@ protected:
   /// Writes info to the _infostream (also in parallel)
   void writeInfo(const std::string &s, bool allProcs = false);
 
-  /// @copydoc acceleration::Acceleration::concatenateCouplingData
-  void concatenateCouplingData(
-      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final;
-
   int its = 0, tWindows = 0;
 
 private:

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -12,6 +12,7 @@
 #include "acceleration/impl/QRFactorization.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
 #include "logging/Logger.hpp"
+#include "time/TimeGrids.hpp"
 
 /* ****************************************************************************
  *
@@ -70,7 +71,8 @@ public:
       int                     filter,
       double                  singularityLimit,
       std::vector<int>        dataIDs,
-      impl::PtrPreconditioner preconditioner);
+      impl::PtrPreconditioner preconditioner,
+      bool                    reducedTimeGrid);
 
   /**
    * @brief Destructor, empty.
@@ -88,7 +90,7 @@ public:
   /**
    * @brief Returns all IQN involved data IDs.
    */
-  virtual std::vector<int> getPrimaryDataIDs() const
+  virtual std::vector<int> getPrimaryDataIDs() const override final
   {
     return _primaryDataIDs;
   }
@@ -203,6 +205,9 @@ protected:
   /// @brief Stores x tilde deltas, where x tilde are values computed by solvers.
   Eigen::MatrixXd _matrixW;
 
+  /// @brief  if _reducedTimeGrid = false uses the full QN-WI and if _reducedTimeGrid = true uses rQN-WI form the paper https://onlinelibrary.wiley.com/doi/10.1002/nme.6443
+  const bool _reducedTimeGrid;
+
   /// @brief Stores the current QR decomposition ov _matrixV, can be updated via deletion/insertion of columns
   impl::QRFactorization _qrV;
 
@@ -255,8 +260,8 @@ protected:
   /// Updates the V, W matrices (as well as the matrices for the secondary data)
   virtual void updateDifferenceMatrices(const DataMap &cplData);
 
-  /// Splits up QN system vector back into the coupling data
-  virtual void splitCouplingData(const DataMap &cplData);
+  /// Splits up QN system vector back into the waveforms in coupling data
+  virtual void updateCouplingData(const DataMap &cplData);
 
   /// Applies the filter method for the least-squares system, defined in the configuration
   virtual void applyFilter();
@@ -278,6 +283,7 @@ protected:
 
 private:
   /// @brief Initializes the vectors, matrices and preconditioner
+  /// This has to be done after the first iteration of the first time window, since everything in the QN-algorithm is sampled to the timegrid of the first waveform
   void initializeVectorsAndPreconditioner(const DataMap &cplData);
 
   /**
@@ -286,6 +292,16 @@ private:
    * called by the initializeVectorsAndPreconditioner method in the BaseQNAcceleration class
    */
   virtual void specializedInitializeVectorsAndPreconditioner(const DataMap &cplData) = 0;
+
+  /// @brief Samples and concatenates the data and old data in cplData into a long vector
+  void concatenateCouplingData(Eigen::VectorXd &data, Eigen::VectorXd &oldData, const DataMap &cplData, std::vector<int> dataIDs, std::unique_ptr<precice::time::TimeGrids> &timeGrids) const;
+
+  /// @brief Stores the time grids to which the primary and secondary data involved in the QN system will be interpolated to.
+  std::unique_ptr<time::TimeGrids> _timeGrids;
+
+  /// @brief Stores the time grids to which the primary data involved in the QN system will be interpolated to.
+  /// If _reducedTimeGrids is true then this will only contain the last time stamp of the time window, see https://doi.org/10.1002/nme.6443
+  std::unique_ptr<time::TimeGrids> _primaryTimeGrids;
 
   /// @brief Concatenation of all primary data involved in the QN system.
   Eigen::VectorXd _primaryValues;

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -290,14 +290,14 @@ private:
   virtual void specializedInitializeVectorsAndPreconditioner(const DataMap &cplData) = 0;
 
   /// @brief Samples and concatenates the data and old data in cplData into a long vector
-  void concatenateCouplingData(Eigen::VectorXd &data, Eigen::VectorXd &oldData, const DataMap &cplData, std::vector<int> dataIDs, std::unique_ptr<precice::time::TimeGrids> &timeGrids) const;
+  void concatenateCouplingData(Eigen::VectorXd &data, Eigen::VectorXd &oldData, const DataMap &cplData, std::vector<int> dataIDs, precice::time::TimeGrids timeGrids) const;
 
   /// @brief Stores the time grids to which the primary and secondary data involved in the QN system will be interpolated to.
-  std::unique_ptr<time::TimeGrids> _timeGrids;
+  std::optional<time::TimeGrids> _timeGrids;
 
   /// @brief Stores the time grids to which the primary data involved in the QN system will be interpolated to.
   /// If _reducedTimeGrids is true then this will only contain the last time stamp of the time window, see https://doi.org/10.1002/nme.6443
-  std::unique_ptr<time::TimeGrids> _primaryTimeGrids;
+  std::optional<time::TimeGrids> _primaryTimeGrids;
 
   /// @brief Concatenation of all primary data involved in the QN system.
   Eigen::VectorXd _primaryValues;

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -16,7 +16,7 @@ public:
       double           relaxation,
       std::vector<int> dataIDs);
 
-  virtual std::vector<int> getPrimaryDataIDs() const override
+  virtual std::vector<int> getPrimaryDataIDs() const override final
   {
     return _dataIDs;
   }
@@ -26,14 +26,6 @@ public:
   virtual void performAcceleration(DataMap &cplData) override;
 
   virtual void iterationsConverged(const DataMap &cplData) override
-  {
-    // function not needed in ConstantRelaxationAcceleration
-  }
-
-protected:
-  /// @copydoc acceleration::Acceleration::concatenateCouplingData
-  void concatenateCouplingData(
-      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final
   {
     // function not needed in ConstantRelaxationAcceleration
   }

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -32,9 +32,10 @@ IQNILSAcceleration::IQNILSAcceleration(
     int                     filter,
     double                  singularityLimit,
     std::vector<int>        dataIDs,
-    impl::PtrPreconditioner preconditioner)
+    impl::PtrPreconditioner preconditioner,
+    bool                    reduced)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, std::move(dataIDs), std::move(preconditioner))
+                         filter, singularityLimit, std::move(dataIDs), std::move(preconditioner), reduced)
 {
 }
 

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -33,9 +33,9 @@ IQNILSAcceleration::IQNILSAcceleration(
     double                  singularityLimit,
     std::vector<int>        dataIDs,
     impl::PtrPreconditioner preconditioner,
-    bool                    reduced)
+    bool                    reducedTimeGrid)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, std::move(dataIDs), std::move(preconditioner), reduced)
+                         filter, singularityLimit, std::move(dataIDs), std::move(preconditioner), reducedTimeGrid)
 {
 }
 

--- a/src/acceleration/IQNILSAcceleration.hpp
+++ b/src/acceleration/IQNILSAcceleration.hpp
@@ -33,7 +33,8 @@ public:
       int                     filter,
       double                  singularityLimit,
       std::vector<int>        dataIDs,
-      impl::PtrPreconditioner preconditioner);
+      impl::PtrPreconditioner preconditioner,
+      bool                    reducedTimeGrid);
 
   virtual ~IQNILSAcceleration() {}
 

--- a/src/acceleration/IQNIMVJAcceleration.cpp
+++ b/src/acceleration/IQNIMVJAcceleration.cpp
@@ -41,9 +41,10 @@ IQNIMVJAcceleration::IQNIMVJAcceleration(
     int                            imvjRestartType,
     int                            chunkSize,
     int                            RSLSreusedTimeWindows,
-    double                         RSSVDtruncationEps)
+    double                         RSSVDtruncationEps,
+    bool                           reducedTimeGrid)
     : BaseQNAcceleration(initialRelaxation, forceInitialRelaxation, maxIterationsUsed, pastTimeWindowsReused,
-                         filter, singularityLimit, std::move(dataIDs), preconditioner),
+                         filter, singularityLimit, std::move(dataIDs), preconditioner, reducedTimeGrid),
       //  _secondaryOldXTildes(),
       _invJacobian(),
       _oldInvJacobian(),

--- a/src/acceleration/IQNIMVJAcceleration.hpp
+++ b/src/acceleration/IQNIMVJAcceleration.hpp
@@ -54,7 +54,8 @@ public:
       int                            imvjRestartType,
       int                            chunkSize,
       int                            RSLSreusedTimeWindows,
-      double                         RSSVDtruncationEps);
+      double                         RSSVDtruncationEps,
+      bool                           reducedTimeGrid);
 
   /**
    * @brief Destructor, empty.

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -61,6 +61,7 @@ private:
   const std::string ATTR_SINGULARITYLIMIT;
   const std::string ATTR_TYPE;
   const std::string ATTR_BUILDJACOBIAN;
+  const std::string ATTR_REDUCEDTIMEGRIDQN;
   const std::string ATTR_IMVJCHUNKSIZE;
   const std::string ATTR_RSLS_REUSED_TIME_WINDOWS;
   const std::string ATTR_RSSVD_TRUNCATIONEPS;
@@ -113,6 +114,7 @@ private:
     double                imvjRSSVD_truncationEps    = 0;
     bool                  estimateJacobian           = false;
     bool                  alwaysBuildJacobian        = false;
+    bool                  reducedTimeGridQN          = true;
     std::string           preconditionerType;
 
     std::vector<double> scalingFactorsInOrder() const;

--- a/src/acceleration/test/AccelerationIntraCommTest.cpp
+++ b/src/acceleration/test/AccelerationIntraCommTest.cpp
@@ -1,5 +1,6 @@
 #include <Eigen/Core>
 #include <algorithm>
+#include <boost/test/data/test_case.hpp>
 #include <cmath>
 #include <map>
 #include <memory>
@@ -40,7 +41,7 @@ using DataMap = std::map<int, PtrCouplingData>;
 BOOST_AUTO_TEST_SUITE(AccelerationIntraCommTests)
 
 /// Test that runs on 4 processors.
-BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
+BOOST_DATA_TEST_CASE(testVIQNILSppWithoutSubsteps, boost::unit_test::data::make({true, false}), exchangeSubsteps)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   double           initialRelaxation        = 0.01;
@@ -61,16 +62,16 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                        timeWindowsReused, filter, singularityLimit, dataIDs, prec);
+                        timeWindowsReused, filter, singularityLimit, dataIDs, prec, !exchangeSubsteps);
 
   Eigen::VectorXd dcol1;
   Eigen::VectorXd fcol1;
 
-  DataMap       data;
-  mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
-  mesh::PtrData forces(new mesh::Data("fvalues", -1, 1));
-
-  bool exchangeSubsteps = false; // @todo add testVIQNILSppWithSubsteps, where exchangeSubsteps = true as soon as acceleration scheme supports subcycling.
+  DataMap         data;
+  mesh::PtrData   displacements(new mesh::Data("dvalues", -1, 1));
+  mesh::PtrData   forces(new mesh::Data("fvalues", -1, 1));
+  PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
+  PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
 
   if (context.isPrimary()) { // Primary
     /**
@@ -85,10 +86,11 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(forces->values(), insert);
 
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
     data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
@@ -102,6 +104,9 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
     displacements->values() = insert;
     insert << 0.1, 0.1, 0.1, 0.1;
     forces->values() = insert;
+
+    dpcd->setSampleAtTime(1, dpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
   } else if (context.isRank(1)) { // SecondaryRank1
 
@@ -117,10 +122,11 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(forces->values(), insert);
 
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
     data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
@@ -135,6 +141,9 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
     insert << 0.1, 0.1, 0.1, 0.1;
     forces->values() = insert;
 
+    dpcd->setSampleAtTime(1, dpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
+
   } else if (context.isRank(2)) { // Secondary rank 2
 
     /**
@@ -142,12 +151,12 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
      */
 
     // init displacements
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
 
     // init forces
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
     data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
@@ -156,6 +165,9 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
     fpcd->storeIteration();
 
     pp.initialize(data);
+
+    dpcd->setSampleAtTime(1, dpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
   } else if (context.isRank(3)) { // Secondary rank 3
 
@@ -171,10 +183,11 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
     insert << 0.2, 0.2;
     utils::append(forces->values(), insert);
 
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
     data.insert(std::pair<int, PtrCouplingData>(1, fpcd));
@@ -188,6 +201,9 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
     displacements->values() = insert;
     insert << 0.1, 0.1;
     forces->values() = insert;
+
+    dpcd->setSampleAtTime(1, dpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
   }
 
   pp.performAcceleration(data);
@@ -239,6 +255,8 @@ BOOST_AUTO_TEST_CASE(testVIQNILSppWithoutSubsteps)
   }
 
   data.begin()->second->values() = newdvalues;
+  dpcd->setSampleAtTime(1, dpcd->sample());
+  fpcd->setSampleAtTime(1, fpcd->sample());
 
   pp.performAcceleration(data);
 
@@ -285,6 +303,7 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
   double svdTruncationEps           = 0.0;
   bool   enforceInitialRelaxation   = false;
   bool   alwaysBuildJacobian        = false;
+  bool   exchangeSubsteps           = false; // @todo add testVIQNIMVJppWithSubsteps, where exchangeSubsteps = true as soon as acceleration scheme supports subcycling.
 
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
@@ -299,17 +318,17 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                          timeWindowsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
-                         restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps);
+                         restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps, !exchangeSubsteps);
 
   Eigen::VectorXd dcol1;
   Eigen::VectorXd fcol1;
 
-  mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
-  mesh::PtrData forces(new mesh::Data("fvalues", -1, 1));
+  mesh::PtrData   displacements(new mesh::Data("dvalues", -1, 1));
+  mesh::PtrData   forces(new mesh::Data("fvalues", -1, 1));
+  PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
+  PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
 
   DataMap data;
-
-  bool exchangeSubsteps = false; // @todo add testVIQNIMVJppWithSubsteps, where exchangeSubsteps = true as soon as acceleration scheme supports subcycling.
 
   if (context.isPrimary()) { // Primary
 
@@ -325,10 +344,11 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(forces->values(), insert);
 
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
+    //Need to store 2 values in the waveform iteration
     dpcd->setSampleAtTime(0, dpcd->sample());
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
+    dpcd->setSampleAtTime(1, dpcd->sample());
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -345,6 +365,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     // update forces
     insert << 0.1, 0.1, 0.1, 0.1;
     fpcd->values() = insert;
+
+    // Only the newest value is updated
+    dpcd->setSampleAtTime(1, dpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     // check for correct initial data
     BOOST_TEST(testing::equals(data.at(0)->previousIteration()(0), 1.0), data.at(0)->previousIteration()(0));
@@ -377,10 +401,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     insert << 0.2, 0.2, 0.2, 0.2;
     utils::append(forces->values(), insert);
 
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
+    dpcd->setSampleAtTime(1, dpcd->sample());
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -396,6 +420,9 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     // update forces
     insert << 0.1, 0.1, 0.1, 0.1;
     fpcd->values() = insert;
+
+    dpcd->setSampleAtTime(1, dpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     // check for correct initial data
     BOOST_TEST(testing::equals(data.at(0)->previousIteration()(0), 1.0), data.at(0)->previousIteration()(0));
@@ -421,12 +448,12 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
      */
 
     // init displacements
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
 
     // init forces
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -452,10 +479,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     insert << 0.2, 0.2;
     utils::append(forces->values(), insert);
 
-    PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
-    PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
+    dpcd->setSampleAtTime(1, dpcd->sample());
     fpcd->setSampleAtTime(0, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -472,6 +499,9 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     // update forces
     insert << 0.1, 0.1;
     forces->values() = insert;
+
+    dpcd->setSampleAtTime(1, dpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     // check for correct initial data
     BOOST_TEST(testing::equals(data.at(0)->previousIteration()(0), 1.0), data.at(0)->previousIteration()(0));
@@ -525,6 +555,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
   }
 
   data.begin()->second->values() = newdvalues;
+
+  dpcd->setSampleAtTime(1, dpcd->sample());
+  fpcd->setSampleAtTime(1, fpcd->sample());
+
   pp.performAcceleration(data);
 
   if (context.isPrimary()) { // Primary
@@ -571,6 +605,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   double svdTruncationEps           = 0.0;
   bool   enforceInitialRelaxation   = false;
   bool   alwaysBuildJacobian        = false;
+  bool   exchangeSubsteps           = false; // @todo add testIMVJ_effUpdate_ppWithSubsteps, where exchangeSubsteps = true as soon as acceleration scheme supports subcycling.
 
   std::vector<int> dataIDs;
   dataIDs.push_back(4);
@@ -583,7 +618,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                          timeWindowsReused, filter, singularityLimit, dataIDs, _preconditioner, alwaysBuildJacobian,
-                         restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps);
+                         restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps, !exchangeSubsteps);
 
   mesh::PtrData displacements(new mesh::Data("dvalues", -1, 2));
   mesh::PtrData forces(new mesh::Data("fvalues", -1, 2));
@@ -596,8 +631,6 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   PtrCouplingData dpcd;
   PtrCouplingData fpcd;
 
-  bool exchangeSubsteps = false; // @todo add testIMVJ_effUpdate_ppWithSubsteps, where exchangeSubsteps = true as soon as acceleration scheme supports subcycling.
-
   if (context.isPrimary()) { // Primary
     /**
      * processor with no vertices
@@ -609,10 +642,12 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     // init displacements
     dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
 
     // init forces
     fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -634,8 +669,11 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
 
     dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
     fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -646,6 +684,9 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     pp.initialize(data);
 
     forces->values() << -0.01765744149520443, -0.000534499502588083, 0.05397520666020422, 0.0005546984205735067, 0.05213823386543703, 0.0007618478879228568, -0.01944857239806249, -0.0009206665792022876, -0.02459872346309381, -0.001296931976456198, 0.04688718434761113, 0.001346643628716769, -0.01063536095060684, -0.01905148710330257, 0.02514593936525903, -0.01643393169986981, -0.02189723835016068, -0.000912218689367709, 0.04985117008772211, 0.0009615805506705544, 0.05534647415570375, 0.0004068469082890895;
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(2)) { // Secondary rank 2
     /**
      * processor with 4 vertices
@@ -659,8 +700,11 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
 
     dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
     fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -671,6 +715,9 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     pp.initialize(data);
 
     forces->values() << -0.01465589151503364, -0.0002670111835650672, 0.05711438689366102, 0.0002383730129847531, -0.01536098575916998, -0.000285287812066552, 0.05638274807579218, 0.000283961973555227, -0.006856432131857973, -0.006815594391460808, 0.02901925611525407, -0.02907380915674757, 0.05800715138289463, 9.667376010126116e-05, -0.01376443700165205, -9.547563271960956e-05, 0.05768190311116184, 0.0001311583226994801, -0.01408147387131287, -0.0001216961377915992, -0.0163823504288376, -0.0003874626690545313;
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(3)) { // Secondary rank 3
     /**
      * processor with no vertices
@@ -681,8 +728,12 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
 
     dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
     dpcd->setSampleAtTime(0, dpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
     fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
+
     fpcd->setSampleAtTime(0, fpcd->sample());
+    fpcd->setSampleAtTime(1, fpcd->sample());
 
     dpcd->storeIteration();
     fpcd->storeIteration();
@@ -729,6 +780,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.790053057185293e-06, -2.44566429072041e-08, 1.889281703254964e-06, -1.972492834475447e-07, 1.681634609242917e-06, -2.373356532433882e-07, 1.585003447958184e-06, -5.301850772916681e-08, 1.274187257620066e-06, -2.137488936999111e-07, 1.362955262700412e-06, -2.762153471191986e-07, 1.249747540920782e-06, -3.196338173465977e-07, 1.333501893726392e-06, -3.161541101487353e-07, 1.394538527892028e-06, -1.166536323805688e-07, 1.488382850875808e-06, -2.605379508545059e-07, 2.056077021837937e-06, -1.341692715765341e-07;
     forces->values() << -0.01765744187144705, -0.000534499502451157, 0.05397520721069472, 0.0005546984181272257, 0.05213823442800309, 0.000761847881060882, -0.01944857277019029, -0.0009206665773591249, -0.02459872381892192, -0.001296931982922439, 0.04688718490326162, 0.001346643636856003, -0.01063536111298416, -0.01905148734069537, 0.02514593966043068, -0.01643393192020026, -0.02189723869781963, -0.0009122186870252733, 0.04985117065739809, 0.0009615805515004192, 0.05534647470527156, 0.0004068469091761907;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(2)) { // Secondary rank 2
 
     dref = Eigen::VectorXd::Zero(22);
@@ -754,12 +809,21 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.848184969639987e-06, -1.983566187932991e-07, 1.952383060128974e-06, 1.050101286643166e-07, 2.020975712018586e-06, -9.297459906882382e-08, 2.123910878481957e-06, -3.349554682884977e-08, 0, 0, 0, 0, 7.715047421278781e-07, 2.958323850532032e-07, 6.5137785527863e-07, -3.40165313149562e-07, 1.498023570500414e-06, 2.492038233690158e-07, 1.395223018993416e-06, -3.150663149441921e-07, 1.954718171910318e-06, -3.415637300374603e-08;
     forces->values() << -0.0146558918972568, -0.000267011181975166, 0.05711438744699839, 0.0002383730136872111, -0.0153609861368436, -0.0002852878106683293, 0.05638274862725741, 0.0002839619744993407, -0.00685643232676097, -0.006815594586569211, 0.02901925639144463, -0.02907380943293575, 0.05800715193585099, 9.667375963025685e-05, -0.01376443739049903, -9.547563172575954e-05, 0.05768190366530584, 0.0001311583223016465, -0.01408147425699792, -0.0001216961368213471, -0.01638235080508845, -0.0003874626694560972;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(3)) { // Secondary rank 3
     // Dummy Secondary rank to be able to reuse the 4 proc Intra-participant communication Fixture
   }
 
   // QN- Update, 2. iteration
   pp.performAcceleration(data);
+
+  // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
+  for (auto &pair : data) {
+    pair.second->setSampleAtTime(1, pair.second->sample());
+  }
 
   // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
   for (auto &pair : data) {
@@ -794,6 +858,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.790034504773721e-05, -2.446591076368466e-07, 1.889267115021718e-05, -1.972643201602028e-06, 1.681613350812527e-05, -2.373460013995369e-06, 1.584978895355817e-05, -5.302446869164338e-07, 1.274157692078479e-05, -2.137546278211264e-06, 1.362926508984742e-05, -2.762211725309514e-06, 1.249719424608544e-05, -3.19640295598053e-06, 1.333474052315949e-05, -3.16159193819195e-06, 1.394510078525391e-05, -1.166587691625877e-06, 1.488356439901566e-05, -2.605456452904905e-06, 2.056070000286195e-05, -1.341920935569228e-06;
     forces->values() << -0.01845221261910751, -0.000473660279052688, 0.05115217408647257, 0.0004997712466226923, 0.04953299847638116, 0.0006834967349236343, -0.02003343430934222, -0.000812620519068711, -0.02461452082338934, -0.00115320030035888, 0.04486850176987132, 0.00121794049154945, -0.01080003301957858, -0.01839753254507924, 0.02398381340216066, -0.01606849579606463, -0.02220297183992202, -0.0008082032560853196, 0.04750952330271016, 0.0008672013640382038, 0.05236940113731539, 0.0003710183715860552;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(2)) { // Secondary rank 2
 
     dref = Eigen::VectorXd::Zero(22);
@@ -820,6 +888,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.848182952307335e-05, -1.983938722952872e-06, 1.952389995095743e-05, 1.049689886611777e-06, 2.020972044646931e-05, -9.30012125294331e-07, 2.123911759834233e-05, -3.352823479948144e-07, 0, 0, 0, 0, 7.715124780435689e-06, 2.958056858428718e-06, 6.513639301665504e-06, -3.401886529062288e-06, 1.498034283416962e-05, 2.491634858078641e-06, 1.39521486945152e-05, -3.151050708450101e-06, 1.954707223943552e-05, -3.417246252999375e-07;
     forces->values() << -0.01568208277628194, -0.0002595395446636614, 0.0540328986967421, 0.0002362571305830931, -0.01637736854863682, -0.0002699645831085989, 0.05331751790879287, 0.0002707054191427001, -0.007277539612331946, -0.007235194100552225, 0.02757151633202504, -0.02762772092892902, 0.05505877464319012, 0.0001052840945529276, -0.01465499974491537, -0.0001017767294585529, 0.05464614037258596, 0.0001424559420056945, -0.01506072500921042, -0.0001315030046882618, -0.0173164149989076, -0.0003474184175392483;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(3)) { // Secondary rank 3
     // Dummy Secondary rank to be able to reuse the 4 proc Intra-participant communication Fixture
   }
@@ -860,6 +932,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.659080663925766e-05, -2.839283676791931e-07, 1.756292801739508e-05, -1.881726812992964e-06, 1.564798101471437e-05, -2.265931706775091e-06, 1.470124517392331e-05, -5.705378156142171e-07, 1.186047603634431e-05, -2.115667271562722e-06, 1.273027556448604e-05, -2.674541973319838e-06, 1.165645170777486e-05, -3.135385366949176e-06, 1.247728214631633e-05, -3.082564251671268e-06, 1.295443089215965e-05, -1.185450561958201e-06, 1.387356342346108e-05, -2.500933334689963e-06, 1.911143938064833e-05, -1.289577439500651e-06;
     forces->values() << -0.08018882094302014, 0.004252226533647444, -0.1681454949889014, -0.00376664315520894, -0.1528473285523723, -0.005402482563102148, -0.06546415562528343, 0.007580544006107058, -0.02584070375141325, 0.01001310706105286, -0.1119519940946071, -0.008779400784032571, -0.02359260557541131, 0.03241153400001811, -0.06629773012631451, 0.01232457880930212, -0.04595115217779744, 0.007271575191182346, -0.1343966169086029, -0.006463593204557456, -0.1788931815052193, -0.00241194798896828;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(2)) { // Secondary rank 2
 
     dref = Eigen::VectorXd::Zero(22);
@@ -886,6 +962,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.716650969972045e-05, -1.856138836171773e-06, 1.818701485070425e-05, 9.439657883607802e-07, 1.874709534954619e-05, -8.85448704675396e-07, 1.975527973304359e-05, -3.501096287428596e-07, 0, 0, 0, 0, 7.228951427433641e-06, 2.745909101918556e-06, 6.052367643912141e-06, -3.179587143921995e-06, 1.398276918926419e-05, 2.29762824040882e-06, 1.297587398676e-05, -2.941551341709183e-06, 1.811863361465251e-05, -3.546317448342288e-07;
     forces->values() << -0.09539527385890252, 0.0003208855941258066, -0.1853399184726223, 7.203155656644242e-05, -0.09532865072058605, 0.0009202649288056726, -0.1847925968312873, -0.0007589246108979722, -0.03998875591551594, -0.03982927597079221, -0.08489044889406808, 0.08470593806523596, -0.1739740974580442, 0.0007742373134568178, -0.08383286811708256, -0.0005911288917162662, -0.1811747642897668, 0.001020161732709184, -0.09112767929864005, -0.0008931566039992005, -0.08987332323372975, 0.002763113283891189;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(3)) { // Secondary rank 3
     // Dummy Secondary rank to be able to reuse the 4 proc Intra-participant communication Fixture
   }
@@ -926,6 +1006,10 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.506845042291629e-05, -3.295713481574521e-07, 1.601708402767785e-05, -1.776032790440438e-06, 1.428998106709373e-05, -2.140925300298825e-06, 1.336604025915203e-05, -6.173668108734595e-07, 1.083614857997936e-05, -2.09020895349816e-06, 1.168515223592441e-05, -2.572621503366579e-06, 1.067901778881212e-05, -3.064421860106172e-06, 1.14804152344671e-05, -2.990689693425248e-06, 1.180274523671064e-05, -1.207361572630013e-06, 1.26994053163659e-05, -2.379420351559266e-06, 1.742665917249236e-05, -1.228726437307901e-06;
     forces->values() << -0.07712271523301416, 0.004018032584755363, -0.1572746631951394, -0.003554957358717858, -0.1428154301136939, -0.005100471254411636, -0.06320679903752099, 0.00716455247252809, -0.02577587645775314, 0.009459639059138256, -0.1041793821597049, -0.008283348947413409, -0.02295652849878388, 0.02989440569403293, -0.06182269085435656, 0.01091909076145766, -0.04476922496853244, 0.00687112729333933, -0.1253800696382085, -0.006099818450316078, -0.1674291774005812, -0.002273881806091619;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(2)) { // Secondary rank 2
 
     dref = Eigen::VectorXd::Zero(22);
@@ -952,11 +1036,15 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     fpcd->storeIteration();
     displacements->values() << 1.563743909676446e-05, -1.707572586404205e-06, 1.663287551913161e-05, 8.210579991784308e-07, 1.704678071734513e-05, -8.336427145015805e-07, 1.803030552728031e-05, -3.673472962716038e-07, 0, 0, 0, 0, 6.663771864888832e-06, 2.499283366425937e-06, 5.516134032932667e-06, -2.921164340377279e-06, 1.282308279788757e-05, 2.07209067754735e-06, 1.184094543159743e-05, -2.698009821996337e-06, 1.645805878055576e-05, -3.696322259193852e-07;
     forces->values() << -0.09143825207871489, 0.0002922798859936043, -0.1734744585823354, 8.018501629471556e-05, -0.09140909287296797, 0.0008614262538692869, -0.1729893406976169, -0.0007078492982043917, -0.03836482525057584, -0.03821118279703851, -0.07931609050916776, 0.07913795276507131, -0.1626218046186428, 0.0007411076261039719, -0.08039872451576649, -0.0005667402343291361, -0.1694857588798654, 0.0009766586358261331, -0.0873517838382746, -0.0008552683303008771, -0.08627064033821233, 0.002609015553424872;
+
+    fpcd->setSampleAtTime(1, fpcd->sample());
+    dpcd->setSampleAtTime(1, dpcd->sample());
+
   } else if (context.isRank(3)) { // Secondary rank 3
     // Dummy Secondary rank to be able to reuse the 4 proc Intra-participant communication Fixture
   }
 
-  // QN- Update, 5. iteration
+  // QN- Update, 5. iteratidataon
   pp.performAcceleration(data);
 
   // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
@@ -1046,6 +1134,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   int              filter                   = BaseQNAcceleration::QR1FILTER;
   double           singularityLimit         = 0.1;
   bool             enforceInitialRelaxation = false;
+  bool             exchangeSubsteps         = false; // @todo add testColumnsLoggingWithSubsteps, where exchangeSubsteps = true as soon as acceleration scheme supports subcycling.
   std::vector<int> dataIDs;
   dataIDs.push_back(0);
   std::vector<double> factors;
@@ -1057,7 +1146,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   dummyMesh->setVertexOffsets(vertexOffsets);
 
   IQNILSAcceleration acc(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                         timeWindowsReused, filter, singularityLimit, dataIDs, prec);
+                         timeWindowsReused, filter, singularityLimit, dataIDs, prec, !exchangeSubsteps);
 
   mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
 
@@ -1078,12 +1167,12 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   }
 
   utils::append(displacements->values(), insert);
-
-  bool exchangeSubsteps = false; // @todo add testColumnsLoggingWithSubsteps, where exchangeSubsteps = true as soon as acceleration scheme supports subcycling.
-
   PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
   data.insert(std::pair<int, PtrCouplingData>(0, dpcd));
+
+  // Need at least two samples to get a valid waveform
   dpcd->setSampleAtTime(0, dpcd->sample());
+  dpcd->setSampleAtTime(1, dpcd->sample());
   dpcd->storeIteration();
 
   acc.initialize(data);
@@ -1100,6 +1189,10 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
 
   displacements->values() = insert;
 
+  // Need to update the samples
+  dpcd->setSampleAtTime(0, dpcd->sample());
+  dpcd->setSampleAtTime(1, dpcd->sample());
+
   acc.performAcceleration(data);
 
   Eigen::VectorXd newdvalues1;
@@ -1112,7 +1205,9 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   } else if (context.isRank(3)) {
     utils::append(newdvalues1, 1.0);
   }
+
   data.begin()->second->values() = newdvalues1;
+  dpcd->setSampleAtTime(1, dpcd->sample());
 
   acc.performAcceleration(data);
 
@@ -1126,7 +1221,9 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   } else if (context.isRank(3)) {
     utils::append(newdvalues2, 1.0);
   }
+
   data.begin()->second->values() = newdvalues2;
+  dpcd->setSampleAtTime(1, dpcd->sample());
 
   acc.iterationsConverged(data);
 
@@ -1144,7 +1241,9 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   } else if (context.isRank(3)) {
     utils::append(newdvalues3, 1.0);
   }
+
   data.begin()->second->values() = newdvalues3;
+  dpcd->setSampleAtTime(1, dpcd->sample());
 
   acc.performAcceleration(data);
 
@@ -1158,7 +1257,9 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   } else if (context.isRank(3)) {
     utils::append(newdvalues4, 5.0);
   }
+
   data.begin()->second->values() = newdvalues4;
+  dpcd->setSampleAtTime(1, dpcd->sample());
 
   acc.iterationsConverged(data);
 

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -60,7 +60,7 @@ void testIQNIMVJPP(bool exchangeSubsteps)
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                          timeWindowsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
-                         restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps);
+                         restartType, chunkSize, reusedTimeWindowsAtRestart, svdTruncationEps, !exchangeSubsteps);
 
   Eigen::VectorXd fcol1;
 
@@ -71,11 +71,13 @@ void testIQNIMVJPP(bool exchangeSubsteps)
   displacements->values().resize(4);
   displacements->values() << 1.0, 1.0, 1.0, 1.0;
   displacements->setSampleAtTime(0, displacements->sample());
+  displacements->setSampleAtTime(1, displacements->sample());
 
   // init forces
   forces->values().resize(4);
   forces->values() << 0.2, 0.2, 0.2, 0.2;
   forces->setSampleAtTime(0, forces->sample());
+  forces->setSampleAtTime(1, forces->sample());
 
   cplscheme::PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
   cplscheme::PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
@@ -106,6 +108,10 @@ void testIQNIMVJPP(bool exchangeSubsteps)
 
   data.begin()->second->values() << 10, 10, 10, 10;
 
+  // Update the waveform as well
+  displacements->setSampleAtTime(1, displacements->sample());
+  forces->setSampleAtTime(1, forces->sample());
+
   pp.performAcceleration(data);
 
   BOOST_TEST(testing::equals(data.at(0)->values()(0), -5.63401340929695848558e-01));
@@ -118,14 +124,11 @@ void testIQNIMVJPP(bool exchangeSubsteps)
   BOOST_TEST(testing::equals(data.at(1)->values()(3), 8.28025852497733250157e-02));
 }
 
-#if 0
-// TODO not yet supported
 BOOST_AUTO_TEST_CASE(testIQNIMVJPPWithSubsteps)
 {
   PRECICE_TEST(1_rank);
   testIQNIMVJPP(true);
 }
-#endif
 
 BOOST_AUTO_TEST_CASE(testIQNIMVJPPWithoutSubsteps)
 {
@@ -157,7 +160,7 @@ void testVIQNPP(bool exchangeSubsteps)
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
-                        timeWindowsReused, filter, singularityLimit, dataIDs, prec);
+                        timeWindowsReused, filter, singularityLimit, dataIDs, prec, !exchangeSubsteps);
 
   mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
   mesh::PtrData forces(new mesh::Data("fvalues", -1, 1));
@@ -166,11 +169,13 @@ void testVIQNPP(bool exchangeSubsteps)
   displacements->values().resize(4);
   displacements->values() << 1.0, 1.0, 1.0, 1.0;
   displacements->setSampleAtTime(0, displacements->sample());
+  displacements->setSampleAtTime(1, displacements->sample());
 
   // init forces
   forces->values().resize(4);
   forces->values() << 0.2, 0.2, 0.2, 0.2;
   forces->setSampleAtTime(0, forces->sample());
+  forces->setSampleAtTime(1, forces->sample());
 
   cplscheme::PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
   cplscheme::PtrCouplingData fpcd = makeCouplingData(forces, dummyMesh, exchangeSubsteps);
@@ -186,6 +191,7 @@ void testVIQNPP(bool exchangeSubsteps)
 
   displacements->values() << 1.0, 2.0, 3.0, 4.0;
   displacements->setSampleAtTime(1, displacements->sample());
+
   forces->values() << 0.1, 0.1, 0.1, 0.1;
   forces->setSampleAtTime(1, forces->sample());
 
@@ -207,6 +213,9 @@ void testVIQNPP(bool exchangeSubsteps)
   utils::append(newdvalues, 10.0);
   data.begin()->second->values() = newdvalues;
 
+  displacements->setSampleAtTime(1, displacements->sample());
+  forces->setSampleAtTime(1, forces->sample());
+
   pp.performAcceleration(data);
 
   BOOST_TEST(testing::equals(data.at(0)->values()(0), -5.63401340929692295845e-01));
@@ -219,14 +228,11 @@ void testVIQNPP(bool exchangeSubsteps)
   BOOST_TEST(testing::equals(data.at(1)->values()(3), 8.28025852497733944046e-02));
 }
 
-#if 0
-// TODO not yet supported
 BOOST_AUTO_TEST_CASE(testVIQNPPWithSubsteps)
 {
   PRECICE_TEST(1_rank);
   testVIQNPP(true);
- }
-#endif
+}
 
 BOOST_AUTO_TEST_CASE(testVIQNPPWithoutSubsteps)
 {

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -295,6 +295,8 @@ target_sources(preciceCore
     src/time/Storage.hpp
     src/time/Time.cpp
     src/time/Time.hpp
+    src/time/TimeGrids.cpp
+    src/time/TimeGrids.hpp
     src/time/Waveform.cpp
     src/time/Waveform.hpp
     src/utils/ArgumentFormatter.hpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -99,6 +99,7 @@ target_sources(testprecice
     src/testing/main.cpp
     src/testing/tests/ExampleTests.cpp
     src/time/tests/StorageTest.cpp
+    src/time/tests/TimeGridsTest.cpp
     src/time/tests/WaveformTest.cpp
     src/utils/tests/AlgorithmTest.cpp
     src/utils/tests/DimensionsTest.cpp

--- a/src/time/TimeGrids.cpp
+++ b/src/time/TimeGrids.cpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <numeric>
+#include <vector>
+
+#include "TimeGrids.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice::time {
+
+TimeGrids::TimeGrids(const DataMap &cplData, std::vector<int> dataIDs, bool reducedTimeGrid)
+{
+  for (int dataID : dataIDs) {
+    Eigen::VectorXd timeGrid = cplData.at(dataID)->timeStepsStorage().getTimes();
+    if (reducedTimeGrid) {
+      _timeGrids.insert(std::pair<int, Eigen::VectorXd>(dataID, timeGrid.tail<1>()));
+    } else {
+      _timeGrids.insert(std::pair<int, Eigen::VectorXd>(dataID, timeGrid));
+    }
+  }
+}
+
+Eigen::VectorXd TimeGrids::getTimeGrid(int dataID) const
+{
+
+  PRECICE_ASSERT(_timeGrids.count(dataID), "there does not exists a stored time grid corresponding to this dataID");
+
+  return _timeGrids.at(dataID);
+}
+
+void TimeGrids::moveTimeGridToNewWindow(const DataMap &cplData)
+{
+  for (auto &pair : _timeGrids) {
+    if (pair.second.size() == 1) {
+      _timeGrids.at(pair.first) = cplData.at(pair.first)->timeStepsStorage().getTimes().tail<1>();
+    } else {
+      int dataID = pair.first;
+      // Only way to access the first time stamp is through the whole vector
+      Eigen::VectorXd newtimeGrid = cplData.at(dataID)->timeStepsStorage().getTimes();
+      double          newTimesMin = newtimeGrid(0);
+      double          newTimesMax = newtimeGrid(newtimeGrid.size() - 1);
+
+      Eigen::VectorXd timeGrid    = pair.second;
+      double          oldTimesMin = _timeGrids.at(dataID)(0);
+      double          oldTimesMax = _timeGrids.at(dataID)(timeGrid.size() - 1);
+
+      //  Linearly transforms the time grid from the old time window [t_{N-1}, t_N] to the new time window [t_N, t_{N+1}] by translating and scaling the time grid
+      auto transformNewTime = [oldTimesMin, oldTimesMax, newTimesMin, newTimesMax](double t) -> double { return (t - oldTimesMin) / (oldTimesMax - oldTimesMin) * (newTimesMax - newTimesMin) + newTimesMin; };
+      timeGrid              = timeGrid.unaryExpr(transformNewTime);
+      _timeGrids.at(dataID) = timeGrid;
+    }
+  }
+}
+} // namespace precice::time

--- a/src/time/TimeGrids.hpp
+++ b/src/time/TimeGrids.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <numeric>
+#include <vector>
+
+#include "cplscheme/CouplingData.hpp"
+#include "cplscheme/SharedPointer.hpp"
+#include "logging/LogMacros.hpp"
+#include "logging/Logger.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice {
+namespace time {
+
+/**
+ * @brief Interface for storing the time grids in the Quasi-Newton and Aitken methods.
+ * A time grid is a ordered vector containing the time stamps from the samples in the waveform of the coupled data.
+ *
+ *
+ */
+class TimeGrids {
+public:
+  /// Map from data ID to data values.
+  using DataMap = std::map<int, cplscheme::PtrCouplingData>;
+
+  /**
+   * @brief saves the current time grid of the couplig data
+   * @param cplData
+   * @param dataIDs of which time grids we want to save
+   * @param reduced if true then only the last timestep is saved in the timeGrid otherwise all timesteps are saved in the time grid
+   * This is used in the Quasi-Newton method to toggle between the full and reduced variant detailed here
+   */
+  TimeGrids(const DataMap &cplData, std::vector<int> dataIDs, bool reduced);
+
+  Eigen::VectorXd getTimeGrid(int dataID) const;
+
+  //  Linearly transforms the time grid from the old time window [t_{N-1}, t_N] to the new time window [t_N, t_{N+1}]
+  // This is done to allow the QN methods to sample from the new time window while keeping the structure and vector dimensions inside the QN method
+  void moveTimeGridToNewWindow(const DataMap &cplData);
+
+private:
+  logging::Logger _log{"acceleration::WaveformTimeGrids"};
+
+  /// @brief List of the time grid to which all the data will be interpolated to
+  /// Stored in a map, since each data entry has its own time grid
+  std::map<int, Eigen::VectorXd> _timeGrids;
+};
+
+} // namespace time
+} // namespace precice

--- a/src/time/tests/TimeGridsTest.cpp
+++ b/src/time/tests/TimeGridsTest.cpp
@@ -1,0 +1,94 @@
+#ifndef PRECICE_NO_MPI
+
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/src/Core/Matrix.h>
+
+#include "acceleration/SharedPointer.hpp"
+#include "acceleration/test/helper.hpp"
+#include "cplscheme/CouplingData.hpp"
+#include "cplscheme/SharedPointer.hpp"
+#include "mesh/Mesh.hpp"
+
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+#include "time/TimeGrids.hpp"
+
+BOOST_AUTO_TEST_SUITE(TimeTests)
+
+using namespace precice;
+using namespace precice::time;
+
+using precice::testing::makeCouplingData;
+
+struct TimeGridsTestsFixture {
+  using DataMap = std::map<int, cplscheme::PtrCouplingData>;
+};
+
+BOOST_FIXTURE_TEST_SUITE(TimeGridsTest, TimeGridsTestsFixture)
+
+BOOST_AUTO_TEST_CASE(TestMoveAndScaleTimeGrids)
+{
+  PRECICE_TEST(1_rank);
+  std::vector<int> dataIDs;
+  dataIDs.push_back(0);
+  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
+
+  mesh::PtrData displacements(new mesh::Data("dvalues", -1, 1));
+
+  // init displacements and waveform
+  displacements->values().resize(4);
+  displacements->values() << 1.0, 1.0, 1.0, 1.0;
+  displacements->setSampleAtTime(0, displacements->sample());
+  displacements->setSampleAtTime(0.5, displacements->sample());
+  displacements->setSampleAtTime(1, displacements->sample());
+
+  cplscheme::PtrCouplingData dpcd = makeCouplingData(displacements, dummyMesh, true);
+
+  DataMap data;
+  data.insert(std::pair<int, cplscheme::PtrCouplingData>(0, dpcd));
+
+  time::TimeGrids fullTimeGrid(data, dataIDs, false);
+  time::TimeGrids reducedTimeGrid(data, dataIDs, true);
+
+  Eigen::VectorXd storedFullTimeGrid    = fullTimeGrid.getTimeGrid(dataIDs[0]);
+  Eigen::VectorXd storedReducedTimeGrid = reducedTimeGrid.getTimeGrid(dataIDs[0]);
+
+  /// Test that the time grids contain the correct gridpoints
+  BOOST_TEST(testing::equals(storedFullTimeGrid(0), 0.0));
+  BOOST_TEST(testing::equals(storedFullTimeGrid(1), 0.5));
+  BOOST_TEST(testing::equals(storedFullTimeGrid(2), 1.0));
+  BOOST_TEST(testing::equals(storedReducedTimeGrid(0), 1.0));
+
+  // Create a second data pointer with the contentes of the second time window
+  mesh::PtrData newdisplacements(new mesh::Data("dvalues", -1, 1));
+
+  // init newdisplacements
+  newdisplacements->values().resize(4);
+  newdisplacements->values() << 1.0, 1.0, 1.0, 1.0;
+  newdisplacements->setSampleAtTime(1.0, newdisplacements->sample());
+  newdisplacements->setSampleAtTime(3.0, newdisplacements->sample());
+
+  cplscheme::PtrCouplingData newdpcd = makeCouplingData(newdisplacements, dummyMesh, true);
+
+  DataMap newdata;
+  newdata.insert(std::pair<int, cplscheme::PtrCouplingData>(0, newdpcd));
+
+  // move the time grid to the new time window
+  fullTimeGrid.moveTimeGridToNewWindow(newdata);
+  reducedTimeGrid.moveTimeGridToNewWindow(newdata);
+
+  storedFullTimeGrid    = fullTimeGrid.getTimeGrid(dataIDs[0]);
+  storedReducedTimeGrid = reducedTimeGrid.getTimeGrid(dataIDs[0]);
+
+  /// Test that the time grids contain the correct gridpoints
+
+  BOOST_TEST(testing::equals(storedFullTimeGrid(0), 1.0));
+  BOOST_TEST(testing::equals(storedFullTimeGrid(1), 2.0));
+  BOOST_TEST(testing::equals(storedFullTimeGrid(2), 3.0));
+  BOOST_TEST(testing::equals(storedReducedTimeGrid(0), 3.0));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+#endif

--- a/tests/quasi-newton/helpers.cpp
+++ b/tests/quasi-newton/helpers.cpp
@@ -2,6 +2,7 @@
 
 #include "helpers.hpp"
 
+#include "math/differences.hpp"
 #include "precice/precice.hpp"
 #include "testing/Testing.hpp"
 
@@ -232,6 +233,216 @@ void runTestQNEmptyPartition(std::string const &config, TestContext const &conte
     BOOST_TEST(iterations <= 20);
     BOOST_TEST(iterations >= 5);
   }
+}
+
+void runTestQNWithWaveforms(std::string const &config, TestContext const &context)
+{
+
+  std::string meshName, writeDataName, readDataName;
+
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "Data1";
+    readDataName  = "Data2";
+  } else {
+    BOOST_REQUIRE(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "Data2";
+    readDataName  = "Data1";
+  }
+
+  precice::Participant interface(context.name, config, context.rank, context.size);
+  VertexID             vertexIDs[2];
+
+  // meshes for rank 0 and rank 1, we use matching meshes for both participants
+  double positions0[4] = {1.0, 0.0, 1.0, 0.5};
+  double positions1[4] = {2.0, 0.0, 2.0, 1.0};
+
+  if (context.isNamed("SolverOne")) {
+    if (context.isPrimary()) {
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
+    } else {
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
+    }
+  } else {
+    BOOST_REQUIRE(context.isNamed("SolverTwo"));
+    if (not context.isPrimary()) {
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
+    } else {
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
+    }
+  }
+
+  int             nSubsteps = 5;             // perform subcycling on solvers. 5 steps happen in each window.
+  Eigen::MatrixXd savedValues(nSubsteps, 2); // save the solution to check for correctness after it has converged
+
+  interface.initialize();
+  double maxDt         = interface.getMaxTimeStepSize();
+  double inValues[2]   = {0.0, 0.0};
+  double outValues[2]  = {0.0, 0.0};
+  double dt            = maxDt / nSubsteps; //Do 5 substeps to check if QN and Waveform iterations work together
+  int    nSubStepsDone = 0;                 // Counts the number of substeps that are done
+  double t             = 0;
+  int    iterations    = 0;
+  double timeCheckpoint;
+  while (interface.isCouplingOngoing()) {
+
+    if (interface.requiresWritingCheckpoint()) {
+      timeCheckpoint = t;
+      iterations     = 0;
+      nSubStepsDone  = 0;
+    }
+
+    interface.readData(meshName, readDataName, {vertexIDs, 2}, dt, {inValues, 2});
+
+    /*
+      Solves the following linear system
+      2*x1 + x2 = t**2
+      -x1 + x2 = t
+      Analytical solutions are x1 = 1/3*(t**2 - t) and x2 = 1/3*(t**2 + 2*t).
+    */
+
+    if (context.isNamed("SolverOne")) {
+      for (int i = 0; i < 2; i++) {
+        outValues[i] = inValues[i]; //only pushes solution through
+      }
+    } else {
+      outValues[0] = (-inValues[0] - inValues[1] + t * t);
+      outValues[1] = inValues[0] + t;
+    }
+
+    // save the outValues in savedValues to check for correctness later
+    savedValues(nSubStepsDone, 0) = outValues[0];
+    savedValues(nSubStepsDone, 1) = outValues[1];
+
+    interface.writeData(meshName, writeDataName, {vertexIDs, 2}, {outValues, 2});
+
+    nSubStepsDone += 1;
+    t += dt;
+
+    interface.advance(dt);
+    maxDt = interface.getMaxTimeStepSize();
+    dt    = dt > maxDt ? maxDt : dt;
+
+    if (interface.requiresReadingCheckpoint()) {
+      nSubStepsDone = 0;
+      t             = timeCheckpoint;
+      iterations++;
+    }
+  }
+  interface.finalize();
+
+  // Check that the last time window has converged to the analytical solution
+  auto analyticalSolution = [](double localTime) { return std::vector<double>{(localTime * localTime - localTime) / 3, (localTime * localTime + 2 * localTime) / 3}; };
+  for (int i = 0; i < nSubsteps; i++) {
+    // scaling with the time window length which is equal to 1
+    double localTime = (1.0 * i) / nSubStepsDone + timeCheckpoint;
+    BOOST_TEST(math::equals(savedValues(i, 0), analyticalSolution(localTime)[0], 1e-10));
+    BOOST_TEST(math::equals(savedValues(i, 1), analyticalSolution(localTime)[1], 1e-10));
+  }
+}
+
+void runTestQNWithWaveformsReducedTimeGrid(std::string const &config, TestContext const &context)
+{
+
+  std::string meshName, writeDataName, readDataName;
+
+  if (context.isNamed("SolverOne")) {
+    meshName      = "MeshOne";
+    writeDataName = "Data1";
+    readDataName  = "Data2";
+  } else {
+    BOOST_REQUIRE(context.isNamed("SolverTwo"));
+    meshName      = "MeshTwo";
+    writeDataName = "Data2";
+    readDataName  = "Data1";
+  }
+
+  precice::Participant interface(context.name, config, context.rank, context.size);
+  VertexID             vertexIDs[1];
+
+  // meshes for rank 0 and rank 1, we use matching meshes for both participants
+  double positions0[2] = {1.0, 0.0};
+  double positions1[2] = {2.0, 0.0};
+
+  if (context.isNamed("SolverOne")) {
+    if (context.isPrimary()) {
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
+    } else {
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
+    }
+  } else {
+    BOOST_REQUIRE(context.isNamed("SolverTwo"));
+    if (not context.isPrimary()) {
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
+    } else {
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
+    }
+  }
+
+  int             nSubsteps = 2;          // perform subcycling on solvers. 2 steps happen in each window.
+  Eigen::VectorXd savedValues(nSubsteps); // save the solution to check for correctness after it has converged
+
+  interface.initialize();
+  double maxDt         = interface.getMaxTimeStepSize();
+  double inValues[1]   = {0.0};
+  double outValues[1]  = {0.0};
+  double dt            = maxDt / nSubsteps; //Do 2 substeps to check if QN and Waveform iterations work together
+  int    nSubStepsDone = 0;                 // Counts the number of substeps that are done
+  double t             = 0;
+  int    iterations    = 0;
+  double timeCheckpoint;
+  double pastXValue = 1;
+  while (interface.isCouplingOngoing()) {
+
+    if (interface.requiresWritingCheckpoint()) {
+      timeCheckpoint = t;
+      iterations     = 0;
+      nSubStepsDone  = 0;
+    }
+
+    interface.readData(meshName, readDataName, {vertexIDs, 1}, dt, {inValues, 1});
+
+    /*
+    rQNWR need the time steps to be coupled together, thus to test rQNWR we solve
+     the following linear system over the two time steps
+      2*x1 = 1
+      -x1+2*x2 = 0,
+      where x1 and x2 denote the x values in the first respectively second time step.
+
+      The solution is given by x1 = 1/2 and x2 = 1/4.
+    */
+
+    if (context.isNamed("SolverOne")) {
+      outValues[0] = inValues[0]; //only pushes solution through
+    } else {
+      outValues[0] = (-inValues[0] + pastXValue);
+      pastXValue   = outValues[0];
+    }
+
+    // save the outValues in savedValues to check for correctness later
+    savedValues(nSubStepsDone, 0) = outValues[0];
+
+    interface.writeData(meshName, writeDataName, {vertexIDs, 1}, {outValues, 1});
+
+    nSubStepsDone += 1;
+    t += dt;
+
+    interface.advance(dt);
+    maxDt = interface.getMaxTimeStepSize();
+    dt    = dt > maxDt ? maxDt : dt;
+
+    if (interface.requiresReadingCheckpoint()) {
+      nSubStepsDone = 0;
+      t             = timeCheckpoint;
+      pastXValue    = 1;
+      iterations++;
+    }
+  }
+  interface.finalize();
+  // Check that the last time window has converged to the correct solution
+  BOOST_TEST(math::equals(savedValues(0), 0.5, 1e-10));
+  BOOST_TEST(math::equals(savedValues(1), 0.25, 1e-10));
 }
 
 #endif

--- a/tests/quasi-newton/helpers.hpp
+++ b/tests/quasi-newton/helpers.hpp
@@ -11,4 +11,7 @@ void runTestQN(bool includeSecondaryData, std::string const &config, TestContext
 
 void runTestQNEmptyPartition(std::string const &config, TestContext const &context);
 
+void runTestQNWithWaveforms(std::string const &config, TestContext const &context);
+
+void runTestQNWithWaveformsReducedTimeGrid(std::string const &config, TestContext const &context);
 #endif

--- a/tests/quasi-newton/parallel/TestQN11.cpp
+++ b/tests/quasi-newton/parallel/TestQN11.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "../helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(QuasiNewton)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_CASE(TestQN11)
+{
+  PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
+  // serial coupling,Waveform iterations, IQN-ILS
+  runTestQNWithWaveforms(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/quasi-newton/parallel/TestQN11.xml
+++ b/tests/quasi-newton/parallel/TestQN11.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="Data1" waveform-degree="2" />
+  <data:scalar name="Data2" waveform-degree="2" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data1" mesh="MeshOne" />
+    <read-data name="Data2" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <write-data name="Data2" mesh="MeshTwo" />
+    <read-data name="Data1" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="true" />
+    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="true" />
+    <max-iterations value="32" />
+    <relative-convergence-measure limit="1e-11" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-11" data="Data1" mesh="MeshOne" />
+    <acceleration:IQN-ILS reducedTimeGrid="false">
+      <data name="Data2" mesh="MeshOne" />
+      <data name="Data1" mesh="MeshOne" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="32" />
+      <time-windows-reused value="1" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/quasi-newton/serial/TestQN11.cpp
+++ b/tests/quasi-newton/serial/TestQN11.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "../helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(QuasiNewton)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_CASE(TestQN11)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  // serial coupling,Waveform iterations, IQN-ILS
+  runTestQNWithWaveforms(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/quasi-newton/serial/TestQN11.xml
+++ b/tests/quasi-newton/serial/TestQN11.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="Data1" waveform-degree="2" />
+  <data:scalar name="Data2" waveform-degree="2" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data1" mesh="MeshOne" />
+    <read-data name="Data2" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <write-data name="Data2" mesh="MeshTwo" />
+    <read-data name="Data1" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="true" />
+    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="true" />
+    <max-iterations value="20" />
+    <relative-convergence-measure limit="1e-13" data="Data2" mesh="MeshOne" />
+    <acceleration:IQN-ILS reducedTimeGrid="false">
+      <data name="Data2" mesh="MeshOne" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="20" />
+      <time-windows-reused value="2" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/quasi-newton/serial/TestQN12.cpp
+++ b/tests/quasi-newton/serial/TestQN12.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "../helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(QuasiNewton)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_CASE(TestQN12)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  // serial coupling,Waveform iterations, IQN-ILS with reduced time grid
+  runTestQNWithWaveformsReducedTimeGrid(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/quasi-newton/serial/TestQN12.xml
+++ b/tests/quasi-newton/serial/TestQN12.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="Data1" waveform-degree="2" />
+  <data:scalar name="Data2" waveform-degree="2" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data1" mesh="MeshOne" />
+    <read-data name="Data2" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <write-data name="Data2" mesh="MeshTwo" />
+    <read-data name="Data1" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1" />
+    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="true" />
+    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="true" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1e-13" data="Data2" mesh="MeshOne" />
+    <acceleration:IQN-ILS reducedTimeGrid="true">
+      <data name="Data2" mesh="MeshOne" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="10" />
+      <time-windows-reused value="2" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/quasi-newton/serial/TestQN13.cpp
+++ b/tests/quasi-newton/serial/TestQN13.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "../helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(QuasiNewton)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_CASE(TestQN13)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  // serial coupling,Waveform iterations, IQN-IMVJ
+  runTestQNWithWaveforms(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/quasi-newton/serial/TestQN13.xml
+++ b/tests/quasi-newton/serial/TestQN13.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="Data1" waveform-degree="2" />
+  <data:scalar name="Data2" waveform-degree="2" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data1" mesh="MeshOne" />
+    <read-data name="Data2" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <write-data name="Data2" mesh="MeshTwo" />
+    <read-data name="Data1" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="true" />
+    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="true" />
+    <max-iterations value="20" />
+    <relative-convergence-measure limit="1e-13" data="Data2" mesh="MeshOne" />
+    <acceleration:IQN-IMVJ reducedTimeGrid="false">
+      <data name="Data2" mesh="MeshOne" />
+      <filter type="QR2" limit="1e-3" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="20" />
+      <time-windows-reused value="2" />
+    </acceleration:IQN-IMVJ>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/quasi-newton/serial/TestQN14.cpp
+++ b/tests/quasi-newton/serial/TestQN14.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "../helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(QuasiNewton)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_CASE(TestQN14)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  // serial coupling,Waveform iterations, IQN-IMVJ with reduced time grids
+  runTestQNWithWaveformsReducedTimeGrid(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/quasi-newton/serial/TestQN14.xml
+++ b/tests/quasi-newton/serial/TestQN14.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="Data1" waveform-degree="2" />
+  <data:scalar name="Data2" waveform-degree="2" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Data1" mesh="MeshOne" />
+    <read-data name="Data2" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <write-data name="Data2" mesh="MeshTwo" />
+    <read-data name="Data1" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1" />
+    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="true" />
+    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="true" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1e-13" data="Data2" mesh="MeshOne" />
+    <acceleration:IQN-IMVJ reducedTimeGrid="true">
+      <data name="Data2" mesh="MeshOne" />
+      <filter type="QR2" limit="1e-8" />
+      <initial-relaxation value="0.1" />
+      <max-used-iterations value="20" />
+      <time-windows-reused value="2" />
+    </acceleration:IQN-IMVJ>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -64,6 +64,7 @@ target_sources(testprecice
     tests/quasi-newton/parallel/TestQN1.cpp
     tests/quasi-newton/parallel/TestQN10.cpp
     tests/quasi-newton/parallel/TestQN10EmptyPartition.cpp
+    tests/quasi-newton/parallel/TestQN11.cpp
     tests/quasi-newton/parallel/TestQN1EmptyPartition.cpp
     tests/quasi-newton/parallel/TestQN2.cpp
     tests/quasi-newton/parallel/TestQN2EmptyPartition.cpp
@@ -84,6 +85,10 @@ target_sources(testprecice
     tests/quasi-newton/serial/DefaultConfig.cpp
     tests/quasi-newton/serial/TestQN1.cpp
     tests/quasi-newton/serial/TestQN10.cpp
+    tests/quasi-newton/serial/TestQN11.cpp
+    tests/quasi-newton/serial/TestQN12.cpp
+    tests/quasi-newton/serial/TestQN13.cpp
+    tests/quasi-newton/serial/TestQN14.cpp
     tests/quasi-newton/serial/TestQN2.cpp
     tests/quasi-newton/serial/TestQN3.cpp
     tests/quasi-newton/serial/TestQN4.cpp


### PR DESCRIPTION
## Main changes of this PR

Adds support for Quasi Newton acceleration for waveform iterations.


## Motivation and additional information

Implements the algorithm described https://onlinelibrary.wiley.com/doi/10.1002/nme.6443 for fixed time grids. For moving time grids everything will be interpolated to the first time grid from the first time window inside the QNWR class instead of using the waveforms inside the QN method as done in #1834. 

For IMVJ variant the same fix for all time steps as described in issue  #1996 will be used. 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
