### PR TITLE
Fix communicator name in M2N

### DIFF
--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -18,8 +18,8 @@ extern bool syncMode;
 
 namespace m2n {
 
-M2N::M2N(com::PtrCommunication intraComm, DistributedComFactory::SharedPointer distrFactory, bool useOnlyPrimaryCom, bool useTwoLevelInit)
-    : _interComm(std::move(intraComm)),
+M2N::M2N(com::PtrCommunication interComm, DistributedComFactory::SharedPointer distrFactory, bool useOnlyPrimaryCom, bool useTwoLevelInit)
+    : _interComm(std::move(interComm)),
       _distrFactory(std::move(distrFactory)),
       _useOnlyPrimaryCom(useOnlyPrimaryCom),
       _useTwoLevelInit(useTwoLevelInit)

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -226,6 +226,7 @@ private:
   /// mesh::getID() -> Pointer to distributed communication
   std::map<int, DistributedCommunication::SharedPointer> _distComs;
 
+  /// connection between the primary ranks of the connected participants
   com::PtrCommunication _interComm;
 
   DistributedComFactory::SharedPointer _distrFactory;

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -226,7 +226,7 @@ private:
   /// mesh::getID() -> Pointer to distributed communication
   std::map<int, DistributedCommunication::SharedPointer> _distComs;
 
-  com::PtrCommunication _intraComm;
+  com::PtrCommunication _interComm;
 
   DistributedComFactory::SharedPointer _distrFactory;
 


### PR DESCRIPTION
## Main changes of this PR

This PR corrects the name of the communicator stored in M2N.

## Motivation and additional information

Wrong names are bad names.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
