### PR TITLE
Extend SVD to cover input multiplicators with different sizes

### DIFF
--- a/src/acceleration/IQNIMVJAcceleration.cpp
+++ b/src/acceleration/IQNIMVJAcceleration.cpp
@@ -80,11 +80,6 @@ void IQNIMVJAcceleration::initialize(
   if (_imvjRestartType > 0)
     _imvjRestart = true;
 
-  // initialize parallel matrix-matrix operation module
-  _parMatrixOps = std::make_shared<impl::ParallelMatrixOperations>();
-  _parMatrixOps->initialize(not _imvjRestart);
-  _svdJ.initialize(_parMatrixOps, getLSSystemRows());
-
   int entries  = _residuals.size();
   int global_n = 0;
 
@@ -93,6 +88,11 @@ void IQNIMVJAcceleration::initialize(
   } else {
     global_n = _dimOffsets.back();
   }
+
+  // initialize parallel matrix-matrix operation module
+  _parMatrixOps = std::make_shared<impl::ParallelMatrixOperations>();
+  _parMatrixOps->initialize(not _imvjRestart);
+  _svdJ.initialize(_parMatrixOps, global_n, getLSSystemRows());
 
   if (not _imvjRestart) {
     // only need memory for Jacobain if not in restart mode

--- a/src/acceleration/impl/SVDFactorization.cpp
+++ b/src/acceleration/impl/SVDFactorization.cpp
@@ -19,10 +19,12 @@ SVDFactorization::SVDFactorization(
 
 void SVDFactorization::initialize(
     PtrParMatrixOps parOps,
-    int             globalRows)
+    int             globalRowsA,
+    int             globalRowsB)
 {
   _parMatrixOps = std::move(parOps);
-  _globalRows   = globalRows;
+  _globalRowsA  = globalRowsA;
+  _globalRowsB  = globalRowsB;
   _initialized  = true;
 }
 
@@ -73,6 +75,7 @@ void SVDFactorization::reset()
 
 void SVDFactorization::computeQRdecomposition(
     Matrix const &A,
+    int           globalRows,
     Matrix &      Q,
     Matrix &      R)
 {
@@ -100,7 +103,7 @@ void SVDFactorization::computeQRdecomposition(
     Vector col = A.col(colIndex);
 
     // if system is quadratic; discard
-    if (_globalRows == colIndex) {
+    if (globalRows == colIndex) {
       PRECICE_WARN("The matrix that is about to be factorized is quadratic, i.e., the new column cannot be orthogonalized; discard.");
       return;
     }
@@ -288,9 +291,14 @@ int SVDFactorization::cols()
   return _cols;
 }
 
-int SVDFactorization::rows()
+int SVDFactorization::rowsA()
 {
-  return _rows;
+  return _rowsA;
+}
+
+int SVDFactorization::rowsB()
+{
+  return _rowsB;
 }
 
 Rank SVDFactorization::rank()

--- a/src/acceleration/impl/SVDFactorization.cpp
+++ b/src/acceleration/impl/SVDFactorization.cpp
@@ -291,16 +291,6 @@ int SVDFactorization::cols()
   return _cols;
 }
 
-int SVDFactorization::rowsA()
-{
-  return _rowsA;
-}
-
-int SVDFactorization::rowsB()
-{
-  return _rowsB;
-}
-
 Rank SVDFactorization::rank()
 {
   return _cols;

--- a/src/acceleration/impl/SVDFactorization.hpp
+++ b/src/acceleration/impl/SVDFactorization.hpp
@@ -64,15 +64,15 @@ public:
      *
      */
     if (_initialSVD) {
-      PRECICE_ASSERT(A.rows() == _rows, A.rows(), _rows);
-      PRECICE_ASSERT(B.rows() == _rows, B.rows(), _rows);
+      PRECICE_ASSERT(A.rows() == _rowsA, A.rows(), _rowsA);
+      PRECICE_ASSERT(B.rows() == _rowsB, B.rows(), _rowsB);
     } else {
-      PRECICE_ASSERT(A.rows() == B.rows(), A.rows(), B.rows());
       PRECICE_ASSERT(A.cols() == B.cols(), A.cols(), B.cols());
-      _rows  = A.rows();
+      _rowsA = A.rows();
+      _rowsB = B.rows();
       _cols  = 0;
-      _psi   = Matrix::Zero(_rows, 0);
-      _phi   = Matrix::Zero(_rows, 0);
+      _psi   = Matrix::Zero(_rowsA, 0);
+      _phi   = Matrix::Zero(_rowsB, 0);
       _sigma = Vector::Zero(0);
     }
 
@@ -82,7 +82,7 @@ public:
 
     // Atil := \psi^T *A
     // local computation of \psi^T * A and allreduce_sum to Atil (global), stored local on each proc
-    _parMatrixOps->multiply(_psi.transpose(), A, Atil, (int) _psi.cols(), _globalRows, (int) A.cols());
+    _parMatrixOps->multiply(_psi.transpose(), A, Atil, (int) _psi.cols(), _globalRowsA, (int) A.cols());
 
     // Ptil := (I-\psi\psi^T)A
     // Atil is local on each proc, thus fully local computation, embarrassingly parallel
@@ -90,19 +90,19 @@ public:
 
     // compute orthogonal basis P of Ptil, i.e., QR-dec (P, R_A) = QR(Ptil)
     Matrix P, R_A;
-    computeQRdecomposition(Ptil, P, R_A);
+    computeQRdecomposition(Ptil, _globalRowsA, P, R_A);
 
     /**  (2): compute orthogonal basis Q of (I-\phi\phi^T)B
      */
     Matrix Btil(_phi.cols(), B.cols()); // Btil is of size (K_bar x m)
     // Btil := \phi^T *B
-    _parMatrixOps->multiply(_phi.transpose(), B, Btil, (int) _phi.cols(), _globalRows, (int) B.cols());
+    _parMatrixOps->multiply(_phi.transpose(), B, Btil, (int) _phi.cols(), _globalRowsB, (int) B.cols());
     // Qtil := (I-\phi\phi^T)B
     Matrix Qtil = B - _phi * Btil;
 
     // compute orthogonal basis Q of Qtil, i.e., QR-dec (Q, R_B) = QR(Qtil)
     Matrix Q, R_B;
-    computeQRdecomposition(Qtil, Q, R_B);
+    computeQRdecomposition(Qtil, _globalRowsB, Q, R_B);
 
     //     e_orthModes.stop(true);
 
@@ -136,13 +136,13 @@ public:
 
     /** (4) rotate left and right subspaces
      */
-    Matrix rotLeft(_rows, _psi.cols() + P.cols());
-    Matrix rotRight(_rows, _phi.cols() + Q.cols());
+    Matrix rotLeft(_rowsA, _psi.cols() + P.cols());
+    Matrix rotRight(_rowsB, _phi.cols() + Q.cols());
 
-    rotLeft.block(0, 0, _rows, _psi.cols())         = _psi;
-    rotLeft.block(0, _psi.cols(), _rows, P.cols())  = P;
-    rotRight.block(0, 0, _rows, _phi.cols())        = _phi;
-    rotRight.block(0, _phi.cols(), _rows, Q.cols()) = Q;
+    rotLeft.block(0, 0, _rowsA, _psi.cols())         = _psi;
+    rotLeft.block(0, _psi.cols(), _rowsA, P.cols())  = P;
+    rotRight.block(0, 0, _rowsB, _phi.cols())        = _phi;
+    rotRight.block(0, _phi.cols(), _rowsB, Q.cols()) = Q;
 
     // [\psi,P] is distributed block-row wise, but \psiPrime is local on each proc, hence local mult.
     _psi = rotLeft * psiPrime;
@@ -164,8 +164,8 @@ public:
     }
     _waste += waste;
 
-    _psi.conservativeResize(_rows, _cols);
-    _phi.conservativeResize(_rows, _cols);
+    _psi.conservativeResize(_rowsA, _cols);
+    _phi.conservativeResize(_rowsB, _cols);
     _sigma.conservativeResize(_cols);
     PRECICE_ASSERT(_sigma(0) >= 0.0);
     PRECICE_DEBUG("SVD factorization of Jacobian is truncated to {} DOFs. Cut off {} DOFs", _cols, waste);
@@ -177,7 +177,7 @@ public:
    * @brief: initializes the updated SVD factorization, i.e., sets the object for
    * parallel matrix-matrix operations and the number of global rows.
    */
-  void initialize(PtrParMatrixOps parMatOps, int globalRows);
+  void initialize(PtrParMatrixOps parMatOps, int globalRowsA, int globalRowsB);
 
   /**
    * @brief: resets the SVD factorization
@@ -202,8 +202,11 @@ public:
   /// @brief: returns the number of columns in the QR-decomposition
   int cols();
 
-  /// @brief: returns the number of rows in the QR-decomposition
-  int rows();
+  /// @brief: returns the number of rows in the QR-decomposition relating to the first multiplicator A
+  int rowsA();
+
+  /// @brief: returns the number of rows in the QR-decomposition relating to the second multiplicator B
+  int rowsB();
 
   /// @brief: returns the rank of the truncated SVD factorization
   Rank rank();
@@ -248,7 +251,7 @@ private:
    *  The threshold parameter eps, indicates whether a column is seen to be in the column space
    *  of Q via the criterium ||v_orth|| / ||v|| <= eps (cmp. QR2 Filter)
    */
-  void computeQRdecomposition(Matrix const &A, Matrix &Q, Matrix &R);
+  void computeQRdecomposition(Matrix const &A, int globalRows, Matrix &Q, Matrix &R);
 
   logging::Logger _log{"acceleration::SVDFactorization"};
 
@@ -263,14 +266,20 @@ private:
   Matrix _phi;
   Vector _sigma;
 
-  /// Number of rows (on each proc, i.e., local)
-  int _rows = 0;
+  /// Number of rows of first multiplicator (on each proc, i.e., local)
+  int _rowsA = 0;
+
+  /// Number of rows of second multiplicator (on each proc, i.e., local)
+  int _rowsB = 0;
 
   /// Number of columns, i.e., rank of the truncated svd
   int _cols = 0;
 
-  /// Number of global rows, i.e., sum of _rows for all procs
-  int _globalRows = 0;
+  /// Number of global rows of first multiplicator, i.e., sum of _rows for all procs
+  int _globalRowsA = 0;
+
+  /// Number of global rows of second multiplicator, i.e., sum of _rows for all procs
+  int _globalRowsB = 0;
 
   // Total number of truncated modes after last call to method getWaste()
   int _waste = 0;

--- a/src/acceleration/impl/SVDFactorization.hpp
+++ b/src/acceleration/impl/SVDFactorization.hpp
@@ -202,12 +202,6 @@ public:
   /// @brief: returns the number of columns in the QR-decomposition
   int cols();
 
-  /// @brief: returns the number of rows in the QR-decomposition relating to the first multiplicator A
-  int rowsA();
-
-  /// @brief: returns the number of rows in the QR-decomposition relating to the second multiplicator B
-  int rowsB();
-
   /// @brief: returns the rank of the truncated SVD factorization
   Rank rank();
 

--- a/src/acceleration/test/SVDFactorizationTest.cpp
+++ b/src/acceleration/test/SVDFactorizationTest.cpp
@@ -19,15 +19,27 @@ using namespace precice::acceleration::impl;
 BOOST_AUTO_TEST_CASE(testSVDFactorization)
 {
   PRECICE_TEST(1_rank);
-  int                      m                   = 8;
+  int                      m                   = 2; // size of a*
+  int                      n                   = 3; // size of b*
   double                   eps                 = 1.2e-3;
   const bool               cyclicCommunication = false;
   std::vector<double>      factors(1.0, 1.0);
-  Eigen::VectorXd          a(m);
-  Eigen::VectorXd          b(m);
+  Eigen::VectorXd          a1(2);
+  Eigen::VectorXd          a2(2);
+  Eigen::VectorXd          a3(2);
+  Eigen::VectorXd          b1(3);
+  Eigen::VectorXd          b2(3);
+  Eigen::VectorXd          b3(3);
   SVDFactorization::Vector singleValues = SVDFactorization::Vector::Zero(2);
-  singleValues(0)                       = 0.000578589774323541;
-  singleValues(1)                       = 8.13011257500996e-05;
+
+  a1 << 1., -1.;
+  a2 << 1., -1.;
+  a3 << 1., 0.;
+  b1 << 2., 4., 4.;
+  b2 << 2., 4., 4.;
+  b3 << -2., -10., -7.;
+  singleValues(0) = 12.;
+  singleValues(1) = 3.;
 
   // prepare preConditioner to be used to construct a SVD factorization class
   auto prec(std::make_shared<impl::ConstantPreconditioner>(factors));
@@ -40,15 +52,12 @@ BOOST_AUTO_TEST_CASE(testSVDFactorization)
   // construct a SVD factorization object
   SVDFactorization svd_1(eps, prec);
 
-  svd_1.initialize(ptrParMatrixOp, m);
-  // update 4 times
-  for (int i = 0; i < 4; i++) {
-    for (int j = 0; j < m; j++) {
-      a(j) = j * 0.001 - i * 0.001;
-      b(j) = j * 0.001 - i * 0.007;
-    }
-    svd_1.update(a, b);
-  }
+  svd_1.initialize(ptrParMatrixOp, m, n);
+
+  svd_1.update(a1, b1);
+  svd_1.update(a2, b2);
+  svd_1.update(a3, b3);
+
   // check if the over small single values have been correctly truncated
   BOOST_TEST(svd_1.rank() == 2);
   BOOST_TEST(testing::equals(svd_1.singularValues(), singleValues, 1e-10));


### PR DESCRIPTION
## Main changes of this PR
The SVD factorization could deal with two input vectors with different sizes. Tests are modified to test it.

## Motivation and additional information
It serves the #2010.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.16.3.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
