### PR TITLE
Add secondary data to exsting QN tests

### DIFF
--- a/tests/quasi-newton/helpers.cpp
+++ b/tests/quasi-newton/helpers.cpp
@@ -8,17 +8,21 @@
 /// tests for different QN settings if correct fixed point is reached
 void runTestQN(std::string const &config, TestContext const &context)
 {
-  std::string meshName, writeDataName, readDataName;
+  std::string meshName, writeDataName1, writeDataName2, readDataName1, readDataName2;
 
   if (context.isNamed("SolverOne")) {
-    meshName      = "MeshOne";
-    writeDataName = "Data1";
-    readDataName  = "Data2";
+    meshName       = "MeshOne";
+    writeDataName1 = "Data11";
+    writeDataName2 = "Data12";
+    readDataName1  = "Data21";
+    readDataName2  = "Data22";
   } else {
     BOOST_REQUIRE(context.isNamed("SolverTwo"));
-    meshName      = "MeshTwo";
-    writeDataName = "Data2";
-    readDataName  = "Data1";
+    meshName       = "MeshTwo";
+    writeDataName1 = "Data21";
+    writeDataName2 = "Data22";
+    readDataName1  = "Data11";
+    readDataName2  = "Data12";
   }
 
   precice::Participant interface(context.name, config, context.rank, context.size);
@@ -45,8 +49,10 @@ void runTestQN(std::string const &config, TestContext const &context)
   }
 
   interface.initialize();
-  double inValues[4]  = {0.0, 0.0, 0.0, 0.0};
-  double outValues[4] = {0.0, 0.0, 0.0, 0.0};
+  double inValues1[4]  = {0.0, 0.0, 0.0, 0.0};
+  double inValues2[4]  = {0.0, 0.0, 0.0, 0.0};
+  double outValues1[4] = {0.0, 0.0, 0.0, 0.0};
+  double outValues2[4] = {0.0, 0.0, 0.0, 0.0};
 
   int iterations = 0;
 
@@ -55,7 +61,8 @@ void runTestQN(std::string const &config, TestContext const &context)
     }
 
     double preciceDt = interface.getMaxTimeStepSize();
