### PR TITLE
Improve the computational efficiency of the Bspline interpolation

### DIFF
--- a/docs/changelog/2021.md
+++ b/docs/changelog/2021.md
@@ -1,0 +1,1 @@
+- Improved the runtime of the creation of the Bspline interpolation, by switching the matrix A inside the Bspline class to a sparse matrix.


### PR DESCRIPTION
## Main changes of this PR

Change the matrix A which contains the time step information in the Bspline algorithm to sparse.

## Motivation and additional information

The current implementation of the Bspline algorithm uses a dense matrix as A containing the time steps, which results in a significant slow down a large number of time steps. This change utilizes the sparse nature of the matrix A and thus speeds up the considerably for a large number of time steps. 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
