### PR TITLE
Add error message for empty data

### DIFF
--- a/docs/changelog/2024.md
+++ b/docs/changelog/2024.md
@@ -1,0 +1,1 @@
+- Added error in case of missing samples in origin of read mappings.

--- a/src/precice/impl/DataContext.cpp
+++ b/src/precice/impl/DataContext.cpp
@@ -96,8 +96,11 @@ int DataContext::mapData(std::optional<double> after, bool skipZero)
 
   // Execute the mappings
   for (auto &context : _mappingContexts) {
-    PRECICE_ASSERT(!context.fromData->stamples().empty(),
-                   "There must be samples at this point!");
+    PRECICE_CHECK(!context.fromData->stamples().empty(),
+                  "Data {0} on mesh {1} didn't contain any data samples while attempting to map to mesh {2}. "
+                  "Check your exchange tags to ensure your coupling scheme exchanges the data or the pariticipant produces it using an action. "
+                  "The expected exchange tag should look like this: <exchange data=\"{0}\" mesh=\"{1}\" from=... to=... />.",
+                  context.fromData->getName(), context.mapping->getInputMesh()->getName(), context.mapping->getOutputMesh()->getName());
 
     // linear lookup should be sufficient here
     const auto timestampExists = [times = context.toData->timeStepsStorage().getTimes()](double lookup) -> bool {


### PR DESCRIPTION
## Main changes of this PR

Running into the assertion that a data contains no samples is highly confusing and misleading.

This PR adds a descriptive error message that attempts to explain the root course of the issue.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
