### PR TITLE
Fix polars warning in profiling script

### DIFF
--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -79,7 +79,11 @@ def printWide(df):
         return len("{:}".format(s))
 
     headerWidths = tuple(map(formattedLength, df.columns))
-    bodyWidths = tuple(df.select(pl.all().map_elements(formattedLength)).max().row(0))
+    bodyWidths = tuple(
+        df.select(pl.all().map_elements(formattedLength, return_dtype=pl.Int64))
+        .max()
+        .row(0)
+    )
     assert len(headerWidths) == len(bodyWidths)
     colwidths = map(max, zip(headerWidths, bodyWidths, repeat(mincolwidth)))
 


### PR DESCRIPTION
...using polars 0.20.21 runs into

```
MapWithoutReturnDtypeWarning: Calling `map_elements` without specifying `return_dtype` can lead to unpredictable results. Specify `return_dtype` to silence this warning.
```

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
