### PR TITLE
Use HIP as CMake language

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,11 @@ if (PRECICE_FEATURE_GINKGO_MAPPING)
 
   # 2. Check if Ginkgo was built with HIP and if HIP is available on the system
   if(PRECICE_WITH_HIP)
+    include(CheckLanguage)
+    check_language(HIP)
+    enable_language(HIP)
+    set(CMAKE_HIP_STANDARD 17)
+    set(CMAKE_HIP_STANDARD_REQUIRED ON)
     if(NOT DEFINED HIP_PATH)
      if(NOT DEFINED $ENV{HIP_PATH})
        set(HIP_PATH "/opt/rocm/hip" CACHE PATH "Path to which HIP has been installed")
@@ -283,11 +288,7 @@ if (PRECICE_FEATURE_GINKGO_MAPPING)
      set(ENV{ROCM_PATH} ${ROCM_PATH})
     endif()
 
-    find_package(HIP REQUIRED)
     find_package(hipsolver REQUIRED)
-
-    set(HIP_CLANG_FLAGS "-fPIC -w")
-    set(HIP_NVCC_FLAGS "-fPIC")
   endif()
 
   if(PRECICE_WITH_OMP)


### PR DESCRIPTION
## Main changes of this PR

Makes use of CMake's `enable_language` for HIP.

## Motivation and additional information

Since CMake version 3.21, [HIP is handled as a language](https://cmake.org/cmake/help/latest/command/enable_language.html) by CMake. Due to our baseline upgrade, we can make use of this upgrade.

This was contributed by @MarcelKoch

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I sticked to CMake version 3.22.1.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
