### PR TITLE
Add simple version check

### DIFF
--- a/docs/changelog/2007.md
+++ b/docs/changelog/2007.md
@@ -1,0 +1,1 @@
+- Added a clearer error message when attempting to use a pre-version 3 configuration file.

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -215,7 +215,7 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
   for (auto &subtag : SubTags) {
     std::string expectedName = (subtag->m_Prefix.length() ? subtag->m_Prefix + ":" : "") + subtag->m_Name;
     PRECICE_CHECK(expectedName != "solver-interface",
-                  "This configuration contains the tag <solver-interface>, meaning it was written for a preCICE version 1 or 2. "
+                  "This configuration contains the tag <solver-interface>, meaning it was created for a preCICE version prior to version 3. "
                   "Please check that you are using the correct case or preCICE version.");
     const auto tagPosition = std::find_if(
         DefTags.begin(),

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -216,7 +216,7 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
     std::string expectedName = (subtag->m_Prefix.length() ? subtag->m_Prefix + ":" : "") + subtag->m_Name;
     PRECICE_CHECK(expectedName != "solver-interface",
                   "This configuration contains the tag <solver-interface>, meaning it was created for a preCICE version prior to version 3. "
-                  "Please check that you are using the correct case or preCICE version.");
+                  "Are you using the correct version of your simulation case? Has this simulation case been updated to this version of preCICE?");
     const auto tagPosition = std::find_if(
         DefTags.begin(),
         DefTags.end(),

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -214,7 +214,10 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 
   for (auto &subtag : SubTags) {
     std::string expectedName = (subtag->m_Prefix.length() ? subtag->m_Prefix + ":" : "") + subtag->m_Name;
-    const auto  tagPosition  = std::find_if(
+    PRECICE_CHECK(expectedName != "solver-interface",
+                  "This configuration contains the tag <solver-interface>, meaning it was written for a preCICE version 1 or 2. "
+                  "Please check that you are using the correct case or preCICE version.");
+    const auto tagPosition = std::find_if(
         DefTags.begin(),
         DefTags.end(),
         [expectedName](const std::shared_ptr<XMLTag> &pTag) {


### PR DESCRIPTION
## Main changes of this PR

This PR adds a simple version check to detect configurations for preCICE v1 and v2.
The parser fails with the following message if it encounters a tag called `<solver-interface`:

```console
$ precice-tools check v2/solverdummy.xml
Checking v2/solverdummy.xml for syntax and basic setup issues...
precice-tools: ERROR: This configuration contains the tag <solver-interface>, meaning it was written for a preCICE version 1 or 2. Please check that you are using the correct case or preCICE version.
```

## Motivation and additional information

v1 and v2 configurations fail in the ConfigParser as it encounters an unknown tag `solver-interface`.
This is a very obscure error though and doesn't highlight the actual problem that the config is for an older verison.

This change is a naive implementation that should be useful enough.

Related to #2004

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.
