### PR TITLE
Remove custom time at CouplingScheme initalization

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -267,17 +267,15 @@ void BaseCouplingScheme::finalize()
   PRECICE_ASSERT(_isInitialized, "Called finalize() before initialize().");
 }
 
-void BaseCouplingScheme::initialize(double startTime, int startTimeWindow)
+void BaseCouplingScheme::initialize()
 {
   // initialize with zero data here, might eventually be overwritten in exchangeInitialData
   initializeReceiveDataStorage();
   // Initialize uses the template method pattern (https://en.wikipedia.org/wiki/Template_method_pattern).
-  PRECICE_TRACE(startTime, startTimeWindow);
+  PRECICE_TRACE();
   PRECICE_ASSERT(not isInitialized());
-  PRECICE_ASSERT(math::greaterEquals(startTime, 0.0), startTime);
-  PRECICE_ASSERT(startTimeWindow >= 0, startTimeWindow);
-  _time.resetTo(startTime);
-  _timeWindows         = startTimeWindow;
+  _time.resetTo(0);
+  _timeWindows         = 1;
   _hasDataBeenReceived = false;
 
   if (isImplicitCouplingScheme()) {

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -175,13 +175,8 @@ public:
   /// Finalizes the coupling scheme.
   void finalize() override final;
 
-  /**
-   * @brief Initializes the coupling scheme.
-   *
-   * @param[in] startTime starting time of coupling scheme
-   * @param[in] startTimeWindow starting counter of time window, from which coupling scheme starts
-   */
-  void initialize(double startTime, int startTimeWindow) override final;
+  /// @copydoc cplscheme::CouplingScheme::initialize()
+  void initialize() override final;
 
   ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override final;
 

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -77,14 +77,12 @@ void CompositionalCouplingScheme::addCouplingScheme(
   }
 }
 
-void CompositionalCouplingScheme::initialize(
-    double startTime,
-    int    startTimeWindow)
+void CompositionalCouplingScheme::initialize()
 {
-  PRECICE_TRACE(startTime, startTimeWindow);
+  PRECICE_TRACE();
   PRECICE_ASSERT(_activeSchemes.empty());
   for (const auto scheme : allSchemes()) {
-    scheme->initialize(startTime, startTimeWindow);
+    scheme->initialize();
     _activeSchemes.push_back(scheme);
   }
 }

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -74,12 +74,8 @@ public:
   /**
    * @brief Initializes the coupling scheme and establishes a communication
    *        connection to the coupling partner.
-   * @param[in] startTime TODO
-   * @param[in] startTimeWindow TODO
    */
-  void initialize(
-      double startTime,
-      int    startTimeWindow) final override;
+  void initialize() final override;
 
   /// Returns true, if any of the composed coupling schemes sendsInitializedData for this participant
   bool sendsInitializedData() const override final;

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -75,13 +75,8 @@ public:
   /**
    * @brief Initializes the coupling scheme and establishes a communication
    *        connection to the coupling partner. Initializes coupling data.
-   *
-   * @param[in] startTime starting time for coupling @BU correct?
-   * @param[in] startTimeWindow counter of time window for coupling @BU correct?
    */
-  virtual void initialize(
-      double startTime,
-      int    startTimeWindow) = 0;
+  virtual void initialize() = 0;
 
   /**
    * @brief Returns whether this participant of the coupling scheme sends initialized data.

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -93,7 +93,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
 
     if (participantName == std::string("Participant0")) {
       mesh->data(0)->setSampleAtTime(0, time::Sample{1, mesh->data(0)->values()});
-      cplScheme->initialize(0.0, 1);
+      cplScheme->initialize();
       BOOST_TEST(not cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());
@@ -131,7 +131,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
     } else if (participantName == std::string("Participant1")) {
       auto ddims = mesh->data(1)->getDimensions();
       mesh->data(1)->setSampleAtTime(0, time::Sample{ddims, mesh->data(1)->values()});
-      cplScheme->initialize(0.0, 1);
+      cplScheme->initialize();
       BOOST_TEST(cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());
@@ -170,7 +170,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       auto ddims = mesh->data(2)->getDimensions();
       BOOST_TEST(participantName == std::string("Participant2"), participantName);
       mesh->data(2)->setSampleAtTime(0, time::Sample{ddims, mesh->data(2)->values()});
-      cplScheme->initialize(0.0, 1);
+      cplScheme->initialize();
       BOOST_TEST(cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
       BOOST_TEST(cplScheme->isCouplingOngoing());
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit2)
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
-  composition.initialize(0.0, 1);
+  composition.initialize();
   int advances = 0;
   while (composition.isCouplingOngoing()) {
     composition.addComputedTime(1.0);
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit3)
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
   composition.addCouplingScheme(scheme3);
-  composition.initialize(0.0, 1);
+  composition.initialize();
   int advances = 0;
   while (composition.isCouplingOngoing()) {
     composition.addComputedTime(1.0);
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit2)
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
-  composition.initialize(0.0, 1);
+  composition.initialize();
   int advances = 0;
   BOOST_TEST_MESSAGE("Init Expl " << scheme1->getTimeWindows());
   BOOST_TEST_MESSAGE("Init Impl " << scheme2->getTimeWindows());
@@ -343,7 +343,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit2Explicit1)
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
-  composition.initialize(0.0, 1);
+  composition.initialize();
   int advances = 0;
   while (composition.isCouplingOngoing()) {
     composition.addComputedTime(1.0);
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionExplicit1Implicit3)
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
-  composition.initialize(0.0, 1);
+  composition.initialize();
   int advances = 0;
   while (composition.isCouplingOngoing()) {
     composition.addComputedTime(1.0);
@@ -415,7 +415,7 @@ BOOST_AUTO_TEST_CASE(testDummySchemeCompositionImplicit3Explicit1)
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   composition.addCouplingScheme(scheme2);
-  composition.initialize(0.0, 1);
+  composition.initialize();
   int advances = 0;
   while (composition.isCouplingOngoing()) {
     composition.addComputedTime(1.0);

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -13,14 +13,12 @@ DummyCouplingScheme::DummyCouplingScheme(
 {
 }
 
-void DummyCouplingScheme::initialize(
-    double startTime,
-    int    startTimeWindows)
+void DummyCouplingScheme::initialize()
 {
   PRECICE_ASSERT(not _isInitialized);
   _isInitialized = true;
   _isOngoing     = true;
-  _timeWindows   = startTimeWindows;
+  _timeWindows   = 1;
   _iterations    = 1;
 }
 

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -34,9 +34,7 @@ public:
   /**
    * @brief
    */
-  void initialize(
-      double startTime,
-      int    startTimeWindows) override final;
+  void initialize() override final;
 
   /**
    * @brief Not implemented.

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -53,7 +53,7 @@ void runSimpleExplicitCoupling(
 
   if (participantName == std::string("Participant0")) {
     mesh->data(0)->setSampleAtTime(0, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -99,7 +99,7 @@ void runSimpleExplicitCoupling(
     BOOST_TEST(cplScheme.getNextTimeStepMaxSize() == 0.0);
   } else if (participantName == std::string("Participant1")) {
     mesh->data(1)->setSampleAtTime(0, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     double value = dataValues0(vertex.getID());
     BOOST_TEST(testing::equals(value, valueData0));
@@ -168,7 +168,7 @@ void runExplicitCouplingWithSubcycling(
   BOOST_TEST(((participantName == nameParticipant0) || (participantName == nameParticipant1)));
   if (participantName == nameParticipant0) {
     mesh->data(0)->setSampleAtTime(0, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     mesh->data(0)->timeStepsStorage().trim();
     double dtDesired = cplScheme.getNextTimeStepMaxSize() / 2.0;
     double dtUsed    = dtDesired;
@@ -227,7 +227,7 @@ void runExplicitCouplingWithSubcycling(
   } else if (participantName == nameParticipant1) {
     // Start coupling
     mesh->data(1)->setSampleAtTime(0, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     // Validate current coupling status
     BOOST_TEST(testing::equals(dataValues0(vertex.getID()), valueData0));
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
     double solverDt = 0.3;
     double preciceDt, dt;
     mesh->data(0)->setSampleAtTime(0, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     BOOST_TEST(cplScheme.getNextTimeStepMaxSize() == 1);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingFirstParticipantSetsDt)
   } else {
     BOOST_TEST(context.isNamed(nameParticipant1));
     mesh->data(1)->setSampleAtTime(0, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isCouplingOngoing());
@@ -536,7 +536,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
     cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     mesh->data(2)->setSampleAtTime(0, time::Sample{mesh->data(2)->getDimensions(), mesh->data(2)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived()); // receives initial data
     // BOOST_TEST(testing::equals(dataValues0(0), 0.0));  // @todo Should receive 0.0, because Data0 is not initialized. See https://github.com/precice/precice/issues/1693
     BOOST_TEST(testing::equals(dataValues0(0), 5.0)); // @todo Incorrect due to bug. See https://github.com/precice/precice/issues/1693
@@ -560,7 +560,7 @@ BOOST_AUTO_TEST_CASE(testSerialDataInitialization)
     cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     mesh->data(0)->setSampleAtTime(0, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
     mesh->data(1)->setSampleAtTime(0, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived()); // receives initial data
     BOOST_TEST(testing::equals(dataValues2(0), 2.0));
     dataValues0(0) = 4.0;
@@ -632,7 +632,7 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
     cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     BOOST_TEST(not cplScheme.hasDataBeenReceived());
     mesh->data(2)->setSampleAtTime(0, time::Sample{mesh->data(2)->getDimensions(), mesh->data(2)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived()); // receives initial data
     // BOOST_TEST(testing::equals(dataValues0(0), 0.0));  // @todo Should receive 0.0, because Data0 is not initialized. See https://github.com/precice/precice/issues/1693
     BOOST_TEST(testing::equals(dataValues0(0), 5.0)); // @todo Incorrect due to bug. See https://github.com/precice/precice/issues/1693
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE(testParallelDataInitialization)
     cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     mesh->data(0)->setSampleAtTime(0, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
     mesh->data(1)->setSampleAtTime(0, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived()); // receives initial data
     BOOST_TEST(testing::equals(dataValues2(0), 3.0));
     dataValues0(0) = 4.0;

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     sendCouplingData->setSampleAtTime(0, time::Sample{1, Eigen::VectorXd::Constant(1, 4.0)});
     cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
-    cplScheme.initialize(0.0, 0);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(receiveCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 3);
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(receiveCouplingData->values().size() == 1);
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
     BOOST_TEST(sendCouplingData->values().size() == 3);
-    cplScheme.initialize(0.0, 0);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 4.0));
     BOOST_TEST(receiveCouplingData->getPreviousIterationSize() == 1);

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -74,7 +74,7 @@ void runCoupling(
 
   if (nameParticipant == nameParticipant0) {
     mesh->data(0)->setSampleAtTime(0, time::Sample{1, mesh->data(0)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -143,7 +143,7 @@ void runCoupling(
     BOOST_TEST(computedTimesteps == 3);
   } else if (nameParticipant == nameParticipant1) {
     mesh->data(1)->setSampleAtTime(0, time::Sample{1, mesh->data(1)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -247,7 +247,7 @@ void runCouplingWithSubcycling(
   if (nameParticipant == nameParticipant0) {
     iterationCount++; // different handling due to subcycling
     mesh->data(0)->setSampleAtTime(0, time::Sample{1, mesh->data(0)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -336,7 +336,7 @@ void runCouplingWithSubcycling(
   else if (nameParticipant == nameParticipant1) {
     iterationCount++; // different handling due to subcycling
     mesh->data(1)->setSampleAtTime(0, time::Sample{1, mesh->data(1)->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
     BOOST_TEST(not cplScheme.isActionRequired(CouplingScheme::Action::ReadCheckpoint));
@@ -738,7 +738,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
     BOOST_TEST(Fixture::isImplicitCouplingScheme(cplScheme));
     sendCouplingData->setSampleAtTime(0, time::Sample{1, sendCouplingData->values()});
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     // ensure that initial data was read
     BOOST_TEST(receiveCouplingData->getSize() == 3);
@@ -780,7 +780,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 0.0));
     BOOST_TEST(sendCouplingData->getSize() == 3);
     BOOST_TEST(testing::equals(sendCouplingData->values(), Eigen::Vector3d(1.0, 2.0, 3.0)));
-    cplScheme.initialize(0.0, 1);
+    cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     BOOST_TEST(receiveCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 4.0));

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -312,21 +312,18 @@ void ParticipantImpl::initialize()
     watchIntegral->initialize();
   }
 
-  // Initialize coupling state, overwrite these values for restart
-  const double time       = 0.0;
-  const int    timeWindow = 1;
-
   _meshLock.lockAll();
 
   for (auto &context : _accessor->writeDataContexts()) {
-    context.storeBufferedData(time);
+    const double startTime = 0.0;
+    context.storeBufferedData(startTime);
   }
 
   mapInitialWrittenData();
   performDataActions({action::Action::WRITE_MAPPING_POST});
 
   PRECICE_DEBUG("Initialize coupling schemes");
-  _couplingScheme->initialize(time, timeWindow);
+  _couplingScheme->initialize();
 
   mapInitialReadData();
   performDataActions({action::Action::READ_MAPPING_POST});


### PR DESCRIPTION
## Main changes of this PR

This PR removes the untested ability to provide a custom time and time window to the initialization of `CouplingScheme`s.
According to @uekerman it is a remnant from a former restart functionality.

## Motivation and additional information

Less complexity

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