-    interface.readData(meshName, readDataName, vertexIDs, preciceDt, inValues);
+    interface.readData(meshName, readDataName1, vertexIDs, preciceDt, inValues1);
+    interface.readData(meshName, readDataName2, vertexIDs, preciceDt, inValues2);
 
     /*
       Solves the following non-linear equations, which are extended to a fixed-point equation (simply +x)
@@ -70,16 +77,22 @@ void runTestQN(std::string const &config, TestContext const &context)
 
     if (context.isNamed("SolverOne")) {
       for (int i = 0; i < 4; i++) {
-        outValues[i] = inValues[i]; //only pushes solution through
+        outValues1[i] = inValues1[i]; //only pushes solution through
+        outValues2[i] = inValues2[i];
       }
     } else {
-      outValues[0] = 2 * inValues[0] * inValues[0] - inValues[1] * inValues[2] - 8.0 + inValues[0];
-      outValues[1] = inValues[0] * inValues[0] * inValues[1] + 2.0 * inValues[0] * inValues[1] * inValues[2] + inValues[1] * inValues[2] * inValues[2] + inValues[1];
-      outValues[2] = inValues[2] * inValues[2] - 4.0 + inValues[2];
-      outValues[3] = inValues[3] * inValues[3] - 4.0 + inValues[3];
+      outValues1[0] = 2 * inValues1[0] * inValues1[0] - inValues1[1] * inValues1[2] - 8.0 + inValues1[0];
+      outValues1[1] = inValues1[0] * inValues1[0] * inValues1[1] + 2.0 * inValues1[0] * inValues1[1] * inValues1[2] + inValues1[1] * inValues1[2] * inValues1[2] + inValues1[1];
+      outValues1[2] = inValues1[2] * inValues1[2] - 4.0 + inValues1[2];
+      outValues1[3] = inValues1[3] * inValues1[3] - 4.0 + inValues1[3];
+      outValues2[0] = 2 * inValues2[0] * inValues2[0] - inValues2[1] * inValues2[2] - 8.0 + inValues2[0];
+      outValues2[1] = inValues2[0] * inValues2[0] * inValues2[1] + 2.0 * inValues2[0] * inValues2[1] * inValues2[2] + inValues2[1] * inValues2[2] * inValues2[2] + inValues2[1];
+      outValues2[2] = inValues2[2] * inValues2[2] - 4.0 + inValues2[2];
+      outValues2[3] = inValues2[3] * inValues2[3] - 4.0 + inValues2[3];
     }
 
-    interface.writeData(meshName, writeDataName, vertexIDs, outValues);
+    interface.writeData(meshName, writeDataName1, vertexIDs, outValues1);
+    interface.writeData(meshName, writeDataName2, vertexIDs, outValues2);
     interface.advance(1.0);
 
     if (interface.requiresReadingCheckpoint()) {
@@ -90,10 +103,14 @@ void runTestQN(std::string const &config, TestContext const &context)
   interface.finalize();
 
   //relative residual in config is 1e-7, so 2 orders of magnitude less strict
-  BOOST_TEST(outValues[0] == -2.0, boost::test_tools::tolerance(1e-5));
-  BOOST_TEST(outValues[1] == 0.0, boost::test_tools::tolerance(1e-5));
-  BOOST_TEST(outValues[2] == -2.0, boost::test_tools::tolerance(1e-5));
-  BOOST_TEST(outValues[3] == -2.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues1[0] == -2.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues1[1] == 0.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues1[2] == -2.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues1[3] == -2.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues2[0] == -2.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues2[1] == 0.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues2[2] == -2.0, boost::test_tools::tolerance(1e-5));
+  BOOST_TEST(outValues2[3] == -2.0, boost::test_tools::tolerance(1e-5));
 
   // to exclude false or no convergence
   BOOST_TEST(iterations <= 20);

--- a/tests/quasi-newton/helpers.cpp
+++ b/tests/quasi-newton/helpers.cpp
@@ -6,7 +6,7 @@
 #include "testing/Testing.hpp"
 
 /// tests for different QN settings if correct fixed point is reached
-void runTestQN(std::string const &config, TestContext const &context)
+void runTestQN(bool includeSecondaryData, std::string const &config, TestContext const &context)
 {
   std::string meshName, writeDataName1, writeDataName2, readDataName1, readDataName2;
 
@@ -62,7 +62,9 @@ void runTestQN(std::string const &config, TestContext const &context)
 
     double preciceDt = interface.getMaxTimeStepSize();
     interface.readData(meshName, readDataName1, vertexIDs, preciceDt, inValues1);
-    interface.readData(meshName, readDataName2, vertexIDs, preciceDt, inValues2);
+    if (includeSecondaryData) {
+      interface.readData(meshName, readDataName2, vertexIDs, preciceDt, inValues2);
+    }
 
     /*
       Solves the following non-linear equations, which are extended to a fixed-point equation (simply +x)
@@ -73,26 +75,37 @@ void runTestQN(std::string const &config, TestContext const &context)
 
       Analytical solutions are (+/-2, 0, +/-2, +/-2).
       Assumably due to the initial relaxation the iteration always converges to the solution in the negative quadrant.
+
+      The first solver only pushes the solution through, the second solver solves the equations.
+
+      The first outValues set would be handled as primary data and the second outValues set as secondary data in the acceleration methods. So only when the boolean `includeSecondaryData` is true, the second data set is involved.
+      In the QN tests, both the options with and without secondary data are tested.
     */
 
     if (context.isNamed("SolverOne")) {
       for (int i = 0; i < 4; i++) {
         outValues1[i] = inValues1[i]; //only pushes solution through
-        outValues2[i] = inValues2[i];
+        if (includeSecondaryData) {
+          outValues2[i] = inValues2[i];
+        }
       }
     } else {
       outValues1[0] = 2 * inValues1[0] * inValues1[0] - inValues1[1] * inValues1[2] - 8.0 + inValues1[0];
       outValues1[1] = inValues1[0] * inValues1[0] * inValues1[1] + 2.0 * inValues1[0] * inValues1[1] * inValues1[2] + inValues1[1] * inValues1[2] * inValues1[2] + inValues1[1];
       outValues1[2] = inValues1[2] * inValues1[2] - 4.0 + inValues1[2];
       outValues1[3] = inValues1[3] * inValues1[3] - 4.0 + inValues1[3];
-      outValues2[0] = 2 * inValues2[0] * inValues2[0] - inValues2[1] * inValues2[2] - 8.0 + inValues2[0];
-      outValues2[1] = inValues2[0] * inValues2[0] * inValues2[1] + 2.0 * inValues2[0] * inValues2[1] * inValues2[2] + inValues2[1] * inValues2[2] * inValues2[2] + inValues2[1];
-      outValues2[2] = inValues2[2] * inValues2[2] - 4.0 + inValues2[2];
-      outValues2[3] = inValues2[3] * inValues2[3] - 4.0 + inValues2[3];
+      if (includeSecondaryData) {
+        outValues2[0] = 2 * inValues2[0] * inValues2[0] - inValues2[1] * inValues2[2] - 8.0 + inValues2[0];
+        outValues2[1] = inValues2[0] * inValues2[0] * inValues2[1] + 2.0 * inValues2[0] * inValues2[1] * inValues2[2] + inValues2[1] * inValues2[2] * inValues2[2] + inValues2[1];
+        outValues2[2] = inValues2[2] * inValues2[2] - 4.0 + inValues2[2];
+        outValues2[3] = inValues2[3] * inValues2[3] - 4.0 + inValues2[3];
+      }
     }
 
     interface.writeData(meshName, writeDataName1, vertexIDs, outValues1);
