### PR TITLE
Error on no read samples

### DIFF
--- a/docs/changelog/2064.md
+++ b/docs/changelog/2064.md
@@ -1,0 +1,1 @@
+- Added an error message for data that is read but never mapped or exchanged.

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -108,6 +108,11 @@ bool Data::hasGradient() const
   return _hasGradient;
 }
 
+bool Data::hasSamples() const
+{
+  return !_waveform.stamples().empty();
+}
+
 void Data::requireDataGradient()
 {
   _hasGradient = true;

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -117,6 +117,9 @@ public:
   /// Returns if the data contains gradient data
   bool hasGradient() const;
 
+  /// Returns if there are sample of this data
+  bool hasSamples() const;
+
   /// Set the additional requirement of gradient data
   void requireDataGradient();
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1076,9 +1076,14 @@ void ParticipantImpl::readData(
     return;
   }
 
-  ReadDataContext &context          = _accessor->readDataContext(meshName, dataName);
-  const auto       dataDims         = context.getDataDimensions();
-  const auto       expectedDataSize = vertices.size() * dataDims;
+  ReadDataContext &context = _accessor->readDataContext(meshName, dataName);
+  PRECICE_CHECK(context.hasSamples(), "Data \"{}\" cannot be read from mesh \"{}\" as it contains no samples. "
+                                      "This is typically a configuration issue of the data flow. "
+                                      "Check if the data is correctly exchanged to this participant \"{}\" and mapped to mesh \"{}\".",
+                dataName, meshName, _accessorName, meshName);
+
+  const auto dataDims         = context.getDataDimensions();
+  const auto expectedDataSize = vertices.size() * dataDims;
   PRECICE_CHECK(expectedDataSize == values.size(),
                 "Input/Output sizes are inconsistent attempting to read {}D data \"{}\" from mesh \"{}\". "
                 "You passed {} vertices and {} data components, but we expected {} data components ({} x {}).",

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -23,6 +23,11 @@ void ReadDataContext::appendMappingConfiguration(MappingContext &mappingContext,
   PRECICE_ASSERT(hasReadMapping());
 }
 
+bool ReadDataContext::hasSamples() const
+{
+  return _providedData->hasSamples();
+}
+
 void ReadDataContext::readValues(::precice::span<const VertexID> vertices, double readTime, ::precice::span<double> values) const
 {
   Eigen::Map<Eigen::MatrixXd>       outputData(values.data(), getDataDimensions(), values.size());

--- a/src/precice/impl/ReadDataContext.hpp
+++ b/src/precice/impl/ReadDataContext.hpp
@@ -54,6 +54,9 @@ public:
    */
   void readValues(::precice::span<const VertexID> vertices, double time, ::precice::span<double> values) const;
 
+  /// Are there samples to read from?
+  bool hasSamples() const;
+
   /// Disable copy construction
   ReadDataContext(const ReadDataContext &copy) = delete;
 

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -190,6 +190,7 @@ std::pair<Eigen::VectorXd, Eigen::MatrixXd> Storage::getTimesAndValues() const
 
 Eigen::VectorXd Storage::sample(double time) const
 {
+  PRECICE_ASSERT(this->nTimes() != 0, "There are no samples available");
   const int usedDegree = computeUsedDegree(_degree, nTimes());
 
   if (usedDegree == 0) {


### PR DESCRIPTION
## Main changes of this PR

This PR adds a more refined assertion for this problem when sampling and adds an error message for preventing this assertion from triggering.

The new error reads:
```
ERROR:
Data "Data-Three" cannot be read from mesh "SolverOne-Mesh" as it contains no samples.
This is generally a configuration issue of the data flow.
Check if the data is correctly exchanged to this participant"SolverOne" and mapping to mesh "SolverOne-Mesh".
```

## Motivation and additional information

Closes #2063

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
