### PR TITLE
Add series to exporter

### DIFF
--- a/docs/changelog/2055.md
+++ b/docs/changelog/2055.md
@@ -1,0 +1,1 @@
+- Added Paraview series files to most exporters of tine windows. This makes loading exports easier and assigns the correct time stamps to them.

--- a/docs/changelog/2055.md
+++ b/docs/changelog/2055.md
@@ -1,1 +1,1 @@
-- Added Paraview series files to most exporters of tine windows. This makes loading exports easier and assigns the correct time stamps to them.
+- Added Paraview series files to most exporters of time windows. This makes loading exports easier and assigns the correct time stamps to them.

--- a/docs/changelog/2055.md
+++ b/docs/changelog/2055.md
@@ -1,1 +1,1 @@
-- Added Paraview series files to most exporters of time windows. This makes loading exports easier and assigns the correct time stamps to them.
+- Added Paraview series files to `vtk`, `vtu`, and `vtp` exporters when exporting time windows. This makes loading exports easier and assigns the correct time stamps to them.

--- a/src/io/Export.cpp
+++ b/src/io/Export.cpp
@@ -1,0 +1,49 @@
+#include "io/Export.hpp"
+#include <filesystem>
+#include "utils/fmt.hpp"
+
+namespace precice::io {
+
+bool Export::isParallel() const
+{
+  return _size > 1;
+};
+
+std::string Export::formatIndex(int index) const
+{
+  if (index == 0) {
+    return "init";
+  }
+  using std::string_literals::operator""s;
+  return ((_kind == ExportKind::TimeWindows) ? "dt"s : "it"s).append(std::to_string(index));
+}
+
+void Export::writeSeriesFile(std::string_view filename) const
+{
+  if (_records.empty())
+    return;
+
+  namespace fs = std::filesystem;
+  fs::path outfile(_location);
+  if (not _location.empty()) {
+    fs::create_directories(outfile);
+  }
+  outfile /= filename;
+
+  // Prepare filestream
+  std::ofstream outFile(outfile.string(), std::ios::trunc);
+
+  outFile << R"({ "file-series-version" : "1.0", "files" : [)";
+
+  for (std::size_t i = 0; i < _records.size() - 1; ++i) {
+    outFile << fmt::format(R"( {{ "name" : "{}", "time" : {} }},)", _records[i].filename, _records[i].time);
+  }
+  outFile << fmt::format(R"( {{ "name" : "{}", "time" : {} }} ] }})", _records.back().filename, _records.back().time);
+}
+
+void Export::recordExport(std::string filename, double time)
+{
+  _records.push_back(Record{filename, time});
+}
+
+} // namespace precice::io

--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace precice {
 namespace mesh {
@@ -51,20 +52,12 @@ public:
    */
   virtual void doExport(int index, double time) = 0;
 
-protected:
-  bool isParallel() const
-  {
-    return _size > 1;
-  };
+  virtual void exportSeries() const = 0;
 
-  std::string formatIndex(int index) const
-  {
-    if (index == 0) {
-      return "init";
-    }
-    using std::string_literals::operator""s;
-    return ((_kind == ExportKind::TimeWindows) ? "dt"s : "it"s).append(std::to_string(index));
-  }
+protected:
+  bool isParallel() const;
+
+  std::string formatIndex(int index) const;
 
   bool keepExport(int index) const
   {
@@ -78,6 +71,17 @@ protected:
   int                     _frequency;
   int                     _rank;
   int                     _size;
+
+  struct Record {
+    std::string filename;
+    double      time;
+  };
+
+  std::vector<Record> _records;
+
+  void writeSeriesFile(std::string_view filename) const;
+
+  void recordExport(std::string filename, double time);
 };
 
 } // namespace io

--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -123,4 +123,9 @@ void ExportCSV::doExport(int index, double time)
   }
 }
 
+void ExportCSV::exportSeries() const
+{
+  // not supported by paraview
+}
+
 } // namespace precice::io

