### PR TITLE
Relax assertions in preconditioner for ummatched weight and target sizes

### DIFF
--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -58,7 +58,7 @@ public:
   {
     PRECICE_TRACE();
     if (transpose) {
-      PRECICE_DEBUG_IF(_weights.size() != M.cols(), "The number of columns of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+      PRECICE_DEBUG_IF((int) _weights.size() != M.cols(), "The number of columns of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
 
       int validCols = std::min(static_cast<int>(M.cols()), (int) _weights.size());
       for (int i = 0; i < validCols; i++) {
@@ -67,7 +67,7 @@ public:
         }
       }
     } else {
-      PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+      PRECICE_DEBUG_IF((int) _weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
 
       int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
       for (int i = 0; i < M.cols(); i++) {
@@ -87,7 +87,7 @@ public:
     PRECICE_TRACE();
     //PRECICE_ASSERT(_needsGlobalWeights);
     if (transpose) {
-      PRECICE_DEBUG_IF(_weights.size() != M.cols(), "The number of columns of the matrix {} and weights size {} mismatched.", M.cols(), _weights.size());
+      PRECICE_DEBUG_IF((int) _weights.size() != M.cols(), "The number of columns of the matrix {} and weights size {} mismatched.", M.cols(), _weights.size());
 
       int validCols = std::min(static_cast<int>(M.cols()), (int) _weights.size());
       for (int i = 0; i < validCols; i++) {
@@ -96,7 +96,7 @@ public:
         }
       }
     } else {
-      PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+      PRECICE_DEBUG_IF((int) _weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
 
       int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
       for (int i = 0; i < M.cols(); i++) {
@@ -111,7 +111,7 @@ public:
   void apply(Eigen::MatrixXd &M)
   {
     PRECICE_TRACE();
-    PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+    PRECICE_DEBUG_IF((int) _weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
 
     // scale matrix M
     int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
@@ -126,7 +126,7 @@ public:
   void apply(Eigen::VectorXd &v)
   {
     PRECICE_TRACE();
-    PRECICE_DEBUG_IF(_weights.size() != v.size(), "The vector size {} and weights size {} mismatched.", v.size(), _weights.size());
+    PRECICE_DEBUG_IF((int) _weights.size() != v.size(), "The vector size {} and weights size {} mismatched.", v.size(), _weights.size());
 
     // scale vector
     int validSize = std::min(static_cast<int>(v.size()), (int) _weights.size());
@@ -139,7 +139,7 @@ public:
   void revert(Eigen::MatrixXd &M)
   {
     PRECICE_TRACE();
-    PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+    PRECICE_DEBUG_IF((int) _weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
 
     // scale matrix M
     int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
@@ -154,7 +154,7 @@ public:
   void revert(Eigen::VectorXd &v)
   {
     PRECICE_TRACE();
-    PRECICE_DEBUG_IF(_weights.size() != v.size(), "The vector size {} and weights size {} mismatched.", v.size(), _weights.size());
+    PRECICE_DEBUG_IF((int) _weights.size() != v.size(), "The vector size {} and weights size {} mismatched.", v.size(), _weights.size());
 
     // revert vector scaling
     int validSize = std::min(static_cast<int>(v.size()), (int) _weights.size());

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -58,16 +58,20 @@ public:
   {
     PRECICE_TRACE();
     if (transpose) {
-      PRECICE_ASSERT(M.cols() == (int) _weights.size(), M.cols(), _weights.size());
-      for (int i = 0; i < M.cols(); i++) {
+      PRECICE_DEBUG_IF(_weights.size() != M.cols(), "The number of columns of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+
+      int validCols = std::min(static_cast<int>(M.cols()), (int) _weights.size());
+      for (int i = 0; i < validCols; i++) {
         for (int j = 0; j < M.rows(); j++) {
           M(j, i) *= _weights[i];
         }
       }
     } else {
-      PRECICE_ASSERT(M.rows() == (int) _weights.size(), M.rows(), (int) _weights.size());
+      PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+
+      int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
       for (int i = 0; i < M.cols(); i++) {
-        for (int j = 0; j < M.rows(); j++) {
+        for (int j = 0; j < validRows; j++) {
           M(j, i) *= _weights[j];
         }
       }
@@ -83,16 +87,20 @@ public:
     PRECICE_TRACE();
     //PRECICE_ASSERT(_needsGlobalWeights);
     if (transpose) {
-      PRECICE_ASSERT(M.cols() == (int) _invWeights.size());
-      for (int i = 0; i < M.cols(); i++) {
+      PRECICE_DEBUG_IF(_weights.size() != M.cols(), "The number of columns of the matrix {} and weights size {} mismatched.", M.cols(), _weights.size());
+
+      int validCols = std::min(static_cast<int>(M.cols()), (int) _weights.size());
+      for (int i = 0; i < validCols; i++) {
         for (int j = 0; j < M.rows(); j++) {
           M(j, i) *= _invWeights[i];
         }
       }
     } else {
-      PRECICE_ASSERT(M.rows() == (int) _invWeights.size(), M.rows(), (int) _invWeights.size());
+      PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
+
+      int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
       for (int i = 0; i < M.cols(); i++) {
-        for (int j = 0; j < M.rows(); j++) {
+        for (int j = 0; j < validRows; j++) {
           M(j, i) *= _invWeights[j];
         }
       }
@@ -103,11 +111,12 @@ public:
   void apply(Eigen::MatrixXd &M)
   {
     PRECICE_TRACE();
-    PRECICE_ASSERT(M.rows() == (int) _weights.size(), M.rows(), (int) _weights.size());
+    PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
 
     // scale matrix M
+    int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
     for (int i = 0; i < M.cols(); i++) {
-      for (int j = 0; j < M.rows(); j++) {
+      for (int j = 0; j < validRows; j++) {
         M(j, i) *= _weights[j];
       }
     }
@@ -117,11 +126,11 @@ public:
   void apply(Eigen::VectorXd &v)
   {
     PRECICE_TRACE();
+    PRECICE_DEBUG_IF(_weights.size() != v.size(), "The vector size {} and weights size {} mismatched.", v.size(), _weights.size());
 
-    PRECICE_ASSERT(v.size() == (int) _weights.size());
-
-    // scale residual
-    for (int j = 0; j < v.size(); j++) {
+    // scale vector
+    int validSize = std::min(static_cast<int>(v.size()), (int) _weights.size());
+    for (int j = 0; j < validSize; j++) {
       v[j] *= _weights[j];
     }
   }
@@ -130,12 +139,12 @@ public:
   void revert(Eigen::MatrixXd &M)
   {
     PRECICE_TRACE();
-
-    PRECICE_ASSERT(M.rows() == (int) _weights.size());
+    PRECICE_DEBUG_IF(_weights.size() != M.rows(), "The number of rows of the matrix {} and weights size {} mismatched.", M.rows(), _weights.size());
 
     // scale matrix M
+    int validRows = std::min(static_cast<int>(M.rows()), (int) _weights.size());
     for (int i = 0; i < M.cols(); i++) {
-      for (int j = 0; j < M.rows(); j++) {
+      for (int j = 0; j < validRows; j++) {
         M(j, i) *= _invWeights[j];
       }
     }
@@ -145,11 +154,11 @@ public:
   void revert(Eigen::VectorXd &v)
   {
     PRECICE_TRACE();
+    PRECICE_DEBUG_IF(_weights.size() != v.size(), "The vector size {} and weights size {} mismatched.", v.size(), _weights.size());
 
-    PRECICE_ASSERT(v.size() == (int) _weights.size());
-
-    // scale residual
-    for (int j = 0; j < v.size(); j++) {
+    // revert vector scaling
+    int validSize = std::min(static_cast<int>(v.size()), (int) _weights.size());
+    for (int j = 0; j < validSize; j++) {
       v[j] *= _invWeights[j];
     }
   }

--- a/src/acceleration/test/PreconditionerTest.cpp
+++ b/src/acceleration/test/PreconditionerTest.cpp
@@ -20,9 +20,13 @@ using namespace precice::acceleration::impl;
 struct ResPreconditionerFixture {
   Eigen::VectorXd _data;
   Eigen::VectorXd _res;
+  Eigen::VectorXd _dataLargerSize;
+  Eigen::VectorXd _dataSmallerSize;
   Eigen::VectorXd _compareDataRes;
   Eigen::VectorXd _compareDataResSum;
   Eigen::VectorXd _compareDataResSum2;
+  Eigen::VectorXd _compareDataLargerSizeResSum;
+  Eigen::VectorXd _compareDataSmallerSizeResSum;
   Eigen::VectorXd _compareDataValue;
   Eigen::VectorXd _compareDataConstant;
 
@@ -30,6 +34,12 @@ struct ResPreconditionerFixture {
   {
     _data.resize(8);
     _data << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0;
+
+    _dataLargerSize.resize(10);
+    _dataLargerSize << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0, 20.0;
+
+    _dataSmallerSize.resize(6);
+    _dataSmallerSize << 1.0, 2.0, 3.0, 4.0, 5.0, 6.0;
 
     _res.resize(8);
     _res << 0.1, 0.1, 0.001, 0.001, 0.001, 0.001, 10.0, 20.0;
@@ -63,6 +73,26 @@ struct ResPreconditionerFixture {
         6.00012000479918228280e+00,
         7.00014000559904481236e+00,
         8.00016000639890734192e+00;
+
+    _compareDataLargerSizeResSum.resize(10);
+    _compareDataLargerSizeResSum << 7.90585229434499154877e+01,
+        1.58117045886899830975e+02,
+        1.67708453051717078779e+04,
+        2.23611270735622783832e+04,
+        2.79514088419528488885e+04,
+        3.35416906103434157558e+04,
+        3.50007001329973377324e+00,
+        4.00008001519969536020e+00,
+        10.0,
+        20.0;
+
+    _compareDataSmallerSizeResSum.resize(6);
+    _compareDataSmallerSizeResSum << 7.90585229434499154877e+01,
+        1.58117045886899830975e+02,
+        1.67708453051717078779e+04,
+        2.23611270735622783832e+04,
+        2.79514088419528488885e+04,
+        3.35416906103434157558e+04;
 
     _compareDataValue.resize(8);
     _compareDataValue << 4.47213595499957927704e-01,
@@ -224,6 +254,72 @@ BOOST_AUTO_TEST_CASE(testConstPreconditioner)
   BOOST_TEST(testing::equals(_data, _compareDataConstant));
   precond.revert(_data);
   BOOST_TEST(testing::equals(_data, backup));
+}
+
+BOOST_AUTO_TEST_CASE(testPreconditionerLargerDataSize)
+{
+  PRECICE_TEST(1_rank);
+  std::vector<size_t> svs;
+  svs.push_back(2);
+  svs.push_back(4);
+  svs.push_back(2);
+
+  ResidualSumPreconditioner precond(-1);
+
+  precond.initialize(svs);
+  Eigen::VectorXd backup = _dataLargerSize;
+
+  //should change, update twice to really test the summation
+  precond.update(false, _data, _res);
+  precond.update(false, _data, _res * 2);
+  BOOST_TEST(precond.requireNewQR());
+  precond.newQRfulfilled();
+  precond.apply(_dataLargerSize); //should only scale the first 8 values
+  BOOST_TEST(testing::equals(_dataLargerSize, _compareDataLargerSizeResSum));
+
+  precond.revert(_dataLargerSize);
+  BOOST_TEST(testing::equals(_dataLargerSize, backup));
+
+  //should not change weights
+  precond.update(true, _data, _res * 10);
+  BOOST_TEST(not precond.requireNewQR());
+  precond.apply(_dataLargerSize);
+  BOOST_TEST(testing::equals(_dataLargerSize, _compareDataLargerSizeResSum));
+  precond.revert(_dataLargerSize);
+  BOOST_TEST(testing::equals(_dataLargerSize, backup));
+}
+
+BOOST_AUTO_TEST_CASE(testPreconditionerLargerResSize)
+{
+  PRECICE_TEST(1_rank);
+  std::vector<size_t> svs;
+  svs.push_back(2);
+  svs.push_back(4);
+  svs.push_back(2);
+
+  ResidualSumPreconditioner precond(-1);
+
+  precond.initialize(svs);
+  Eigen::VectorXd backup = _dataSmallerSize;
+
+  //should change, update twice to really test the summation
+  precond.update(false, _data, _res);
+  precond.update(false, _data, _res * 2);
+  BOOST_TEST(precond.requireNewQR());
+  precond.newQRfulfilled();
+  precond.apply(_dataSmallerSize); //should only use the first 6 scaling factors
+  BOOST_TEST(testing::equals(_dataSmallerSize, _compareDataSmallerSizeResSum));
+
+  precond.revert(_dataSmallerSize);
+  BOOST_TEST(testing::equals(_dataSmallerSize, backup));
+
+  //should not change weights
+  precond.update(true, _data, _res * 10);
+  BOOST_TEST(not precond.requireNewQR());
+  precond.apply(_dataSmallerSize);
+  BOOST_TEST(testing::equals(_dataSmallerSize, _compareDataSmallerSizeResSum));
+  precond.revert(_dataSmallerSize);
+  BOOST_TEST(testing::equals(_dataSmallerSize, backup));
 }
 
 BOOST_AUTO_TEST_CASE(testMultilpleMeshes)


### PR DESCRIPTION
## Main changes of this PR
The assertions in the preconditioner are relaxed to `debug` information to allow non-equal sizes of the weight and target to be scaled. This is the case for `Wtil` in #2010.  
Tests are added for this change.

## Motivation and additional information
Part of #2010.

## Author's checklist
* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
