### PR TITLE
Extend error mesage on undefined data

### DIFF
--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -105,8 +105,9 @@
 #define PRECICE_REQUIRE_DATA_READ_IMPL(mesh, data)                                                                             \
   PRECICE_VALIDATE_DATA_NAME_IMPL(mesh, data)                                                                                  \
   PRECICE_CHECK((_accessor->isDataRead(mesh, data)),                                                                           \
-                "This participant does not use Data \"{0}\", but attempted to read it. "                                       \
-                "Please extend the configuration of participant \"{1}\" by defining <read-data mesh=\"{2}\" name=\"{0}\" />.", \
+                "This participant does not use data \"{0}\" via mesh \"{2}\", but attempted to read it. "                                       \
+                "Please extend the configuration of participant \"{1}\" by defining <read-data mesh=\"{2}\" name=\"{0}\" /> "
+                "or check if the data is defined on this mesh.", \
                 data, _accessorName, mesh);
 
 /** Implementation of PRECICE_REQUIRE_DATA_WRITE()
@@ -116,8 +117,9 @@
 #define PRECICE_REQUIRE_DATA_WRITE_IMPL(mesh, data)                                                                             \
   PRECICE_VALIDATE_DATA_NAME_IMPL(mesh, data)                                                                                   \
   PRECICE_CHECK((_accessor->isDataWrite(mesh, data)),                                                                           \
-                "This participant does not use Data \"{0}\", but attempted to write it. "                                       \
-                "Please extend the configuration of participant \"{1}\" by defining <write-data mesh=\"{2}\" name=\"{0}\" />.", \
+                "This participant does not use data \"{0}\" via mesh \"{2}\", but attempted to write it. "                                       \
+                "Please extend the configuration of participant \"{1}\" by defining <write-data mesh=\"{2}\" name=\"{0}\" /> "
+                "or check if the data is defined on this mesh.", \
                 data, _accessorName, mesh);
 
 /** Validates a given dataID

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -102,24 +102,24 @@
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_REQUIRE_DATA_READ_IMPL(mesh, data)                                                                             \
-  PRECICE_VALIDATE_DATA_NAME_IMPL(mesh, data)                                                                                  \
-  PRECICE_CHECK((_accessor->isDataRead(mesh, data)),                                                                           \
-                "This participant does not use data \"{0}\" via mesh \"{2}\", but attempted to read it. "                                       \
-                "Please extend the configuration of participant \"{1}\" by defining <read-data mesh=\"{2}\" name=\"{0}\" /> "
-                "or check if the data is defined on this mesh.", \
+#define PRECICE_REQUIRE_DATA_READ_IMPL(mesh, data)                                                                            \
+  PRECICE_VALIDATE_DATA_NAME_IMPL(mesh, data)                                                                                 \
+  PRECICE_CHECK((_accessor->isDataRead(mesh, data)),                                                                          \
+                "This participant does not use data \"{0}\" via mesh \"{2}\", but attempted to read it. "                     \
+                "Please extend the configuration of participant \"{1}\" by defining <read-data mesh=\"{2}\" name=\"{0}\" /> " \
+                "or check if the data is defined on this mesh.",                                                              \
                 data, _accessorName, mesh);
 
 /** Implementation of PRECICE_REQUIRE_DATA_WRITE()
  *
  * @attention Do not use this macro directly!
  */
-#define PRECICE_REQUIRE_DATA_WRITE_IMPL(mesh, data)                                                                             \
-  PRECICE_VALIDATE_DATA_NAME_IMPL(mesh, data)                                                                                   \
-  PRECICE_CHECK((_accessor->isDataWrite(mesh, data)),                                                                           \
-                "This participant does not use data \"{0}\" via mesh \"{2}\", but attempted to write it. "                                       \
-                "Please extend the configuration of participant \"{1}\" by defining <write-data mesh=\"{2}\" name=\"{0}\" /> "
-                "or check if the data is defined on this mesh.", \
+#define PRECICE_REQUIRE_DATA_WRITE_IMPL(mesh, data)                                                                            \
+  PRECICE_VALIDATE_DATA_NAME_IMPL(mesh, data)                                                                                  \
+  PRECICE_CHECK((_accessor->isDataWrite(mesh, data)),                                                                          \
+                "This participant does not use data \"{0}\" via mesh \"{2}\", but attempted to write it. "                     \
+                "Please extend the configuration of participant \"{1}\" by defining <write-data mesh=\"{2}\" name=\"{0}\" /> " \
+                "or check if the data is defined on this mesh.",                                                               \
                 data, _accessorName, mesh);
 
 /** Validates a given dataID


### PR DESCRIPTION
## Main changes of this PR

I stumbled upon this error message:

```
--[precice] ERROR:  This participant does not use Data "Color", but attempted to write it. Please extend the configuration of participant "Generator-Right" by defining <write-data mesh="Generator-Right-Mesh" name="Color" />.
```

However, my problem was not that I had not used some data named "Color", but that I was using the wrong mesh.

This PR extends the error message to highlight that the mesh also matters.

## Motivation and additional information

The error message might be a bit misleading otherwise.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> Do we need one?
* I added a test to cover the proposed changes in our test suite. -> N/A
* For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> N/A
* I sticked to C++17 features. -> N/A
* I sticked to CMake version 3.22.1. -> N/A
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* Does the changelog entry make sense? Is it formatted correctly? -> N/A
* [ ] Do you understand the code changes? @fsimonis 

