### PR TITLE
Refactor mesh information into exporters

### DIFF
--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -56,10 +56,15 @@ protected:
   {
     return _size > 1;
   };
-  std::string_view kindPrefix() const
+
+  std::string formatIndex(int index) const
   {
-    return (_kind == ExportKind::TimeWindows) ? "dt" : "it";
-  };
+    if (index == 0) {
+      return "init";
+    }
+    using std::string_literals::operator""s;
+    return ((_kind == ExportKind::TimeWindows) ? "dt"s : "it"s).append(std::to_string(index));
+  }
 
   std::string             _participantName;
   std::string             _location;

--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -66,6 +66,11 @@ protected:
     return ((_kind == ExportKind::TimeWindows) ? "dt"s : "it"s).append(std::to_string(index));
   }
 
+  bool keepExport(int index) const
+  {
+    return (_kind == ExportKind::Iterations) || ((_frequency > 0) && (index % _frequency == 0));
+  }
+
   std::string             _participantName;
   std::string             _location;
   const mesh::Mesh *const _mesh;

--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace precice {
 namespace mesh {
@@ -16,23 +17,57 @@ class Export {
 public:
   virtual ~Export() = default;
 
-  Export()               = default;
+  enum struct ExportKind : bool {
+    TimeWindows,
+    Iterations
+  };
+
+  Export(
+      std::string_view  participantName,
+      std::string_view  location,
+      const mesh::Mesh &mesh,
+      ExportKind        kind,
+      int               frequency,
+      int               rank,
+      int               size)
+      : _participantName(participantName),
+        _location(location),
+        _mesh(&mesh),
+        _kind(kind),
+        _frequency(frequency),
+        _rank(rank),
+        _size(size){};
+
   Export(const Export &) = delete;
   Export(Export &&)      = delete;
   Export &operator=(const Export &) = delete;
   Export &operator=(Export &&) = delete;
 
   /**
-   * @brief Does export. Has to be implemented in subclass.
+   * @brief Export the mesh and writes files.
    *
-   * @param[in] name Filename (without path).
-   * @param[in] location Location (path without filename).
-   * @param[in] mesh Mesh to be exported.
+   * @param[in] index the index of this iteration or time window
+   * @param[in] time the associated time of this time window
    */
-  virtual void doExport(
-      const std::string &name,
-      const std::string &location,
-      const mesh::Mesh & mesh) = 0;
+  virtual void doExport(int index, double time) = 0;
+
+protected:
+  bool isParallel() const
+  {
+    return _size > 1;
+  };
+  std::string_view kindPrefix() const
+  {
+    return (_kind == ExportKind::TimeWindows) ? "dt" : "it";
+  };
+
+  std::string             _participantName;
+  std::string             _location;
+  const mesh::Mesh *const _mesh;
+  ExportKind              _kind;
+  int                     _frequency;
+  int                     _rank;
+  int                     _size;
 };
 
 } // namespace io

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -68,11 +68,9 @@ void ExportCSV::doExport(int index, double time)
   }
   outfile /= filename;
 
-  const auto &mesh = *_mesh;
-
   // Prepare filestream
   std::ofstream outFile(outfile.string(), std::ios::trunc);
-  const bool    is3d = (mesh.getDimensions() == 3);
+  const bool    is3d = (_mesh->getDimensions() == 3);
 
   // write header
   outFile << "PosX;PosY";
@@ -80,10 +78,10 @@ void ExportCSV::doExport(int index, double time)
     outFile << ";PosZ";
   }
   outFile << ";Rank";
