### PR TITLE
Add error for missing samples when initializing coupling schemes

### DIFF
--- a/docs/changelog/2044.md
+++ b/docs/changelog/2044.md
@@ -1,1 +1,1 @@
-- Added a configuration check for data which is send, but neither written nor mapped.
+- Added a configuration check for data which is sent, but neither written nor mapped.

--- a/docs/changelog/2044.md
+++ b/docs/changelog/2044.md
@@ -1,0 +1,1 @@
+- Added a configuration check for data which is send, but neither written nor mapped.

--- a/docs/changelog/2044.md
+++ b/docs/changelog/2044.md
@@ -1,1 +1,1 @@
-- Added a configuration check for data which is sent, but neither written nor mapped.
+- Added a configuration check for missing data samples, which may be caused by missing mappings or `write-data` tags.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -120,7 +120,10 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
 
   for (const auto &data : sendData | boost::adaptors::map_values) {
     const auto &stamples = data->stamples();
-    PRECICE_ASSERT(stamples.size() > 0);
+    PRECICE_CHECK(!stamples.empty(),
+                  "Data {0} on mesh {1} didn't contain any samples while attempting to send it to the coupling partner. "
+                  "Make sure participant {2} specifies data {0} to be written using tag <write-data mesh=\"{1}\" data=\"{0}\"/>.",
+                  data->getDataName(), data->getMeshName(), localParticipant());
 
     int nTimeSteps = data->timeStepsStorage().nTimes();
     PRECICE_ASSERT(nTimeSteps > 0);

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -122,7 +122,8 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
     const auto &stamples = data->stamples();
     PRECICE_CHECK(!stamples.empty(),
                   "Data {0} on mesh {1} didn't contain any samples while attempting to send it to the coupling partner. "
-                  "Make sure participant {2} specifies data {0} to be written using tag <write-data mesh=\"{1}\" data=\"{0}\"/>.",
+                  "Make sure participant {2} specifies data {0} to be written using tag <write-data mesh=\"{1}\" data=\"{0}\"/>. "
+                  "Alternatively, ensure participant {2} defines a mapping to mesh {1} from a mesh using data {0}.",
                   data->getDataName(), data->getMeshName(), localParticipant());
 
     int nTimeSteps = data->timeStepsStorage().nTimes();

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -120,11 +120,7 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
 
   for (const auto &data : sendData | boost::adaptors::map_values) {
     const auto &stamples = data->stamples();
-    PRECICE_CHECK(!stamples.empty(),
-                  "Data {0} on mesh {1} didn't contain any samples while attempting to send it to the coupling partner. "
-                  "Make sure participant {2} specifies data {0} to be written using tag <write-data mesh=\"{1}\" data=\"{0}\"/>. "
-                  "Alternatively, ensure participant {2} defines a mapping to mesh {1} from a mesh using data {0}.",
-                  data->getDataName(), data->getMeshName(), localParticipant());
+    PRECICE_ASSERT(!stamples.empty());
 
     int nTimeSteps = data->timeStepsStorage().nTimes();
     PRECICE_ASSERT(nTimeSteps > 0);
@@ -281,6 +277,8 @@ void BaseCouplingScheme::initialize()
   _time.resetTo(0);
   _timeWindows         = 1;
   _hasDataBeenReceived = false;
+
+  checkCouplingDataAvailable();
 
   if (isImplicitCouplingScheme()) {
     storeIteration();
@@ -613,6 +611,23 @@ void BaseCouplingScheme::checkCompletenessRequiredActions()
   _fulfilledActions.clear();
 }
 
+void BaseCouplingScheme::checkCouplingDataAvailable()
+{
+  PRECICE_TRACE();
+  for (const auto &data : _allData | boost::adaptors::map_values) {
+    if (data->getDirection() == CouplingData::Direction::Receive) {
+      PRECICE_ASSERT(!data->stamples().empty(), "initializeReceiveDataStorage() didn't initialize data correctly");
+    } else {
+      PRECICE_CHECK(!data->stamples().empty(),
+                    "Data {0} on mesh {1} doesn't contain any samples while initializing a coupling scheme of participant {2}. "
+                    "There are two common configuration issues that may cause this. "
+                    "Either, make sure participant {2} specifies data {0} to be written using tag <write-data mesh=\"{1}\" data=\"{0}\"/>. "
+                    "Or ensure participant {2} defines a mapping to mesh {1} from a mesh using data {0}.",
+                    data->getDataName(), data->getMeshName(), localParticipant());
+    }
+  }
+}
+
 void BaseCouplingScheme::setAcceleration(
     const acceleration::PtrAcceleration &acceleration)
 {
@@ -777,7 +792,13 @@ bool BaseCouplingScheme::reachedEndOfTimeWindow() const
 void BaseCouplingScheme::storeIteration()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme());
+
   for (const auto &data : _allData | boost::adaptors::map_values) {
+    PRECICE_CHECK(!data->stamples().empty(),
+                  "Data {0} on mesh {1} didn't contain any samples while attempting to send it to the coupling partner. "
+                  "Make sure participant {2} specifies data {0} to be written using tag <write-data mesh=\"{1}\" data=\"{0}\"/>. "
+                  "Alternatively, ensure participant {2} defines a mapping to mesh {1} from a mesh using data {0}.",
+                  data->getDataName(), data->getMeshName(), localParticipant());
     data->storeIteration();
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -533,6 +533,11 @@ private:
   void checkCompletenessRequiredActions();
 
   /**
+   * @brief Issues an error if coupling data does not contain stamples.
+   */
+  void checkCouplingDataAvailable();
+
+  /**
    * @brief Initialize txt writers for iterations and convergence tracking
    */
   void initializeTXTWriters();


### PR DESCRIPTION
## Main changes of this PR

This PR adds an error message when the user exchanges data which is not generated by the participant either via write-data tags or mappings.

## Motivation and additional information

Closes #1870

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
