### PR TITLE
Use templated constant for range tags

### DIFF
--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -380,7 +380,7 @@ private:
 };
 
 /// Allows to use @ref Communication::AsVectorTag in a less verbose way.
-template<typename T>
+template <typename T>
 inline constexpr auto asVector = Communication::AsVectorTag<T>{};
 
 /** Establishes a circular communication for the given participant.

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -15,19 +15,6 @@
 namespace precice {
 namespace com {
 
-/** Tag used to specify which type of vector to return
- * @see Communication::receiveRange()
- */
-template <typename T>
-struct AsVectorTag {
-};
-
-/* TODO When moving to C++17 use inline variable:
- *
- * template<typename T>
- * inline constexpr auto asVector = Communication::AsVectorTag<T>{};
- */
-
 /**
  * @brief Interface for all interprocess communication classes.
  *
@@ -351,6 +338,14 @@ public:
   /// @name Range communication
   /// @{
 
+  /** Tag used to specify which type of vector to return
+   * Use @ref asVector instead
+   * @see Communication::receiveRange()
+   */
+  template <typename T>
+  struct AsVectorTag {
+  };
+
   /// Sends a range of doubles (size + content)
   void sendRange(precice::span<const double> itemsToSend, Rank rankReceiver);
 
@@ -383,6 +378,10 @@ protected:
 private:
   logging::Logger _log{"com::Communication"};
 };