-  for (const auto &data : mesh.data()) {
+  for (const auto &data : _mesh->data()) {
     auto dataName = data->getName();
     auto dim      = data->getDimensions();
-    PRECICE_ASSERT(static_cast<std::size_t>(data->values().size()) == mesh.nVertices() * dim);
+    PRECICE_ASSERT(static_cast<std::size_t>(data->values().size()) == _mesh->nVertices() * dim);
     outFile << ';' << dataName;
     if (dim == 2) {
       outFile << "X;" << dataName << 'Y';
@@ -95,7 +93,7 @@ void ExportCSV::doExport(int index, double time)
 
   // Prepare writing data
   std::vector<StridedAccess> dataColumns;
-  for (const auto &data : mesh.data()) {
+  for (const auto &data : _mesh->data()) {
     auto    dim    = data->getDimensions();
     double *values = data->values().data();
     for (int i = 0; i < dim; ++i) {
@@ -105,9 +103,9 @@ void ExportCSV::doExport(int index, double time)
 
   // write vertex data
   const std::string rankCol = ";" + std::to_string(_rank);
-  const auto        size    = mesh.nVertices();
+  const auto        size    = _mesh->nVertices();
   for (std::size_t vid = 0; vid < size; ++vid) {
-    const auto &vertex = mesh.vertex(vid);
+    const auto &vertex = _mesh->vertex(vid);
     outFile << vertex.coord(0) << ';';
     outFile << vertex.coord(1);
     if (is3d) {

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -55,7 +55,7 @@ void ExportCSV::doExport(int index, double time)
   std::string filename;
   if (isParallel()) {
     // Participant-Mesh-r2.it2
-    filename = fmt::format("{}-{}-r{}.{}{}.csv", _participantName, _mesh->getName(), _rank, kindPrefix(), index);
+    filename = fmt::format("{}-{}.{}{}_{}.csv", _participantName, _mesh->getName(), _rank, kindPrefix(), index);
   } else {
     // Participant-Mesh.it2
     filename = fmt::format("{}-{}.{}{}.csv", _participantName, _mesh->getName(), kindPrefix(), index);

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -55,10 +55,10 @@ void ExportCSV::doExport(int index, double time)
   std::string filename;
   if (isParallel()) {
     // Participant-Mesh-r2.it2
-    filename = fmt::format("{}-{}.{}{}_{}.csv", _participantName, _mesh->getName(), _rank, kindPrefix(), index);
+    filename = fmt::format("{}-{}.{}_{}.csv", _participantName, _mesh->getName(), _rank, formatIndex(index));
   } else {
     // Participant-Mesh.it2
-    filename = fmt::format("{}-{}.{}{}.csv", _participantName, _mesh->getName(), kindPrefix(), index);
+    filename = fmt::format("{}-{}.{}.csv", _participantName, _mesh->getName(), formatIndex(index));
   }
 
   namespace fs = std::filesystem;

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -51,6 +51,9 @@ void ExportCSV::doExport(int index, double time)
   PRECICE_ASSERT(index >= 0);
   PRECICE_ASSERT(time >= 0.0);
 
+  if (!keepExport(index))
+    return;
+
   // Construct filename
   std::string filename;
   if (isParallel()) {

--- a/src/io/ExportCSV.hpp
+++ b/src/io/ExportCSV.hpp
@@ -9,10 +9,16 @@ namespace io {
 
 class ExportCSV : public Export {
 public:
-  virtual void doExport(
-      const std::string &name,
-      const std::string &location,
-      const mesh::Mesh & mesh);
+  ExportCSV(
+      std::string_view  participantName,
+      std::string_view  location,
+      const mesh::Mesh &mesh,
+      ExportKind        kind,
+      int               frequency,
+      int               rank,
+      int               size);
+
+  void doExport(int index, double time) final override;
 
 private:
   mutable logging::Logger _log{"io::ExportCSV"};

--- a/src/io/ExportContext.hpp
+++ b/src/io/ExportContext.hpp
@@ -14,6 +14,9 @@ struct ExportContext {
   // @brief Path to export location.
   std::string location;
 
+  // @brief Name of the mesh to export.
+  std::string meshName;
+
   // @brief Exporting every N time windows (equals -1 when not set).
   int everyNTimeWindows = -1;
 

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -34,6 +34,9 @@ void ExportVTK::doExport(int index, double time)
   PRECICE_ASSERT(time >= 0.0);
   PRECICE_ASSERT(!isParallel(), "ExportVTK only supports serial participants.");
 
+  if (!keepExport(index))
+    return;
+
   auto filename = fmt::format("{}-{}.{}.vtk", _participantName, _mesh->getName(), formatIndex(index));
 
   namespace fs = std::filesystem;

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -34,7 +34,7 @@ void ExportVTK::doExport(int index, double time)
   PRECICE_ASSERT(time >= 0.0);
   PRECICE_ASSERT(!isParallel(), "ExportVTK only supports serial participants.");
 
-  auto filename = fmt::format("{}-{}.{}{}.vtk", _participantName, _mesh->getName(), kindPrefix(), index);
+  auto filename = fmt::format("{}-{}.{}.vtk", _participantName, _mesh->getName(), formatIndex(index));
 
   namespace fs = std::filesystem;
   fs::path outfile(_location);

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -18,11 +18,17 @@ namespace io {
 /// Writes polygonal, or triangle meshes to vtk files.
 class ExportVTK : public Export {
 public:
+  ExportVTK(
+      std::string_view  participantName,
+      std::string_view  location,
+      const mesh::Mesh &mesh,
+      ExportKind        kind,
+      int               frequency,
+      int               rank,
+      int               size);
+
   /// Perform writing to VTK file
-  virtual void doExport(
-      const std::string &name,
-      const std::string &location,
-      const mesh::Mesh & mesh);
+  virtual void doExport(int index, double time);
 
   static void initializeWriting(
       std::ofstream &filestream);

--- a/src/io/ExportVTP.cpp
+++ b/src/io/ExportVTP.cpp
@@ -25,12 +25,12 @@ std::string ExportVTP::getVTKFormat() const
 
 std::string ExportVTP::getParallelExtension() const
 {
-  return ".pvtp";
+  return "pvtp";
 }
 
 std::string ExportVTP::getPieceExtension() const
 {
-  return ".vtp";
+  return "vtp";
 }
 
 std::string ExportVTP::getPieceAttributes(const mesh::Mesh &mesh) const

--- a/src/io/ExportVTP.cpp
+++ b/src/io/ExportVTP.cpp
@@ -7,6 +7,17 @@
 
 namespace precice::io {
 
+ExportVTP::ExportVTP(
+    std::string_view  participantName,
+    std::string_view  location,
+    const mesh::Mesh &mesh,
+    ExportKind        kind,
+    int               frequency,
+    int               rank,
+    int               size)
+
+    : ExportXML(participantName, location, mesh, kind, frequency, rank, size){};
+
 std::string ExportVTP::getVTKFormat() const
 {
   return "PolyData";

--- a/src/io/ExportVTP.hpp
+++ b/src/io/ExportVTP.hpp
@@ -25,6 +25,16 @@ namespace io {
  * The naming scheme allows to import these files into Paraview as time series.
  */
 class ExportVTP : public ExportXML {
+public:
+  ExportVTP(
+      std::string_view  participantName,
+      std::string_view  location,
+      const mesh::Mesh &mesh,
+      ExportKind        kind,
+      int               frequency,
+      int               rank,
+      int               size);
+
 private:
   mutable logging::Logger _log{"io::ExportVTP"};
 

--- a/src/io/ExportVTU.cpp
+++ b/src/io/ExportVTU.cpp
@@ -19,6 +19,17 @@
 
 namespace precice::io {
 
+ExportVTU::ExportVTU(
+    std::string_view  participantName,
+    std::string_view  location,
+    const mesh::Mesh &mesh,
+    ExportKind        kind,
+    int               frequency,
+    int               rank,
+    int               size)
+
+    : ExportXML(participantName, location, mesh, kind, frequency, rank, size){};
+
 std::string ExportVTU::getVTKFormat() const
 {
   return "UnstructuredGrid";

--- a/src/io/ExportVTU.cpp
+++ b/src/io/ExportVTU.cpp
@@ -37,12 +37,12 @@ std::string ExportVTU::getVTKFormat() const
 
 std::string ExportVTU::getParallelExtension() const
 {
-  return ".pvtu";
+  return "pvtu";
 }
 
 std::string ExportVTU::getPieceExtension() const
 {
-  return ".vtu";
+  return "vtu";
 }
 
 std::string ExportVTU::getPieceAttributes(const mesh::Mesh &mesh) const

--- a/src/io/ExportVTU.hpp
+++ b/src/io/ExportVTU.hpp
@@ -25,6 +25,16 @@ namespace io {
  * The naming scheme allows to import these files into Paraview as time series.
  */
 class ExportVTU : public ExportXML {
+public:
+  ExportVTU(
+      std::string_view  participantName,
+      std::string_view  location,
+      const mesh::Mesh &mesh,
+      ExportKind        kind,
+      int               frequency,
+      int               rank,
+      int               size);
+
 private:
   mutable logging::Logger _log{"io::ExportVTU"};
 

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -83,13 +83,13 @@ void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
 std::string ExportXML::parallelPieceFilenameFor(int index, int rank) const
 {
   PRECICE_ASSERT(isParallel());
-  return fmt::format("{}-{}.{}{}_{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, rank, getPieceExtension());
+  return fmt::format("{}-{}.{}_{}.{}", _participantName, _mesh->getName(), formatIndex(index), rank, getPieceExtension());
 }
 
 std::string ExportXML::serialPieceFilename(int index) const
 {
   PRECICE_ASSERT(!isParallel());
-  return fmt::format("{}-{}.{}{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, getPieceExtension());
+  return fmt::format("{}-{}.{}.{}", _participantName, _mesh->getName(), formatIndex(index), getPieceExtension());
 }
 
 void ExportXML::writeParallelFile(int index, double time) const
@@ -98,7 +98,7 @@ void ExportXML::writeParallelFile(int index, double time) const
 
   // Construct filename
   // Participant-Mesh.it_2.pvtu
-  auto filename = fmt::format("{}-{}.{}{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, getParallelExtension());
+  auto filename = fmt::format("{}-{}.{}.{}", _participantName, _mesh->getName(), formatIndex(index), getParallelExtension());
 
   namespace fs = std::filesystem;
   fs::path outfile(_location);

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -76,13 +76,13 @@ void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
   }
 }
 
-std::string ExportXML::parallelPieceFilenameFor(int index, int rank)
+std::string ExportXML::parallelPieceFilenameFor(int index, int rank) const
 {
   PRECICE_ASSERT(isParallel());
   return fmt::format("{}-{}-r{}.{}{}.{}", _participantName, _mesh->getName(), rank, kindPrefix(), index, getParallelExtension());
 }
 
-std::string ExportXML::serialPieceFilename(int index)
+std::string ExportXML::serialPieceFilename(int index) const
 {
   PRECICE_ASSERT(!isParallel());
   return fmt::format("{}-{}.{}{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, getParallelExtension());

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -34,6 +34,9 @@ void ExportXML::doExport(int index, double time)
 {
   PRECICE_TRACE(index, time, _mesh->getName());
 
+  if (!keepExport(index))
+    return;
+
   const auto &mesh = *_mesh;
 
   processDataNamesAndDimensions(mesh);

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -83,13 +83,13 @@ void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
 std::string ExportXML::parallelPieceFilenameFor(int index, int rank) const
 {
   PRECICE_ASSERT(isParallel());
-  return fmt::format("{}-{}-r{}.{}_{}.{}", _participantName, _mesh->getName(), rank, kindPrefix(), index, getPieceExtension());
+  return fmt::format("{}-{}.{}{}_{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, rank, getPieceExtension());
 }
 
 std::string ExportXML::serialPieceFilename(int index) const
 {
   PRECICE_ASSERT(!isParallel());
-  return fmt::format("{}-{}.{}_{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, getPieceExtension());
+  return fmt::format("{}-{}.{}{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, getPieceExtension());
 }
 
 void ExportXML::writeParallelFile(int index, double time) const
@@ -98,7 +98,7 @@ void ExportXML::writeParallelFile(int index, double time) const
 
   // Construct filename
   // Participant-Mesh.it_2.pvtu
-  auto filename = fmt::format("{}-{}.{}_{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, getParallelExtension());
+  auto filename = fmt::format("{}-{}.{}{}.{}", _participantName, _mesh->getName(), kindPrefix(), index, getParallelExtension());
 
   namespace fs = std::filesystem;
   fs::path outfile(_location);

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -158,16 +158,14 @@ void ExportXML::writeSubFile(int index, double time) const
 
   outSubFile << "   <" << formatType << ">\n";
 
-  const auto &mesh = *_mesh;
+  outSubFile << "      <Piece " << getPieceAttributes(*_mesh) << "> \n";
+  exportPoints(outSubFile, *_mesh);
 
-  outSubFile << "      <Piece " << getPieceAttributes(mesh) << "> \n";
-  exportPoints(outSubFile, mesh);
-
-  // Write Mesh
-  exportConnectivity(outSubFile, mesh);
+  // Write *_mesh
+  exportConnectivity(outSubFile, *_mesh);
 
   // Write data
-  exportData(outSubFile, mesh);
+  exportData(outSubFile, *_mesh);
 
   outSubFile << "      </Piece>\n";
   outSubFile << "   </" << formatType << "> \n";

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -97,6 +97,9 @@ private:
       const mesh::Mesh &mesh) const;
 
   void exportGradient(const mesh::PtrData data, const int dataDim, std::ostream &outFile) const;
+
+  std::string parallelPieceFilenameFor(int index, int rank) const;
+  std::string serialPieceFilename(int index) const;
 };
 
 } // namespace io

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -23,10 +23,16 @@ namespace io {
 /// Common class to generate the VTK XML-based formats.
 class ExportXML : public Export {
 public:
-  void doExport(
-      const std::string &name,
-      const std::string &location,
-      const mesh::Mesh & mesh) override;
+  ExportXML(
+      std::string_view  participantName,
+      std::string_view  location,
+      const mesh::Mesh &mesh,
+      ExportKind        kind,
+      int               frequency,
+      int               rank,
+      int               size);
+
+  void doExport(int index, double time) final override;
 
   static void writeVertex(
       const Eigen::VectorXd &position,
@@ -67,10 +73,7 @@ private:
   /**
    * @brief Writes the primary file (called only by the primary rank)
    */
-  void writeParallelFile(
-      const std::string &name,
-      const std::string &location,
-      const mesh::Mesh & mesh) const;
+  void writeParallelFile(int index, double time) const;
 
   virtual void writeParallelCells(std::ostream &out) const = 0;
 
@@ -79,10 +82,7 @@ private:
   /**
    * @brief Writes the sub file for each rank
    */
-  void writeSubFile(
-      const std::string &name,
-      const std::string &location,
-      const mesh::Mesh & mesh) const;
+  void writeSubFile(int index, double time) const;
 
   void exportPoints(
       std::ostream &    outFile,

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {
   PRECICE_TEST(""_on(1_rank).setupIntraComm());
   int           dim = 2;
-  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportPolygonalMeshSerial", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -36,17 +36,15 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportCSV exportCSV;
-  std::string   filename = "io-CSVExport-ExportPolygonalMesh";
-  std::string   location = "";
-  exportCSV.doExport(filename, location, mesh);
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 2;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
@@ -71,17 +69,15 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportCSV exportCSV;
-  std::string   filename = "io-ExportCSVTest-testExportPolygonalMesh";
-  std::string   location = "";
-  exportCSV.doExport(filename, location, mesh);
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 3;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportTriangulatedMesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
@@ -109,17 +105,15 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportCSV exportCSV;
-  std::string   filename = "io-ExportCSVTest-testExportTriangulatedMesh";
-  std::string   location = "";
-  exportCSV.doExport(filename, location, mesh);
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 3;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportSplitSquare", dim, testing::nextMeshID());
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
@@ -170,10 +164,8 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportCSV exportCSV;
-  std::string   filename = "io-ExportCSVTest-Square";
-  std::string   location = "";
-  exportCSV.doExport(filename, location, mesh);
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -47,6 +47,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
 
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTK.doExport(0, 0.0);
+  exportVTK.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
@@ -64,6 +65,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTK.doExport(0, 0.0);
+  exportVTK.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
@@ -82,6 +84,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTK.doExport(0, 0.0);
+  exportVTK.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTetrahedron)
@@ -98,6 +101,7 @@ BOOST_AUTO_TEST_CASE(ExportTetrahedron)
 
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTK.doExport(0, 0.0);
+  exportVTK.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // ExportVTK

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   PRECICE_TEST(1_rank)
   int dimensions = 2;
   // Create mesh to map from
-  mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportDataWithGradient", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", 2, 1_dataID);
   dataScalar->requireDataGradient();
@@ -44,17 +44,16 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   Eigen::MatrixXd &gradientsVector = dataVector->gradients();
   gradientsScalar.setOnes();
   gradientsVector.setOnes();
-  io::ExportVTK exportVTK;
-  std::string   filename = "io-VTKExport-ExportDatawithGradient";
-  std::string   location = "";
-  exportVTK.doExport(filename, location, mesh);
+
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTK.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(1_rank);
   int           dim = 2;
-  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1.0));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -63,17 +62,15 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportVTK exportVTK;
-  std::string   filename = "io-VTKExport-ExportPolygonalMesh";
-  std::string   location = "";
-  exportVTK.doExport(filename, location, mesh);
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTK.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(1_rank);
   int           dim = 3;
-  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportTriangulatedMesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d::Constant(1.0));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
@@ -83,17 +80,15 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   mesh::Edge &e3 = mesh.createEdge(v3, v1);
   mesh.createTriangle(e1, e2, e3);
 
-  io::ExportVTK exportVTK;
-  std::string   filename = "io-VTKExport-ExportTriangulatedMesh";
-  std::string   location = "";
-  exportVTK.doExport(filename, location, mesh);
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTK.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTetrahedron)
 {
   PRECICE_TEST(1_rank);
   int           dim = 3;
-  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportTetrahedron", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{0.0, 1.0, 0.0});
@@ -101,10 +96,8 @@ BOOST_AUTO_TEST_CASE(ExportTetrahedron)
 
   mesh.createTetrahedron(v1, v2, v3, v4);
 
-  io::ExportVTK exportVTK;
-  std::string   filename = "io-VTKExport-ExportTetrahedron";
-  std::string   location = "";
-  exportVTK.doExport(filename, location, mesh);
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTK.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // ExportVTK

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -51,6 +51,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTP.doExport(0, 0.0);
+  exportVTP.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
@@ -82,6 +83,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTP.doExport(0, 0.0);
+  exportVTP.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
@@ -99,6 +101,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTP.doExport(0, 0.0);
+  exportVTP.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
@@ -130,8 +133,9 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  exportVTP.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
@@ -166,8 +170,9 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  exportVTP.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportSplitSquare)
@@ -225,8 +230,9 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  exportVTP.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   PRECICE_TEST(1_rank)
   const int dimensions = 2;
   // Create mesh to map from
-  mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportDataWithGradient2D", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -48,10 +48,9 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   Eigen::MatrixXd &gradientsVector = dataVector->gradients();
   gradientsScalar.setOnes();
   gradientsVector.setOnes();
-  io::ExportVTP exportVTP;
-  std::string   filename = "io-VTPExport-ExportDatawithGradient" + std::to_string(dimensions);
-  std::string   location = "";
-  exportVTP.doExport(filename, location, mesh);
+
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
@@ -59,7 +58,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   PRECICE_TEST(1_rank)
   const int dimensions = 3;
   // Create mesh to map from
-  mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportDataWithGradient3D", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -80,17 +79,16 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   Eigen::MatrixXd &gradientsVector = dataVector->gradients();
   gradientsScalar.setOnes();
   gradientsVector.setOnes();
-  io::ExportVTP exportVTP;
-  std::string   filename = "io-VTPExport-ExportDatawithGradient" + std::to_string(dimensions);
-  std::string   location = "";
-  exportVTP.doExport(filename, location, mesh);
+
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {
   PRECICE_TEST(""_on(1_rank).setupIntraComm());
   int           dim = 2;
-  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportPolygonalMeshSerial", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -99,17 +97,15 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportVTP exportVTP;
-  std::string   filename = "io-VTPExport-ExportPolygonalMesh";
-  std::string   location = "";
-  exportVTP.doExport(filename, location, mesh);
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 2;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
@@ -134,17 +130,15 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportVTP exportVTP;
-  std::string   filename = "io-ExportVTPTest-testExportPolygonalMesh";
-  std::string   location = "";
-  exportVTP.doExport(filename, location, mesh);
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 3;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("TriangulatedMesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
@@ -172,17 +166,15 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportVTP exportVTP;
-  std::string   filename = "io-ExportVTPTest-testExportTriangulatedMesh";
-  std::string   location = "";
-  exportVTP.doExport(filename, location, mesh);
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 3;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("SplitSquare", dim, testing::nextMeshID());
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
@@ -233,10 +225,8 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportVTP exportVTP;
-  std::string   filename = "io-ExportVTPTest-Square";
-  std::string   location = "";
-  exportVTP.doExport(filename, location, mesh);
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -52,6 +52,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   gradientsVector.setOnes();
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
@@ -83,6 +84,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   gradientsVector.setOnes();
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
@@ -100,6 +102,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
@@ -132,8 +135,9 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
@@ -169,8 +173,9 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportSplitSquare)
@@ -228,8 +233,9 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportOneTetrahedron)
@@ -244,8 +250,9 @@ BOOST_AUTO_TEST_CASE(ExportOneTetrahedron)
 
   mesh.createTetrahedron(v0, v1, v2, v3);
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
@@ -287,8 +294,9 @@ BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
     mesh.createTetrahedron(v000, v100, v110, v111);
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  exportVTU.doExport(1, 1.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 
   // Create mesh to map from
   int           dimensions = 2;
-  mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportDatawithGradient2D", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -50,10 +50,8 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   Eigen::MatrixXd &gradientsVector = dataVector->gradients();
   gradientsScalar.setOnes();
   gradientsVector.setOnes();
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-VTUExport-ExportDatawithGradient" + std::to_string(dimensions);
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
@@ -61,7 +59,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   PRECICE_TEST(1_rank)
   int dimensions = 3;
   // Create mesh to map from
-  mesh::Mesh    mesh("MyMesh", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportDatawithGradient3D", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -83,17 +81,15 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   Eigen::MatrixXd &gradientsVector = dataVector->gradients();
   gradientsScalar.setOnes();
   gradientsVector.setOnes();
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-VTUExport-ExportDatawithGradient" + std::to_string(dimensions);
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {
   PRECICE_TEST(""_on(1_rank).setupIntraComm());
   int           dim = 2;
-  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportPolygonalMeshSerial", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -102,17 +98,15 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-VTUExport-ExportPolygonalMesh";
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 2;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
@@ -138,17 +132,15 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-ExportVTUTest-testExportPolygonalMesh";
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 3;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportTriangulatedMesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
@@ -177,17 +169,15 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-ExportVTUTest-testExportTriangulatedMesh";
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 {
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 3;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportSplitSquare", dim, testing::nextMeshID());
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
@@ -238,17 +228,15 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-ExportVTUTest-Square";
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportOneTetrahedron)
 {
   PRECICE_TEST(""_on(1_rank).setupIntraComm());
   int           dim = 3;
-  mesh::Mesh    mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("ExportOneTetrahedron", dim, testing::nextMeshID());
   mesh::Vertex &v0 = mesh.createVertex(Eigen::Vector3d::Zero());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{0.0, 1.0, 0.0});
@@ -256,10 +244,8 @@ BOOST_AUTO_TEST_CASE(ExportOneTetrahedron)
 
   mesh.createTetrahedron(v0, v1, v2, v3);
 
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-VTUExport-ExportOneTetrahedron";
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
@@ -268,7 +254,7 @@ BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
   // as well as en empty rank. Empty rank is the 3rd
   PRECICE_TEST(""_on(4_ranks).setupIntraComm());
   int        dim = 3;
-  mesh::Mesh mesh("MyMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("ExportPartitionedCube", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v000 = mesh.createVertex(Eigen::Vector3d{0.0, 0.0, 0.0});
@@ -301,10 +287,8 @@ BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
     mesh.createTetrahedron(v000, v100, v110, v111);
   }
 
-  io::ExportVTU exportVTU;
-  std::string   filename = "io-ExportVTUTest-PartitionedCube";
-  std::string   location = "";
-  exportVTU.doExport(filename, location, mesh);
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -407,8 +407,8 @@ void PartitionOfUnityMapping<RADIAL_BASIS_FUNCTION_T>::exportClusterCentersAsVTU
     centerMesh.setVertexOffsets(std::move(vertexOffsets));
   }
 
-  io::ExportVTU exporter;
-  exporter.doExport(centerMesh.getName(), "exports", centerMesh);
+  io::ExportVTU exporter{"PoU", "exports", centerMesh, io::Export::ExportKind::TimeWindows, 1, utils::IntraComm::getRank(), utils::IntraComm::getSize()};
+  exporter.doExport(0, 0.0);
 }
 
 template <typename RADIAL_BASIS_FUNCTION_T>

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -276,6 +276,19 @@ void Mesh::clearPartitioning()
   _globalNumberOfVertices = 0;
 }
 
+bool Mesh::isPartitionEmpty(Rank rank) const
+{
+  // Without offset data, we assume non-empty partititions
+  if (_vertexOffsets.empty()) {
+    return false;
+  }
+  PRECICE_ASSERT(_vertexOffsets.size() >= static_cast<std::size_t>(rank));
+  if (rank == 0) {
+    return _vertexOffsets[0] == 0;
+  }
+  return _vertexOffsets[rank] - _vertexOffsets[rank - 1] == 0;
+}
+
 Eigen::VectorXd Mesh::getOwnedVertexData(const Eigen::VectorXd &values)
 {
   std::vector<double> ownedDataVector;

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -250,6 +250,9 @@ public:
     return _vertexOffsets;
   }
 
+  /// checks if the given ranks partition is empty
+  bool isPartitionEmpty(Rank rank) const;
+
   /// Only used for tests
   void setVertexOffsets(VertexOffsets vertexOffsets)
   {

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -591,7 +591,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
   // Add export contexts
   for (io::ExportContext &exportContext : _exportConfig->exportContexts()) {
-    auto kind = exportContext.everyIteration ? io::Export::ExportKind::Iterations : io::Export::ExportKind::Iterations;
+    auto kind = exportContext.everyIteration ? io::Export::ExportKind::Iterations : io::Export::ExportKind::TimeWindows;
     // Create one exporter per mesh
     for (const auto &meshContext : participant->usedMeshContexts()) {
 

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -653,6 +653,10 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
       _participants.back()->addExportContext(exportContext);
     }
+    PRECICE_WARN_IF(exportContext.everyNTimeWindows > 1 && exportContext.everyIteration,
+                    "Participant {} defines an exporter of type {} which exports every iteration. "
+                    "This overrides the every-n-time-window value you provided.",
+                    _participants.back()->getName(), exportContext.type);
   }
   _exportConfig->resetExports();
 

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -354,14 +354,14 @@ bool ParticipantState::hasExports() const
 void ParticipantState::exportIntermediate(IntermediateExport exp)
 {
   for (const io::ExportContext &context : exportContexts()) {
-    if (exp.complete) {
-      PRECICE_DEBUG("Exporting mesh {} for timewindow {} to location \"{}\"", context.meshName, exp.timewindow, context.location);
-      context.exporter->doExport(exp.timewindow, exp.time);
-    }
-
     if (context.everyIteration) {
       PRECICE_DEBUG("Exporting mesh {} for iteration {} to location \"{}\"", context.meshName, exp.iteration, context.location);
       context.exporter->doExport(exp.iteration, exp.time);
+      continue;
+    }
+    if (exp.complete) {
+      PRECICE_DEBUG("Exporting mesh {} for timewindow {} to location \"{}\"", context.meshName, exp.timewindow, context.location);
+      context.exporter->doExport(exp.timewindow, exp.time);
     }
   }
 

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -357,21 +357,14 @@ bool ParticipantState::hasExports() const
 void ParticipantState::exportIntermediate(IntermediateExport exp)
 {
   for (const io::ExportContext &context : exportContexts()) {
-    if (exp.complete && (context.everyNTimeWindows > 0) && (exp.timewindow % context.everyNTimeWindows == 0)) {
-      for (const MeshContext *meshContext : usedMeshContexts()) {
-        auto &mesh = *meshContext->mesh;
-        PRECICE_DEBUG("Exporting mesh {} for timewindow {} to location \"{}\"", mesh.getName(), exp.timewindow, context.location);
-        context.exporter->doExport(fmt::format("{}-{}.dt{}", mesh.getName(), getName(), exp.timewindow), context.location, mesh);
-      }
+    if (exp.complete) {
+      //PRECICE_DEBUG("Exporting mesh {} for timewindow {} to location \"{}\"",  .getName(), exp.timewindow, context.location);
+      context.exporter->export(exp.timewindow, exp.time);
     }
 
     if (context.everyIteration) {
-      for (const MeshContext *meshContext : usedMeshContexts()) {
-        auto &mesh = *meshContext->mesh;
-        PRECICE_DEBUG("Exporting mesh {} for iteration {} to location \"{}\"", meshContext->mesh->getName(), exp.iteration, context.location);
-        /// @todo this is the global iteration count. Shouldn't this be local to the timestep? example .dtN.itM or similar
-        context.exporter->doExport(fmt::format("{}-{}.it{}", mesh.getName(), getName(), exp.iteration), context.location, mesh);
-      }
+      PRECICE_DEBUG("Exporting mesh {} for iteration {} to location \"{}\"", meshContext->mesh->getName(), exp.iteration, context.location);
+      context.exporter->export(exp.iteration, exp.time);
     }
   }
 

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -341,11 +341,8 @@ void ParticipantState::exportInitial()
       continue;
     }
 
-    for (const MeshContext *meshContext : usedMeshContexts()) {
-      auto &mesh = *meshContext->mesh;
-      PRECICE_DEBUG("Exporting initial mesh {} to location \"{}\"", mesh.getName(), context.location);
-      context.exporter->doExport(fmt::format("{}-{}.init", mesh.getName(), getName()), context.location, mesh);
-    }
+    PRECICE_DEBUG("Exporting initial mesh {} to location \"{}\"", context.meshName, context.location);
+    context.exporter->doExport(0, 0.0);
   }
 }
 
@@ -358,13 +355,13 @@ void ParticipantState::exportIntermediate(IntermediateExport exp)
 {
   for (const io::ExportContext &context : exportContexts()) {
     if (exp.complete) {
-      //PRECICE_DEBUG("Exporting mesh {} for timewindow {} to location \"{}\"",  .getName(), exp.timewindow, context.location);
-      context.exporter->export(exp.timewindow, exp.time);
+      PRECICE_DEBUG("Exporting mesh {} for timewindow {} to location \"{}\"", context.meshName, exp.timewindow, context.location);
+      context.exporter->doExport(exp.timewindow, exp.time);
     }
 
     if (context.everyIteration) {
-      PRECICE_DEBUG("Exporting mesh {} for iteration {} to location \"{}\"", meshContext->mesh->getName(), exp.iteration, context.location);
-      context.exporter->export(exp.iteration, exp.time);
+      PRECICE_DEBUG("Exporting mesh {} for iteration {} to location \"{}\"", context.meshName, exp.iteration, context.location);
+      context.exporter->doExport(exp.iteration, exp.time);
     }
   }
 


### PR DESCRIPTION
## Main changes of this PR

This PR refactors the mesh, parallel context, and location into the exporters.
Hence, there is now one `Exporter` instance per mesh.

## Motivation and additional information

This simplifies the participant and the handling of filenames.
It also allows adding `series` files #1991.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
