### PR TITLE
Add mesh name to convergence file header

### DIFF
--- a/docs/changelog/2032.md
+++ b/docs/changelog/2032.md
@@ -1,0 +1,1 @@
+- Improved convergence log to display mesh and data name in convergence measures.

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -491,7 +491,7 @@ private:
 
     std::string logHeader() const
     {
-      return "Res" + measure->getAbbreviation() + "(" + couplingData->getDataName() + ")";
+      return fmt::format("Res{}({}:{})", measure->getAbbreviation(), couplingData->getMeshName(), couplingData->getDataName());
     }
   };
 

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -135,9 +135,14 @@ int CouplingData::getDataID()
   return _data->getID();
 }
 
-std::string CouplingData::getDataName()
+std::string CouplingData::getDataName() const
 {
   return _data->getName();
+}
+
+std::string CouplingData::getMeshName() const
+{
+  return _mesh->getName();
 }
 
 std::vector<int> CouplingData::getVertexOffsets()

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -89,7 +89,10 @@ public:
   int getDataID();
 
   /// get name of this CouplingData's data. See Data::getName().
-  std::string getDataName();
+  std::string getDataName() const;
+
+  /// get name of this CouplingData's mesh. See Mesh::getName().
+  std::string getMeshName() const;
 
   /// get vertex offsets of this CouplingData's mesh. See Mesh::getVertexOffsets().
   std::vector<int> getVertexOffsets();


### PR DESCRIPTION
## Main changes of this PR

This PR adds the mesh name to the header entries of convergence files.

A residual relative convergence of data `Displacements` from `TendonTop` looks like this `ResRel(TendonTop:Displacements)`.

## Motivation and additional information

When a solver is receiving the same data name such as displacements via multiple meshes from multiple solvers, then it is impossible to distinguish them in the convergence log.

This widens the headers, makes the table even more misaligned and reduces readability of the output.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
