### PR TITLE
Cleanup exports in Participant

### DIFF
--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -328,8 +328,7 @@ void ParticipantImpl::initialize()
   mapInitialReadData();
   performDataActions({action::Action::READ_MAPPING_POST});
 
-  PRECICE_DEBUG("Plot output");
-  _accessor->exportInitial();
+  handleExports(ExportTiming::Initial);
 
   resetWrittenData();
 
@@ -450,7 +449,7 @@ void ParticipantImpl::handleDataAfterAdvance(bool reachedTimeWindowEnd, bool isT
     }
   }
 
-  handleExports();
+  handleExports(ExportTiming::Advance);
 }
 
 void ParticipantImpl::samplizeWriteData(double time)
@@ -1475,7 +1474,7 @@ void ParticipantImpl::performDataActions(const std::set<action::Action::Timing> 
   }
 }
 
-void ParticipantImpl::handleExports()
+void ParticipantImpl::handleExports(ExportTiming timing)
 {
   PRECICE_TRACE();
   if (!_accessor->hasExports()) {
@@ -1483,6 +1482,11 @@ void ParticipantImpl::handleExports()
   }
   PRECICE_DEBUG("Handle exports");
   profiling::Event e{"handleExports"};
+
+  if (timing == ExportTiming::Initial) {
+    _accessor->exportInitial();
+    return;
+  }
 
   ParticipantState::IntermediateExport exp;
   exp.timewindow = _couplingScheme->getTimeWindows() - 1;

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -360,8 +360,14 @@ private:
 
   void configureM2Ns(const m2n::M2NConfiguration::SharedPointer &config);
 
+  enum struct ExportTiming : bool {
+    Advance = false,
+    Initial = true
+  };
+
   /// Exports meshes with data and watch point data.
-  void handleExports();
+  /// @param[in] timing when the exports are requested
+  void handleExports(ExportTiming timing);
 
   /// Determines participants providing meshes to other participants.
   void configurePartitions(


### PR DESCRIPTION
## Main changes of this PR

This PR unifies the exporter handling in the `ParticipantImpl`.

## Motivation and additional information

The exports are now also profiled in `initialize` and the strange `Plot outputs` message has gone.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