-    interface.writeData(meshName, writeDataName2, vertexIDs, outValues2);
+    if (includeSecondaryData) {
+      interface.writeData(meshName, writeDataName2, vertexIDs, outValues2);
+    }
     interface.advance(1.0);
 
     if (interface.requiresReadingCheckpoint()) {
@@ -107,10 +120,12 @@ void runTestQN(std::string const &config, TestContext const &context)
   BOOST_TEST(outValues1[1] == 0.0, boost::test_tools::tolerance(1e-5));
   BOOST_TEST(outValues1[2] == -2.0, boost::test_tools::tolerance(1e-5));
   BOOST_TEST(outValues1[3] == -2.0, boost::test_tools::tolerance(1e-5));
-  BOOST_TEST(outValues2[0] == -2.0, boost::test_tools::tolerance(1e-5));
-  BOOST_TEST(outValues2[1] == 0.0, boost::test_tools::tolerance(1e-5));
-  BOOST_TEST(outValues2[2] == -2.0, boost::test_tools::tolerance(1e-5));
-  BOOST_TEST(outValues2[3] == -2.0, boost::test_tools::tolerance(1e-5));
+  if (includeSecondaryData) {
+    BOOST_TEST(outValues2[0] == -2.0, boost::test_tools::tolerance(1e-5));
+    BOOST_TEST(outValues2[1] == 0.0, boost::test_tools::tolerance(1e-5));
+    BOOST_TEST(outValues2[2] == -2.0, boost::test_tools::tolerance(1e-5));
+    BOOST_TEST(outValues2[3] == -2.0, boost::test_tools::tolerance(1e-5));
+  }
 
   // to exclude false or no convergence
   BOOST_TEST(iterations <= 20);

--- a/tests/quasi-newton/helpers.hpp
+++ b/tests/quasi-newton/helpers.hpp
@@ -7,7 +7,7 @@
 using namespace precice;
 using precice::testing::TestContext;
 
-void runTestQN(std::string const &config, TestContext const &context);
+void runTestQN(bool includeSecondaryData, std::string const &config, TestContext const &context);
 
 void runTestQNEmptyPartition(std::string const &config, TestContext const &context);
 

--- a/tests/quasi-newton/parallel/TestQN1.cpp
+++ b/tests/quasi-newton/parallel/TestQN1.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN1)
+BOOST_DATA_TEST_CASE(TestQN1, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-ILS, strict QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,12 +52,15 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-1" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN1.xml
+++ b/tests/quasi-newton/parallel/TestQN1.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN10.cpp
+++ b/tests/quasi-newton/parallel/TestQN10.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN10)
+BOOST_DATA_TEST_CASE(TestQN10, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-IMVJ acceleration, to test zero update for V matrix;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN10.xml
+++ b/tests/quasi-newton/parallel/TestQN10.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="2" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN10.xml
+++ b/tests/quasi-newton/parallel/TestQN10.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,23 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="2" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
-    <max-iterations value="20" />
-    <min-iterations value="4" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-4" />
       <initial-relaxation value="0.2" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN10.xml
+++ b/tests/quasi-newton/parallel/TestQN10.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="2" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN2.cpp
+++ b/tests/quasi-newton/parallel/TestQN2.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN2)
+BOOST_DATA_TEST_CASE(TestQN2, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // parallel coupling, IQN-ILS, strict QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,14 +52,17 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data1" mesh="MeshOne" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data11" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data11" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data1" mesh="MeshOne" />
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data11" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-1" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN2.xml
+++ b/tests/quasi-newton/parallel/TestQN2.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN3.cpp
+++ b/tests/quasi-newton/parallel/TestQN3.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN3)
+BOOST_DATA_TEST_CASE(TestQN3, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-IMVJ (which is identical to IQN-ILS as only first timestep is considered), relaxed QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,12 +52,15 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN3.xml
+++ b/tests/quasi-newton/parallel/TestQN3.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN4.cpp
+++ b/tests/quasi-newton/parallel/TestQN4.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN4)
+BOOST_DATA_TEST_CASE(TestQN4, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // multi coupling, IQN-ILS, strict QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN4.xml
+++ b/tests/quasi-newton/parallel/TestQN4.xml
@@ -53,8 +53,8 @@
     <participant name="SolverTwo" control="yes" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN4.xml
+++ b/tests/quasi-newton/parallel/TestQN4.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -43,14 +53,16 @@
     <participant name="SolverTwo" control="yes" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data1" mesh="MeshOne" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data11" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data1" mesh="MeshOne" />
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data11" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-1" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN5.cpp
+++ b/tests/quasi-newton/parallel/TestQN5.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN5)
+BOOST_DATA_TEST_CASE(TestQN5, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-IMVJ acceleration, to test `RS-LS` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN5.xml
+++ b/tests/quasi-newton/parallel/TestQN5.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN5.xml
+++ b/tests/quasi-newton/parallel/TestQN5.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,22 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN5.xml
+++ b/tests/quasi-newton/parallel/TestQN5.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN6.cpp
+++ b/tests/quasi-newton/parallel/TestQN6.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN6)
+BOOST_DATA_TEST_CASE(TestQN6, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-IMVJ acceleration, to test `RS-0` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN6.xml
+++ b/tests/quasi-newton/parallel/TestQN6.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN6.xml
+++ b/tests/quasi-newton/parallel/TestQN6.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,22 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN6.xml
+++ b/tests/quasi-newton/parallel/TestQN6.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN7.cpp
+++ b/tests/quasi-newton/parallel/TestQN7.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN7)
+BOOST_DATA_TEST_CASE(TestQN7, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-IMVJ acceleration, to test `no-restart` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN7.xml
+++ b/tests/quasi-newton/parallel/TestQN7.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN7.xml
+++ b/tests/quasi-newton/parallel/TestQN7.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,22 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN7.xml
+++ b/tests/quasi-newton/parallel/TestQN7.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/parallel/TestQN8.cpp
+++ b/tests/quasi-newton/parallel/TestQN8.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN8)
+BOOST_DATA_TEST_CASE(TestQN8, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-IMVJ acceleration, to test the feature `always-build-jacobian`;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN8.xml
+++ b/tests/quasi-newton/parallel/TestQN8.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,12 +52,15 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ always-build-jacobian="1">
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/parallel/TestQN8.xml
+++ b/tests/quasi-newton/parallel/TestQN8.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN9.cpp
+++ b/tests/quasi-newton/parallel/TestQN9.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Parallel)
-BOOST_AUTO_TEST_CASE(TestQN9)
+BOOST_DATA_TEST_CASE(TestQN9, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks));
   // serial coupling, IQN-IMVJ acceleration, to test `RS-SVD` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/parallel/TestQN9.xml
