### PR TITLE
Add sync events to measure time spend synchronizing

### DIFF
--- a/docs/changelog/2019.md
+++ b/docs/changelog/2019.md
@@ -1,0 +1,1 @@
+- Add the synchronization of ranks to the profiling data if `<profiling synchronize="true" />`

--- a/src/profiling/Event.cpp
+++ b/src/profiling/Event.cpp
@@ -1,10 +1,7 @@
 #include "profiling/Event.hpp"
 #include "profiling/EventUtils.hpp"
-#include "profiling/config/ProfilingConfiguration.hpp"
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
-
-extern bool precice::syncMode;
 
 namespace precice::profiling {
 
@@ -36,7 +33,7 @@ void Event::start()
     return;
   }
 
-  if (_synchronize && syncMode) {
+  if (_synchronize && ::precice::utils::IntraComm::willSynchronize()) {
     // We need to synchronize, so we record a sync event
     PRECICE_ASSERT(_sid != -1);
     registry.putCritical(StartEntry{_sid, Clock::now()});

--- a/src/profiling/Event.cpp
+++ b/src/profiling/Event.cpp
@@ -1,7 +1,10 @@
 #include "profiling/Event.hpp"
 #include "profiling/EventUtils.hpp"
+#include "profiling/config/ProfilingConfiguration.hpp"
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
+
+extern bool precice::syncMode;
 
 namespace precice::profiling {
 
@@ -23,8 +26,6 @@ Event::~Event()
     stop();
   }
 }
-
-extern bool syncMode;
 
 void Event::start()
 {

--- a/src/profiling/Event.hpp
+++ b/src/profiling/Event.hpp
@@ -95,6 +95,7 @@ public:
 
 private:
   int   _eid;
+  int   _sid{-1};
   State _state = State::STOPPED;
   bool  _fundamental{false};
   bool  _synchronize{false};

--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -192,10 +192,20 @@ void EventRegistry::clear()
 void EventRegistry::put(PendingEntry pe)
 {
   PRECICE_ASSERT(_mode != Mode::Off, "The profiling is off.");
+
+  // avoid flushing the queue when we start measuring but only if we don't explicitly want to write every entry
+  auto skipFlush = _writeQueueMax != 1 && std::holds_alternative<StartEntry>(pe);
+
   _writeQueue.emplace_back(std::move(pe));
-  if (_writeQueueMax > 0 && _writeQueue.size() > _writeQueueMax) {
+  if (!skipFlush && _writeQueueMax > 0 && _writeQueue.size() > _writeQueueMax) {
     flush();
   }
+}
+
+void EventRegistry::putCritical(PendingEntry pe)
+{
+  PRECICE_ASSERT(_mode != Mode::Off, "The profiling is off.");
+  _writeQueue.emplace_back(std::move(pe));
 }
 
 namespace {

--- a/src/profiling/EventUtils.hpp
+++ b/src/profiling/EventUtils.hpp
@@ -119,6 +119,9 @@ public:
   /// Records an event
   void put(PendingEntry pe);
 
+  /// Records an event without flushing events
+  void putCritical(PendingEntry pe);
+
   /// Writes all recorded events to file and flushes the buffer.
   void flush();
 

--- a/src/utils/IntraComm.cpp
+++ b/src/utils/IntraComm.cpp
@@ -371,6 +371,11 @@ void IntraComm::synchronize()
   }
 }
 
+bool IntraComm::willSynchronize()
+{
+  return precice::syncMode;
+}
+
 void IntraComm::barrier()
 {
   PRECICE_TRACE();

--- a/src/utils/IntraComm.hpp
+++ b/src/utils/IntraComm.hpp
@@ -88,6 +88,11 @@ public:
    */
   static void synchronize();
 
+  /** Does @synchronize have an effect?
+   * @see precice::syncMode
+   */
+  static bool willSynchronize();
+
   /// Synchronizes all ranks
   static void barrier();
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds profiling events that measure the time waiting when using syncMode

## Motivation and additional information

This allows to correct events with synchronizing sub events and make the trace easier to follow.

[Example trace](https://github.com/precice/precice/files/15248241/trace.json.txt)

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