--- a/src/io/ExportCSV.hpp
+++ b/src/io/ExportCSV.hpp
@@ -20,6 +20,8 @@ public:
 
   void doExport(int index, double time) final override;
 
+  void exportSeries() const final override;
+
 private:
   mutable logging::Logger _log{"io::ExportCSV"};
 };

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -53,6 +53,15 @@ void ExportVTK::doExport(int index, double time)
   exportData(outstream, *_mesh);
   exportGradient(outstream, *_mesh);
   outstream.close();
+  recordExport(filename, time);
+}
+
+void ExportVTK::exportSeries() const
+{
+  if (isParallel())
+    return; // there is no parallel master file
+
+  writeSeriesFile(fmt::format("{}-{}.vtk.series", _participantName, _mesh->getName()));
 }
 
 void ExportVTK::exportMesh(

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -28,7 +28,9 @@ public:
       int               size);
 
   /// Perform writing to VTK file
-  virtual void doExport(int index, double time);
+  void doExport(int index, double time) final override;
+
+  void exportSeries() const final override;
 
   static void initializeWriting(
       std::ofstream &filestream);

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -34,6 +34,8 @@ public:
 
   void doExport(int index, double time) final override;
 
+  void exportSeries() const final override;
+
   static void writeVertex(
       const Eigen::VectorXd &position,
       std::ostream &         outFile);
@@ -73,7 +75,7 @@ private:
   /**
    * @brief Writes the primary file (called only by the primary rank)
    */
-  void writeParallelFile(int index, double time) const;
+  void writeParallelFile(int index, double time);
 
   virtual void writeParallelCells(std::ostream &out) const = 0;
 
@@ -82,7 +84,7 @@ private:
   /**
    * @brief Writes the sub file for each rank
    */
-  void writeSubFile(int index, double time) const;
+  void writeSubFile(int index, double time);
 
   void exportPoints(
       std::ostream &    outFile,

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1492,6 +1492,7 @@ void ParticipantImpl::handleExports(ExportTiming timing)
   exp.timewindow = _couplingScheme->getTimeWindows() - 1;
   exp.iteration  = _numberAdvanceCalls;
   exp.complete   = _couplingScheme->isTimeWindowComplete();
+  exp.final      = !_couplingScheme->isCouplingOngoing();
   exp.time       = _couplingScheme->getTime();
   _accessor->exportIntermediate(exp);
 }

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -363,6 +363,10 @@ void ParticipantState::exportIntermediate(IntermediateExport exp)
       PRECICE_DEBUG("Exporting mesh {} for timewindow {} to location \"{}\"", context.meshName, exp.timewindow, context.location);
       context.exporter->doExport(exp.timewindow, exp.time);
     }
+    if (exp.final) {
+      PRECICE_DEBUG("Exporting seried file of mesh {} to location \"{}\"", context.meshName, context.location);
+      context.exporter->exportSeries();
+    }
   }
 
   if (exp.complete) {

--- a/src/precice/impl/ParticipantState.hpp
+++ b/src/precice/impl/ParticipantState.hpp
@@ -266,6 +266,7 @@ public:
     size_t iteration;
     double time;
     bool   complete;
+    bool   final;
   };
 
   /// Exports timewindows and iterations of meshes and watchpoints

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -124,6 +124,7 @@ target_sources(preciceCore
     src/cplscheme/impl/SharedPointer.hpp
     src/cplscheme/impl/TimeHandler.cpp
     src/cplscheme/impl/TimeHandler.hpp
+    src/io/Export.cpp
     src/io/Export.hpp
     src/io/ExportCSV.cpp
     src/io/ExportCSV.hpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds series files to exporters exporting time windows.

## Motivation and additional information

This allows opening series from the terminal using paraview.
It also assigns the correct timestamp to every export.

Series for iterations are not possible as paraview cannot handle repeated time stamps.

Closes #1991

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