+++ b/tests/quasi-newton/parallel/TestQN9.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
@@ -66,7 +66,7 @@
       <max-used-iterations value="10" />
       <time-windows-reused value="0" />
       <imvj-restart-mode
-        truncation-threshold="0.001"
+        truncation-threshold="0.0001"
         chunk-size="2"
         reused-time-windows-at-restart="2"
         type="RS-SVD" />

--- a/tests/quasi-newton/parallel/TestQN9.xml
+++ b/tests/quasi-newton/parallel/TestQN9.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/parallel/TestQN9.xml
+++ b/tests/quasi-newton/parallel/TestQN9.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,28 +40,33 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />
       <time-windows-reused value="0" />
       <imvj-restart-mode
-        truncation-threshold="0.0001"
+        truncation-threshold="0.001"
         chunk-size="2"
         reused-time-windows-at-restart="2"
         type="RS-SVD" />

--- a/tests/quasi-newton/serial/DefaultConfig.cpp
+++ b/tests/quasi-newton/serial/DefaultConfig.cpp
@@ -2,16 +2,17 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(DefaultConfig)
+BOOST_DATA_TEST_CASE(DefaultConfig, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/DefaultConfig.xml
+++ b/tests/quasi-newton/serial/DefaultConfig.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,12 +52,15 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
     </acceleration:IQN-ILS>
   </coupling-scheme:serial-implicit>
 </precice-configuration>

--- a/tests/quasi-newton/serial/DefaultConfig.xml
+++ b/tests/quasi-newton/serial/DefaultConfig.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN1.cpp
+++ b/tests/quasi-newton/serial/TestQN1.cpp
@@ -2,19 +2,19 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN1)
+BOOST_DATA_TEST_CASE(TestQN1, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-ILS, strict QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
-
 BOOST_AUTO_TEST_SUITE_END() // Integration
 BOOST_AUTO_TEST_SUITE_END() // QuasiNewton
 BOOST_AUTO_TEST_SUITE_END() // Serial

--- a/tests/quasi-newton/serial/TestQN1.xml
+++ b/tests/quasi-newton/serial/TestQN1.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,12 +52,15 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-1" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN1.xml
+++ b/tests/quasi-newton/serial/TestQN1.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN10.cpp
+++ b/tests/quasi-newton/serial/TestQN10.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN10)
+BOOST_DATA_TEST_CASE(TestQN10, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-IMVJ acceleration, to test the warning information to be given for zero update in QN-method
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN10.xml
+++ b/tests/quasi-newton/serial/TestQN10.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="2" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN10.xml
+++ b/tests/quasi-newton/serial/TestQN10.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,23 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="2" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
-    <max-iterations value="20" />
-    <min-iterations value="4" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-4" />
       <initial-relaxation value="0.2" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN10.xml
+++ b/tests/quasi-newton/serial/TestQN10.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="2" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN2.cpp
+++ b/tests/quasi-newton/serial/TestQN2.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN2)
+BOOST_DATA_TEST_CASE(TestQN2, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // parallel coupling, IQN-ILS, strict QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN2.xml
+++ b/tests/quasi-newton/serial/TestQN2.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,14 +52,17 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data1" mesh="MeshOne" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data11" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data1" mesh="MeshOne" />
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data11" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-1" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN2.xml
+++ b/tests/quasi-newton/serial/TestQN2.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN3.cpp
+++ b/tests/quasi-newton/serial/TestQN3.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN3)
+BOOST_DATA_TEST_CASE(TestQN3, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-IMVJ (which is identical to IQN-ILS as only first timestep is considered), relaxed QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN3.xml
+++ b/tests/quasi-newton/serial/TestQN3.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,12 +52,15 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN3.xml
+++ b/tests/quasi-newton/serial/TestQN3.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN4.cpp
+++ b/tests/quasi-newton/serial/TestQN4.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN4)
+BOOST_DATA_TEST_CASE(TestQN4, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // multi coupling, IQN-ILS, strict QR2 filter
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN4.xml
+++ b/tests/quasi-newton/serial/TestQN4.xml
@@ -53,8 +53,8 @@
     <participant name="SolverTwo" control="yes" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN4.xml
+++ b/tests/quasi-newton/serial/TestQN4.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -43,14 +53,16 @@
     <participant name="SolverTwo" control="yes" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data1" mesh="MeshOne" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data11" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data1" mesh="MeshOne" />
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data11" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-1" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN5.cpp
+++ b/tests/quasi-newton/serial/TestQN5.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN5)
+BOOST_DATA_TEST_CASE(TestQN5, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-IMVJ acceleration, to test `RS-LS` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN5.xml
+++ b/tests/quasi-newton/serial/TestQN5.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN5.xml
+++ b/tests/quasi-newton/serial/TestQN5.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,22 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN5.xml
+++ b/tests/quasi-newton/serial/TestQN5.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN6.cpp
+++ b/tests/quasi-newton/serial/TestQN6.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN6)
+BOOST_DATA_TEST_CASE(TestQN6, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-IMVJ acceleration, to test `RS-0` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN6.xml
+++ b/tests/quasi-newton/serial/TestQN6.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN6.xml
+++ b/tests/quasi-newton/serial/TestQN6.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,22 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN6.xml
+++ b/tests/quasi-newton/serial/TestQN6.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN7.cpp
+++ b/tests/quasi-newton/serial/TestQN7.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN7)
+BOOST_DATA_TEST_CASE(TestQN7, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-IMVJ acceleration, to test `no-restart` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN7.xml
+++ b/tests/quasi-newton/serial/TestQN7.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN7.xml
+++ b/tests/quasi-newton/serial/TestQN7.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,22 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN7.xml
+++ b/tests/quasi-newton/serial/TestQN7.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />

--- a/tests/quasi-newton/serial/TestQN8.cpp
+++ b/tests/quasi-newton/serial/TestQN8.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN8)
+BOOST_DATA_TEST_CASE(TestQN8, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-IMVJ (which is identical to IQN-ILS as only first timestep is considered), to test `always-build-jacobian` option;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN8.xml
+++ b/tests/quasi-newton/serial/TestQN8.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,8 +40,10 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -42,12 +52,15 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ always-build-jacobian="1">
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN8.xml
+++ b/tests/quasi-newton/serial/TestQN8.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN9.cpp
+++ b/tests/quasi-newton/serial/TestQN9.cpp
@@ -2,17 +2,18 @@
 
 #include "testing/Testing.hpp"
 
+#include <boost/test/data/test_case.hpp>
 #include <precice/precice.hpp>
 #include "../helpers.hpp"
 
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(QuasiNewton)
 BOOST_AUTO_TEST_SUITE(Serial)
-BOOST_AUTO_TEST_CASE(TestQN9)
+BOOST_DATA_TEST_CASE(TestQN9, boost::unit_test::data::make({true, false}), includeSecondaryData)
 {
   PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
   // serial coupling, IQN-IMVJ acceleration, to test `RS-SVD` method for restart;
-  runTestQN(context.config(), context);
+  runTestQN(includeSecondaryData, context.config(), context);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Integration

--- a/tests/quasi-newton/serial/TestQN9.xml
+++ b/tests/quasi-newton/serial/TestQN9.xml
@@ -52,8 +52,8 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="5" />
     <time-window-size value="1.0" />
-    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" substeps="false" />
     <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />

--- a/tests/quasi-newton/serial/TestQN9.xml
+++ b/tests/quasi-newton/serial/TestQN9.xml
@@ -1,22 +1,30 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="Data11" />
+  <data:scalar name="Data12" />
+  <data:scalar name="Data21" />
+  <data:scalar name="Data22" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="Data11" />
+    <use-data name="Data12" />
+    <use-data name="Data21" />
+    <use-data name="Data22" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="Data11" mesh="MeshOne" />
+    <write-data name="Data12" mesh="MeshOne" />
+    <read-data name="Data21" mesh="MeshOne" />
+    <read-data name="Data22" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
@@ -32,22 +40,27 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="Data21" mesh="MeshTwo" />
+    <write-data name="Data22" mesh="MeshTwo" />
+    <read-data name="Data11" mesh="MeshTwo" />
+    <read-data name="Data12" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="5" />
+    <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data21" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
+    <exchange data="Data22" mesh="MeshOne" from="SolverTwo" to="SolverOne" substeps="false" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data21" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="Data22" mesh="MeshOne" />
     <acceleration:IQN-IMVJ>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="Data21" mesh="MeshOne" />
       <filter type="QR2" limit="1e-3" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/tests/quasi-newton/serial/TestQN9.xml
+++ b/tests/quasi-newton/serial/TestQN9.xml
@@ -50,7 +50,7 @@
 
   <coupling-scheme:serial-implicit>
     <participants first="SolverOne" second="SolverTwo" />
-    <max-time-windows value="1" />
+    <max-time-windows value="5" />
     <time-window-size value="1.0" />
     <exchange data="Data11" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
     <exchange data="Data12" mesh="MeshOne" from="SolverOne" to="SolverTwo" />


### PR DESCRIPTION
## Main changes of this PR
One data set is added to the integrated QN tests and it is supposed to be accelerated as secondary data. 

Among the Quasi-Newton integration tests, those with `ILS` acceleration could pass and those with `IMVJ` acceleration would fail since there is no proper acceleration to the secondary data.

## Motivation and additional information
To increase test coverage of secondary data in QN methods as mentioned in issue #1996.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

