### PR TITLE
Skip export handling if no exports are defined

### DIFF
--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1478,6 +1478,9 @@ void ParticipantImpl::performDataActions(const std::set<action::Action::Timing> 
 void ParticipantImpl::handleExports()
 {
   PRECICE_TRACE();
+  if (!_accessor->hasExports()) {
+    return;
+  }
   PRECICE_DEBUG("Handle exports");
   ParticipantState::IntermediateExport exp;
   exp.timewindow = _couplingScheme->getTimeWindows() - 1;

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -349,6 +349,11 @@ void ParticipantState::exportInitial()
   }
 }
 
+bool ParticipantState::hasExports() const
+{
+  return !_exportContexts.empty() || !_watchPoints.empty() || !_watchIntegrals.empty();
+}
+
 void ParticipantState::exportIntermediate(IntermediateExport exp)
 {
   for (const io::ExportContext &context : exportContexts()) {

--- a/src/precice/impl/ParticipantState.hpp
+++ b/src/precice/impl/ParticipantState.hpp
@@ -301,6 +301,9 @@ public:
 
   /// Returns all \ref ExportContext for exporting meshes and data.
   const std::vector<io::ExportContext> &exportContexts() const;
+
+  /// Returns true, if the participant has any exports enabled
+  bool hasExports() const;
   /// @}
 
   /// @name Error helpers


### PR DESCRIPTION
## Main changes of this PR

This PR adds a shortcut for skipping `ParticipantState::handleExports` if no exports are defined.
The `Handle exports` debug statement is now only logged if there are exports defined, including watchpoints and watchintegrals.

## Motivation and additional information

Less verbose and preparation for adding an export event

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
