### PR TITLE
Add precice user to docker releases

### DIFF
--- a/tools/releasing/packaging/docker/README.md
+++ b/tools/releasing/packaging/docker/README.md
@@ -2,6 +2,8 @@
 
 The point of these dockerfiles is to build a Ubuntu-based distribution of preCICE.
 
+All images contain the user `precice`, allowing them to run executables using MPI.
+
 ## Release images `release.dockerfile`
 
 This Dockerfile uses named releases of preCICE such as `2.1.1` and installs the attached debian package in the container.

--- a/tools/releasing/packaging/docker/nightly.dockerfile
+++ b/tools/releasing/packaging/docker/nightly.dockerfile
@@ -1,6 +1,8 @@
 # Dockerfile to build a ubuntu image containing the installed develop version of preCICE
 
 FROM ubuntu:22.04
+# Add the precice user
+RUN useradd -m -s /bin/bash precice
 ENV TZ=Europe/Berlin
 RUN apt-get update && \
     apt-get -yy upgrade && \

--- a/tools/releasing/packaging/docker/release.dockerfile
+++ b/tools/releasing/packaging/docker/release.dockerfile
@@ -1,6 +1,8 @@
 # Dockerfile to build a ubuntu image containing the installed Debian package of a release
 
 FROM ubuntu:22.04
+# Add the precice user
+RUN useradd -m -s /bin/bash precice
 # Fix the installation of tzdata for Ubuntu
 ARG TIMEZONE=Europe/Berlin
 RUN export TZ=$TIMEZONE && echo $TZ > /etc/timezone && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \


### PR DESCRIPTION
## Main changes of this PR

This PR adds the user `precice` to docker releases.


## Motivation and additional information

It's a minimally invasive way of running MPI programs in the container.

Closes https://github.com/precice/precice/issues/2031

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
