### PR TITLE
Fix escaped semicolons in version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,11 +517,17 @@ target_link_libraries(precice PRIVATE preciceCore)
 include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 
 # File Configuration
-include(GenerateVersionInformation)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/DetectGitRevision.cmake)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp" @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/src/testing/SourceLocation.hpp.in" "${PROJECT_BINARY_DIR}/src/testing/SourceLocation.hpp" @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
+
+# Configure version file generation
+include(GenerateVersionInformation)
+# Configure CMake variables only. The result contains a placeholder for the git revision
+configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.cpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp.in" @ONLY)
+# Dynamically replace the git revision information.
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/DetectGitRevision.cmake)
+
 
 # Setup export header
 include(GenerateExportHeader)

--- a/cmake/DetectGitRevision.cmake
+++ b/cmake/DetectGitRevision.cmake
@@ -14,15 +14,18 @@
 find_package(Git QUIET)
 if(GIT_FOUND)
   add_custom_target(GitRevision
-    COMMAND ${CMAKE_COMMAND} -DSRC=${PROJECT_SOURCE_DIR}/src/precice/impl/versions.cpp.in -DDST=${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp -DpreCICE_VERSION=${preCICE_VERSION} -DpreCICE_VERSION_INFORMATION=${preCICE_VERSION_INFORMATION} -P ${CMAKE_CURRENT_LIST_DIR}/cmake_refresh_git_revision.cmake
+    COMMAND ${CMAKE_COMMAND}
+      -DSRC=${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp.in
+      -DDST=${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp
+      -P ${CMAKE_CURRENT_LIST_DIR}/cmake_refresh_git_revision.cmake
     WORKING_DIRECTORY "${preCICE_SOURCE_DIR}"
-    BYPRODUCTS src/precice/impl/versions.cpp
-    DEPENDS src/precice/impl/versions.cpp.in
+    BYPRODUCTS ${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp
+    DEPENDS ${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp.in
     VERBATIM
     )
   add_dependencies(preciceCore GitRevision)
 else(GIT_FOUND)
   set(preCICE_REVISION "no-info [Git not found]")
-  configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.cpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp" @ONLY)
+  configure_file("${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.cpp" @ONLY)
   message(STATUS "Revision status: No git installation detected.")
 endif(GIT_FOUND)

--- a/cmake/GenerateVersionInformation.cmake
+++ b/cmake/GenerateVersionInformation.cmake
@@ -2,28 +2,20 @@
 # This script generates the version information used in versions.hpp.in
 #
 
-# We use an internal cache to keep the code below a bit more sane
-set(preCICE_VERSION_INFORMATION "" CACHE INTERNAL "")
-
 # Adds a NAME=VALUE pair to the version information
-function(precice_vi_add_value NAME VALUE)
-  if(preCICE_VERSION_INFORMATION)
-    # We have to use \; as separator to prevent the list-escaping of cmake
-    # to remove the ; and escape the whitespaces
-    set(preCICE_VERSION_INFORMATION "${preCICE_VERSION_INFORMATION}\;${NAME}=${VALUE}" CACHE INTERNAL "")
-  else()
-    set(preCICE_VERSION_INFORMATION "${NAME}=${VALUE}" CACHE INTERNAL "")
-  endif()
-endfunction()
+macro(precice_vi_add_value NAME VALUE)
+  set(${NAME} "${VALUE}")# CACHE INTERNAL "")
+endmacro()
 
 # Adds a boolean option to the version information
-function(precice_vi_add_option NAME)
+macro(precice_vi_add_option NAME)
   set(PVI_VAL "N")
   if(${NAME})
     set(PVI_VAL "Y")
   endif()
-  precice_vi_add_value(${NAME} ${PVI_VAL})
-endfunction()
+  precice_vi_add_value("${NAME}_VAL" ${PVI_VAL})
+  unset(PVI_VAL)
+endmacro()
 
 precice_vi_add_option(PRECICE_FEATURE_MPI_COMMUNICATION)
 precice_vi_add_option(PRECICE_FEATURE_PETSC_MAPPING)
@@ -31,22 +23,21 @@ precice_vi_add_option(PRECICE_FEATURE_GINKGO_MAPPING)
 precice_vi_add_option(PRECICE_FEATURE_PYTHON_ACTIONS)
 precice_vi_add_option(PRECICE_BINDINGS_C)
 precice_vi_add_option(PRECICE_BINDINGS_FORTRAN)
-precice_vi_add_value(CXX "${CMAKE_CXX_COMPILER_ID}")
 
 # Add compiler flags
-if(CMAKE_BUILD_TYPE STREQUAL "")
-  precice_vi_add_value(CXXFLAGS "${CMAKE_CXX_FLAGS}")
-elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  precice_vi_add_value(CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  precice_vi_add_value(PRECICE_VI_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}")
 elseif(CMAKE_BUILD_TYPE STREQUAL "Release")
-  precice_vi_add_value(CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
+  precice_vi_add_value(PRECICE_VI_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
 elseif(CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-  precice_vi_add_value(CXXFLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  precice_vi_add_value(PRECICE_VI_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+else()
+  precice_vi_add_value(PRECICE_VI_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 # Add linker flags
 if(BUILD_SHARED_LIBS)
-  precice_vi_add_value(LDFLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+  precice_vi_add_value(PRECICE_VI_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
 else()
-  precice_vi_add_value(LDFLAGS "${CMAKE_STATIC_LINKER_FLAGS}")
+  precice_vi_add_value(PRECICE_VI_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS}")
 endif()

--- a/cmake/cmake_refresh_git_revision.cmake
+++ b/cmake/cmake_refresh_git_revision.cmake
@@ -27,4 +27,5 @@ if("${PRECICE_REVISION_RET}" EQUAL "0")
 else()
   message(STATUS "Revision status: Detection failed")
 endif()
-configure_file( ${SRC} ${DST} @ONLY)
+# Note this is a second configure_file pass which replaces ${VAR} instead of @ONLY
+configure_file( ${SRC} ${DST} )

--- a/docs/changelog/2030.md
+++ b/docs/changelog/2030.md
@@ -1,0 +1,1 @@
+- Fixes incorrect escapes in version information for some CMake versions

--- a/src/precice/impl/versions.cpp.in
+++ b/src/precice/impl/versions.cpp.in
@@ -1,4 +1,14 @@
 #include "precice/impl/versions.hpp"
 
-const char * const precice::preciceRevision = "@preCICE_REVISION@";
-const char * const precice::versionInformation = "@preCICE_VERSION@;@preCICE_REVISION@;@preCICE_VERSION_INFORMATION@";
+const char *const precice::preciceRevision    = "${preCICE_REVISION}";
+const char *const precice::versionInformation = "@preCICE_VERSION@;"
+                                                "${preCICE_REVISION};"
+                                                "PRECICE_FEATURE_MPI_COMMUNICATION=@PRECICE_FEATURE_MPI_COMMUNICATION_VAL@;"
+                                                "PRECICE_FEATURE_PETSC_MAPPING=@PRECICE_FEATURE_PETSC_MAPPING_VAL@;"
+                                                "PRECICE_FEATURE_GINKGO_MAPPING=@PRECICE_FEATURE_GINKGO_MAPPING_VAL@;"
+                                                "PRECICE_FEATURE_PYTHON_ACTIONS=@PRECICE_FEATURE_PYTHON_ACTIONS_VAL@;"
+                                                "PRECICE_BINDINGS_C=@PRECICE_BINDINGS_C_VAL@;"
+                                                "PRECICE_BINDINGS_FORTRAN=@PRECICE_BINDINGS_FORTRAN_VAL@;"
+                                                "CXX=@CMAKE_CXX_COMPILER_ID@;"
+                                                "CXXFLAGS=@PRECICE_VI_CXX_FLAGS@;"
+                                                "LDFLAGS=@PRECICE_VI_LINKER_FLAGS@";


### PR DESCRIPTION
## Main changes of this PR

This PR fixes incorrectly escaped strings in the Version info.

The new method uses the following generation procedure:
1. generate "version info" values for given variables. This is necessary to map true values `ON, on, Yes, yes, 1, True` to `Y` (similar for `N`).
2. use `@ONLY` to substitute all variables known by CMake except the git revision.
3. use `configure_file` without `@ONLY` to substitute the `${preCICE_REVISION}` using git via a separate command.

## Motivation and additional information

Closes #2029

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
