### PR TITLE
Remove `MAX_WAVEFORM_DEGREE`

### DIFF
--- a/docs/changelog/2039.md
+++ b/docs/changelog/2039.md
@@ -1,0 +1,1 @@
+- Allowed arbitraryly high waveform degree.

--- a/docs/changelog/2039.md
+++ b/docs/changelog/2039.md
@@ -1,1 +1,1 @@
-- Allowed arbitraryly high waveform degree.
+- Improved time-interpolation to allow arbitrary high waveform degree.

--- a/src/mesh/config/DataConfiguration.cpp
+++ b/src/mesh/config/DataConfiguration.cpp
@@ -63,8 +63,8 @@ void DataConfiguration::xmlTagCallback(
     };
 
     const int waveformDegree = tag.getIntAttributeValue(ATTR_DEGREE);
-    PRECICE_CHECK(!(waveformDegree < time::Time::MIN_WAVEFORM_DEGREE || waveformDegree > time::Time::MAX_WAVEFORM_DEGREE),
-                  "You tried to configure the data with name \"{}\" to use the waveform-degree=\"{}\", but the degree must be between \"{}\" and \"{}\". Please use a degree in the allowed range.", name, waveformDegree, time::Time::MIN_WAVEFORM_DEGREE, time::Time::MAX_WAVEFORM_DEGREE);
+    PRECICE_CHECK(!(waveformDegree < time::Time::MIN_WAVEFORM_DEGREE),
+                  "You tried to configure the data with name \"{}\" to use the waveform-degree=\"{}\", but the degree must be at least \"{}\".", name, waveformDegree, time::Time::MIN_WAVEFORM_DEGREE);
     addData(name, typeName, waveformDegree);
   } else {
     PRECICE_ASSERT(false, "Received callback from an unknown tag.", tag.getName());

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -51,7 +51,7 @@ void Storage::setSampleAtTime(double time, const Sample &sample)
 
 void Storage::setInterpolationDegree(int interpolationDegree)
 {
-  PRECICE_ASSERT(Time::MIN_WAVEFORM_DEGREE <= _degree && _degree <= Time::MAX_WAVEFORM_DEGREE);
+  PRECICE_ASSERT(interpolationDegree >= Time::MIN_WAVEFORM_DEGREE);
   _degree = interpolationDegree;
 
   // The spline has to be recomputed, since the underlying data has changed
@@ -227,7 +227,6 @@ Eigen::MatrixXd Storage::sampleGradients(double time) const
 
 int Storage::computeUsedDegree(int requestedDegree, int numberOfAvailableSamples) const
 {
-  PRECICE_ASSERT(requestedDegree <= Time::MAX_WAVEFORM_DEGREE);
   return std::min(requestedDegree, numberOfAvailableSamples - 1);
 }
 

--- a/src/time/Time.cpp
+++ b/src/time/Time.cpp
@@ -6,6 +6,4 @@ const int Time::DEFAULT_WAVEFORM_DEGREE = 1;
 
 const int Time::MIN_WAVEFORM_DEGREE = 0;
 
-const int Time::MAX_WAVEFORM_DEGREE = 3;
-
 } // namespace precice::time

--- a/src/time/Time.hpp
+++ b/src/time/Time.hpp
@@ -10,9 +10,6 @@ public:
 
   /// The minimum required interpolation degree.
   static const int MIN_WAVEFORM_DEGREE;
-
-  /// The maximum allowed interpolation degree.
-  static const int MAX_WAVEFORM_DEGREE;
 };
 
 } // namespace time


### PR DESCRIPTION
## Main changes of this PR

Allow arbitrary waveform degree by removing upper bound `MAX_WAVEFORM_DEGREE`

## Motivation and additional information

Closes #2038 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] ~~I added a test to cover the proposed changes in our test suite.~~
* [ ] ~~For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).~~
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
