### PR TITLE
Add handleExports event

### DIFF
--- a/docs/changelog/2041.md
+++ b/docs/changelog/2041.md
@@ -1,0 +1,1 @@
+- Added profiling event for handling exports, which can be a substantial part of `advance`.

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1482,6 +1482,7 @@ void ParticipantImpl::handleExports()
     return;
   }
   PRECICE_DEBUG("Handle exports");
+  profiling::Event e{"handleExports"};
   ParticipantState::IntermediateExport exp;
   exp.timewindow = _couplingScheme->getTimeWindows() - 1;
   exp.iteration  = _numberAdvanceCalls;

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1483,6 +1483,7 @@ void ParticipantImpl::handleExports()
   }
   PRECICE_DEBUG("Handle exports");
   profiling::Event e{"handleExports"};
+
   ParticipantState::IntermediateExport exp;
   exp.timewindow = _couplingScheme->getTimeWindows() - 1;
   exp.iteration  = _numberAdvanceCalls;


### PR DESCRIPTION
## Main changes of this PR

This PR adds a profiling event for handling exports.

## Motivation and additional information

When using `<export:X />` with bigger meshes, then the profiling trace occasionally contains a substantial gap at the end of `initialize` and `advance`, which can mostly be attributed to the exporters.
Adding the event carifies what time is spent in the potentially slow exports.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