+
+/// Allows to use @ref Communication::AsVectorTag in a less verbose way.
+template<typename T>
+inline constexpr auto asVector = Communication::AsVectorTag<T>{};
 
 /** Establishes a circular communication for the given participant.
  *

--- a/src/com/SerializedMesh.cpp
+++ b/src/com/SerializedMesh.cpp
@@ -59,12 +59,12 @@ void SerializedMesh::send(Communication &communication, int rankReceiver)
 SerializedMesh SerializedMesh::receive(Communication &communication, int rankSender)
 {
   SerializedMesh sm;
-  sm.sizes = communication.receiveRange(rankSender, AsVectorTag<int>{});
+  sm.sizes = communication.receiveRange(rankSender, asVector<int>);
   PRECICE_ASSERT(sm.sizes.size() == 5);
   auto nVertices = sm.sizes[1];
   if (nVertices > 0) {
-    sm.coords = communication.receiveRange(rankSender, AsVectorTag<double>{});
-    sm.ids    = communication.receiveRange(rankSender, AsVectorTag<int>{});
+    sm.coords = communication.receiveRange(rankSender, asVector<double>);
+    sm.ids    = communication.receiveRange(rankSender, asVector<int>);
   }
   sm.assertValid();
   return sm;

--- a/src/com/SerializedPartitioning.cpp
+++ b/src/com/SerializedPartitioning.cpp
@@ -101,7 +101,7 @@ void SerializedConnectionMap::send(Communication &communication, int rankReceive
 SerializedConnectionMap SerializedConnectionMap::receive(Communication &communication, int rankSender)
 {
   SerializedConnectionMap scm;
-  scm.content = communication.receiveRange(rankSender, AsVectorTag<int>{});
+  scm.content = communication.receiveRange(rankSender, asVector<int>);
   scm.assertValid();
   return scm;
 }
@@ -176,7 +176,7 @@ void SerializedBoundingBox::send(Communication &communication, int rankReceiver)
 SerializedBoundingBox SerializedBoundingBox::receive(Communication &communication, int rankSender)
 {
   SerializedBoundingBox sbb;
-  sbb.coords = communication.receiveRange(rankSender, AsVectorTag<double>{});
+  sbb.coords = communication.receiveRange(rankSender, asVector<double>);
   sbb.assertValid();
   return sbb;
 }
@@ -280,9 +280,9 @@ void SerializedBoundingBoxMap::send(Communication &communication, int rankReceiv
 SerializedBoundingBoxMap SerializedBoundingBoxMap::receive(Communication &communication, int rankSender)
 {
   SerializedBoundingBoxMap sbbm;
-  sbbm.info = communication.receiveRange(rankSender, AsVectorTag<int>{});
+  sbbm.info = communication.receiveRange(rankSender, asVector<int>);
   if (sbbm.info.size() > 1) {
-    sbbm.coords = communication.receiveRange(rankSender, AsVectorTag<double>{});
+    sbbm.coords = communication.receiveRange(rankSender, asVector<double>);
   }
   sbbm.assertValid();
   return sbbm;

--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -131,19 +131,19 @@ void TestSendAndReceiveEigen(TestContext const &context)
 template <typename T>
 void TestSendAndReceiveRanges(TestContext const &context)
 {
-  using precice::com::AsVectorTag;
   T com;
+  using precice::com::asVector;
 
   if (context.isNamed("A")) {
     com.acceptConnection("process0", "process1", "", 0);
     {
       std::vector<int> recv{1, 2, 3};
-      std::vector<int> msg = com.receiveRange(0, AsVectorTag<int>{});
+      std::vector<int> msg = com.receiveRange(0, asVector<int>);
       BOOST_TEST(msg == recv);
       com.sendRange(msg, 0);
     }
     {
-      std::vector<double> msg = com.receiveRange(0, AsVectorTag<double>{});
+      std::vector<double> msg = com.receiveRange(0, asVector<double>);
       BOOST_TEST(msg == std::vector<double>({1.1, 2.2, 3.3}));
       com.sendRange(msg, 0);
     }
@@ -153,13 +153,13 @@ void TestSendAndReceiveRanges(TestContext const &context)
     {
       std::vector<int> msg{1, 2, 3};
       com.sendRange(msg, 0);
-      msg = com.receiveRange(0, AsVectorTag<int>{});
+      msg = com.receiveRange(0, asVector<int>);
       BOOST_CHECK(msg == std::vector<int>({1, 2, 3}));
     }
     {
       std::vector<double> msg{1.1, 2.2, 3.3};
       com.sendRange(msg, 0);
-      msg = com.receiveRange(0, AsVectorTag<double>{});
+      msg = com.receiveRange(0, asVector<double>);
       BOOST_CHECK(msg == std::vector<double>({1.1, 2.2, 3.3}));
     }
     com.closeConnection();
@@ -547,18 +547,18 @@ template <typename T>
 void TestSendAndReceiveRanges(TestContext const &context)
 {
   T com;
-  using precice::com::AsVectorTag;
+  using precice::com::asVector;
 
   if (context.isPrimary()) {
     com.acceptConnection("Primary", "Secondary", "", 0, 1);
     {
       std::vector<int> recv{1, 2, 3};
-      std::vector<int> msg = com.receiveRange(1, AsVectorTag<int>{});
+      std::vector<int> msg = com.receiveRange(1, asVector<int>);
       BOOST_TEST(msg == recv);
       com.sendRange(msg, 1);
     }
     {
-      std::vector<double> msg = com.receiveRange(1, AsVectorTag<double>{});
+      std::vector<double> msg = com.receiveRange(1, asVector<double>);
       BOOST_TEST(msg == std::vector<double>({1.1, 2.2, 3.3}));
       com.sendRange(msg, 1);
     }
@@ -568,13 +568,13 @@ void TestSendAndReceiveRanges(TestContext const &context)
     {
       std::vector<int> msg{1, 2, 3};
       com.sendRange(msg, 0);
-      msg = com.receiveRange(0, AsVectorTag<int>{});
+      msg = com.receiveRange(0, asVector<int>);
       BOOST_CHECK(msg == std::vector<int>({1, 2, 3}));
     }
     {
       std::vector<double> msg{1.1, 2.2, 3.3};
       com.sendRange(msg, 0);
-      msg = com.receiveRange(0, AsVectorTag<double>{});
+      msg = com.receiveRange(0, asVector<double>);
       BOOST_CHECK(msg == std::vector<double>({1.1, 2.2, 3.3}));
     }
     com.closeConnection();

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -156,7 +156,7 @@ void GatherScatterCommunication::receive(precice::span<double> itemsToReceive, i
   // Secondary ranks receive scattered data
   if (utils::IntraComm::isSecondary()) { // Secondary rank
     if (!itemsToReceive.empty()) {
-      auto received = utils::IntraComm::getCommunication()->receiveRange(0, com::AsVectorTag<double>{});
+      auto received = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<double>);
       PRECICE_ASSERT(!received.empty());
       PRECICE_DEBUG("Received scattered data starting with {}", received[0]);
       std::copy(received.begin(), received.end(), itemsToReceive.begin());
@@ -170,7 +170,7 @@ void GatherScatterCommunication::receive(precice::span<double> itemsToReceive, i
   const int globalSize = _mesh->getGlobalNumberOfVertices() * valueDimension;
   PRECICE_DEBUG("Receiving {} elements from other participant to scatter", globalSize);
 
-  auto globalItemsToReceive = _com->receiveRange(0, com::AsVectorTag<double>{});
+  auto globalItemsToReceive = _com->receiveRange(0, com::asVector<double>);
   PRECICE_ASSERT(globalItemsToReceive.size() == static_cast<std::size_t>(globalSize));
 
   const auto &vertexDistribution = _mesh->getVertexDistribution();

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -47,7 +47,6 @@ void receive(mesh::Mesh::VertexDistribution &m,
              int                             rankSender,
              const com::PtrCommunication &   communication)
 {
-  using precice::com::AsVectorTag;
   m.clear();
   int size = 0;
   communication->receive(size, rankSender);
@@ -55,7 +54,7 @@ void receive(mesh::Mesh::VertexDistribution &m,
   while (size--) {
     Rank rank = -1;
     communication->receive(rank, rankSender);
-    m[rank] = communication->receiveRange(rankSender, AsVectorTag<int>{});
+    m[rank] = communication->receiveRange(rankSender, com::asVector<int>);
   }
 }
 
@@ -695,9 +694,8 @@ void PointToPointCommunication::scatterAllCommunicationMap(CommunicationMap &loc
 
 void PointToPointCommunication::gatherAllCommunicationMap(CommunicationMap &localCommunicationMap)
 {
-  using precice::com::AsVectorTag;
   for (auto &connectionData : _connectionDataVector) {
-    localCommunicationMap[connectionData.remoteRank] = _communication->receiveRange(connectionData.remoteRank, AsVectorTag<int>{});
+    localCommunicationMap[connectionData.remoteRank] = _communication->receiveRange(connectionData.remoteRank, com::asVector<int>);
   }
 }
 

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -196,7 +196,6 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
 {
   PRECICE_TRACE();
   precice::profiling::Event e("map.rbf.mapData.From" + this->input()->getName() + "To" + this->output()->getName(), profiling::Synchronize);
-  using precice::com::AsVectorTag;
 
   PRECICE_DEBUG("Map conservative using {}", getName());
 
@@ -240,7 +239,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
     {
       int secondaryOutputValueSize;
       for (Rank rank : utils::IntraComm::allSecondaryRanks()) {
-        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, AsVectorTag<double>{});
+        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<double>);
         globalInValues.insert(globalInValues.end(), secondaryBuffer.begin(), secondaryBuffer.end());
 
         utils::IntraComm::getCommunication()->receive(secondaryOutputValueSize, rank);
@@ -299,7 +298,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
     }
   }
   if (utils::IntraComm::isSecondary()) {
-    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, AsVectorTag<double>{});
+    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<double>);
 
     const int valueDim = inData.dataDims;
 
@@ -320,7 +319,6 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConsistent(const time::Sample 
 {
   PRECICE_TRACE();
   precice::profiling::Event e("map.rbf.mapData.From" + this->input()->getName() + "To" + this->output()->getName(), profiling::Synchronize);
-  using precice::com::AsVectorTag;
 
   PRECICE_DEBUG("Map {} using {}", (this->hasConstraint(Mapping::CONSISTENT) ? "consistent" : "scaled-consistent"), getName());
 
@@ -352,7 +350,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConsistent(const time::Sample 
       int secondaryOutDataSize{0};
 
       for (Rank rank : utils::IntraComm::allSecondaryRanks()) {
-        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, AsVectorTag<double>{});
+        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<double>);
         std::copy(secondaryBuffer.begin(), secondaryBuffer.end(), globalInValues.begin() + inputSizeCounter);
         inputSizeCounter += secondaryBuffer.size();
 
@@ -409,7 +407,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConsistent(const time::Sample 
     }
   }
   if (utils::IntraComm::isSecondary()) {
-    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, AsVectorTag<double>{});
+    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<double>);
     outData                            = Eigen::Map<Eigen::VectorXd>(receivedValues.data(), receivedValues.size());
   }
 }

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -286,7 +286,7 @@ void ProvidedPartition::compareBoundingBoxes()
 
     // primary rank receives feedback map (map of other participant ranks -> connected ranks at this participant)
     // from other participants primary rank
-    std::vector<Rank> connectedRanksList = _m2ns[0]->getPrimaryRankCommunication()->receiveRange(0, com::AsVectorTag<Rank>{});
+    std::vector<Rank> connectedRanksList = _m2ns[0]->getPrimaryRankCommunication()->receiveRange(0, com::asVector<Rank>);
     remoteConnectionMapSize              = connectedRanksList.size();
 
     mesh::Mesh::CommunicationMap remoteConnectionMap;

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -220,7 +220,7 @@ void ReceivedPartition::compute()
 
       for (int secondaryRank : utils::IntraComm::allSecondaryRanks()) {
         PRECICE_DEBUG("Receive partition feedback from the secondary rank {}", secondaryRank);
-        vertexDistribution[secondaryRank] = utils::IntraComm::getCommunication()->receiveRange(secondaryRank, com::AsVectorTag<VertexID>{});
+        vertexDistribution[secondaryRank] = utils::IntraComm::getCommunication()->receiveRange(secondaryRank, com::asVector<VertexID>);
       }
       PRECICE_ASSERT(_mesh->getVertexDistribution().empty());
       _mesh->setVertexDistribution(std::move(vertexDistribution));
@@ -441,7 +441,7 @@ void ReceivedPartition::compareBoundingBoxes()
 
     // receive connected ranks from secondary ranks and add them to the connection map
     for (int rank : utils::IntraComm::allSecondaryRanks()) {
-      std::vector<Rank> secondaryConnectedRanks = utils::IntraComm::getCommunication()->receiveRange(rank, com::AsVectorTag<Rank>{});
+      std::vector<Rank> secondaryConnectedRanks = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<Rank>);
       if (!secondaryConnectedRanks.empty()) {
         connectedRanksList.push_back(rank);
         connectionMap.emplace(rank, std::move(secondaryConnectedRanks));
@@ -752,7 +752,7 @@ void ReceivedPartition::createOwnerInformation()
         utils::IntraComm::getCommunication()->send(atInterface, 0);
 
         PRECICE_DEBUG("Receive owner information");
-        std::vector<VertexID> ownerVec = utils::IntraComm::getCommunication()->receiveRange(0, com::AsVectorTag<VertexID>{});
+        std::vector<VertexID> ownerVec = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<VertexID>);
         PRECICE_DEBUG("My owner information: {}", ownerVec);
         PRECICE_ASSERT(ownerVec.size() == static_cast<std::size_t>(numberOfVertices));
         setOwnerInformation(ownerVec);
@@ -799,8 +799,8 @@ void ReceivedPartition::createOwnerInformation()
 
         if (localNumberOfVertices != 0) {
           PRECICE_DEBUG("Receive tags from secondary rank {}", rank);
-          secondaryTags[rank]      = utils::IntraComm::getCommunication()->receiveRange(rank, com::AsVectorTag<int>{});
-          secondaryGlobalIDs[rank] = utils::IntraComm::getCommunication()->receiveRange(rank, com::AsVectorTag<VertexID>{});
+          secondaryTags[rank]      = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<int>);
+          secondaryGlobalIDs[rank] = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<VertexID>);
           PRECICE_DEBUG("Rank {} has tags {}", rank, secondaryTags[rank]);
           PRECICE_DEBUG("Rank {} has global IDs {}", rank, secondaryGlobalIDs[rank]);
           bool atInterface = false;

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -944,7 +944,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes2D)
     mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     m2n->getPrimaryRankCommunication()->send(3, 0);
     com::sendBoundingBoxMap(*m2n->getPrimaryRankCommunication(), 0, sendGlobalBB);
-    std::vector<int> connectedRanksList = m2n->getPrimaryRankCommunication()->receiveRange(0, com::AsVectorTag<int>{});
+    std::vector<int> connectedRanksList = m2n->getPrimaryRankCommunication()->receiveRange(0, com::asVector<int>);
     connectionMapSize                   = connectedRanksList.size();
     BOOST_TEST_REQUIRE(connectionMapSize == 2);
 
@@ -1012,7 +1012,7 @@ BOOST_AUTO_TEST_CASE(TestCompareBoundingBoxes3D)
     mesh::PtrMesh                   pSolidzMesh(new mesh::Mesh("SolidzMesh", dimensions, testing::nextMeshID()));
     m2n->getPrimaryRankCommunication()->send(3, 0);
     com::sendBoundingBoxMap(*m2n->getPrimaryRankCommunication(), 0, sendGlobalBB);
-    std::vector<int> connectedRanksList = m2n->getPrimaryRankCommunication()->receiveRange(0, com::AsVectorTag<int>{});
+    std::vector<int> connectedRanksList = m2n->getPrimaryRankCommunication()->receiveRange(0, com::asVector<int>);
     connectionMapSize                   = connectedRanksList.size();
     BOOST_TEST(connectionMapSize == 2);
 


### PR DESCRIPTION
## Main changes of this PR

Uses a templated constant instead of the tag when receiving ranges.

## Motivation and additional information

Makes call-sides less verbose.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
