### PR TITLE
Remove old version workarounds

### DIFF
--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -306,28 +306,7 @@ Eigen::VectorXd RadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::solveConservative
     PRECICE_ASSERT(epsilon.size() == _matrixQ.cols());
 
     // out  = out - solveTranspose tau (sigma in the PETSc impl)
-    // Newer version of eigen provide the solve() for transpose() matrix decopmositions
-#if EIGEN_VERSION_AT_LEAST(3, 4, 0)
     out -= static_cast<Eigen::VectorXd>(_qrMatrixQ.transpose().solve(-epsilon));
-#else
-    // Backwards compatible version
-    Eigen::VectorXd    sigma(_matrixQ.rows());
-    const Eigen::Index nonzero_pivots = _qrMatrixQ.nonzeroPivots();
-
-    if (nonzero_pivots == 0) {
-      sigma.setZero();
-    } else {
-      Eigen::VectorXd c(_qrMatrixQ.colsPermutation().transpose() * (-epsilon));
-
-      _qrMatrixQ.matrixQR().topLeftCorner(nonzero_pivots, nonzero_pivots).template triangularView<Eigen::Upper>().transpose().conjugate().solveInPlace(c.topRows(nonzero_pivots));
-
-      sigma.topRows(nonzero_pivots) = c.topRows(nonzero_pivots);
-      sigma.bottomRows(_qrMatrixQ.rows() - nonzero_pivots).setZero();
-
-      sigma.applyOnTheLeft(_qrMatrixQ.householderQ().setLength(nonzero_pivots));
-      out -= sigma;
-    }
-#endif
   }
   return out;
 }

--- a/src/math/Bspline.cpp
+++ b/src/math/Bspline.cpp
@@ -15,11 +15,7 @@ Bspline::Bspline(Eigen::VectorXd ts, const Eigen::MatrixXd &xs, int splineDegree
 {
 
   PRECICE_ASSERT(ts.size() >= 2, "Interpolation requires at least 2 samples");
-#if EIGEN_VERSION_AT_LEAST(3, 4, 0)
   PRECICE_ASSERT(std::is_sorted(ts.begin(), ts.end()), "Timestamps must be sorted");
-#else
-  PRECICE_ASSERT(std::is_sorted(ts.data(), ts.data() + ts.size()), "Timestamps must be sorted");
-#endif
 
   // organize data in columns. Each column represents one sample in time.
   PRECICE_ASSERT(xs.cols() == ts.size());

--- a/src/testing/GlobalFixtures.cpp
+++ b/src/testing/GlobalFixtures.cpp
@@ -34,8 +34,8 @@ type = enum boost::unit_test::log_level : int {
 boost::unit_test::log_level getBoostTestLogLevel()
 {
   namespace bu = boost::unit_test;
-#if BOOST_VERSION == 106900 || __APPLE__ && __MACH__
-  std::cerr << "Boost 1.69 and macOS get log_level is broken, preCICE log level set to debug.\n";
+#if __APPLE__ && __MACH__
+  std::cerr << "macOS get log_level is broken, preCICE log level set to debug.\n";
   return bu::log_successful_tests;
 #else
   return bu::runtime_config::get<bu::log_level>(bu::runtime_config::btrt_log_level);

--- a/src/utils/Petsc.cpp
+++ b/src/utils/Petsc.cpp
@@ -27,46 +27,6 @@
 
 namespace precice::utils {
 
-#ifndef PRECICE_NO_PETSC
-
-namespace {
-
-using new_signature = PetscErrorCode(PetscOptions, const char[], const char[]);
-using old_signature = PetscErrorCode(const char[], const char[]);
-
-/**
- * @brief Fix for compatibility with PETSc < 3.7.
- *
- * This enables to call PetscOptionsSetValue with proper number of arguments.
- * This instantiates only the template, that specifies correct function signature, whilst
- * the other one is discarded ( https://en.cppreference.com/w/cpp/language/sfinae )
- */
-template <typename curr_signature = decltype(PetscOptionsSetValue)>
-PetscErrorCode PetscOptionsSetValueWrapper(const char name[], const char value[],
-                                           typename std::enable_if<std::is_same<curr_signature, new_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
-                                               PetscOptionsSetValue)
-{
-  return PetscOptionsSetValueImpl(nullptr, name, value);
-}
-
-/**
- * @brief Fix for compatibility with PETSc < 3.7.
- *
- * This enables to call PetscOptionsSetValue with proper number of arguments.
- * This instantiates only the template, that specifies correct function signature, whilst
- * the other one is discarded ( https://en.cppreference.com/w/cpp/language/sfinae )
- */
-template <typename curr_signature = decltype(PetscOptionsSetValue)>
-PetscErrorCode PetscOptionsSetValueWrapper(const char name[], const char value[],
-                                           typename std::enable_if<std::is_same<curr_signature, old_signature>::value, curr_signature>::type PetscOptionsSetValueImpl =
-                                               PetscOptionsSetValue)
-{
-  return PetscOptionsSetValueImpl(name, value);
-}
-
-} // namespace
-#endif
-
 precice::logging::Logger precice::utils::Petsc::_log("utils::Petsc");
 
 #ifndef PRECICE_NO_PETSC
@@ -104,7 +64,7 @@ void Petsc::finalize()
   PetscBool petscIsInitialized;
   PetscInitialized(&petscIsInitialized);
   if (petscIsInitialized) {
-    PetscOptionsSetValueWrapper("-options_left", "no");
+    PetscOptionsSetValue(nullptr, "-options_left", "no");
     PetscFinalize();
   }
 #endif // not PRECICE_NO_PETSC


### PR DESCRIPTION
## Main changes of this PR

This PR removes some version workarounds for PETSc < 3.7, Eigen < 3.4, and Boost < 1.69

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

