### PR TITLE
Add simple exceptions

### DIFF
--- a/extras/bindings/c/src/preciceC.cpp
+++ b/extras/bindings/c/src/preciceC.cpp
@@ -31,13 +31,15 @@ void precicec_createParticipant_withCommunicator(
     int         solverProcessIndex,
     int         solverProcessSize,
     void *      communicator)
-{
+try {
   PRECICE_CHECK(impl == nullptr, errormsgCreate);
   impl.reset(new precice::Participant(participantName,
                                       configFileName,
                                       solverProcessIndex,
                                       solverProcessSize,
                                       communicator));
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_createParticipant(
@@ -45,102 +47,130 @@ void precicec_createParticipant(
     const char *configFileName,
     int         solverProcessIndex,
     int         solverProcessSize)
-{
+try {
   PRECICE_CHECK(impl == nullptr, errormsgCreate);
   impl.reset(new precice::Participant(participantName,
                                       configFileName,
                                       solverProcessIndex,
                                       solverProcessSize));
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_initialize()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->initialize();
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_advance(double computedTimeStepSize)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->advance(computedTimeStepSize);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_finalize()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->finalize();
   impl.reset();
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_getMeshDimensions(const char *meshName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   return impl->getMeshDimensions(meshName);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_getDataDimensions(const char *meshName, const char *dataName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   return impl->getDataDimensions(meshName, dataName);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_isCouplingOngoing()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->isCouplingOngoing()) {
     return 1;
   }
   return 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_isTimeWindowComplete()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->isTimeWindowComplete()) {
     return 1;
   }
   return 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 double precicec_getMaxTimeStepSize()
-{
+try {
   return impl->getMaxTimeStepSize();
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_requiresInitialData()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   return impl->requiresInitialData() ? 1 : 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_requiresWritingCheckpoint()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   return impl->requiresWritingCheckpoint() ? 1 : 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_requiresReadingCheckpoint()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   return impl->requiresReadingCheckpoint() ? 1 : 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_requiresMeshConnectivityFor(const char *meshName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->requiresMeshConnectivityFor(meshName)) {
     return 1;
   }
   return 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_setMeshVertex(
     const char *  meshName,
     const double *position)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto size = static_cast<long unsigned>(impl->getMeshDimensions(meshName));
   return impl->setMeshVertex(meshName, {position, size});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshVertices(
@@ -148,37 +178,45 @@ void precicec_setMeshVertices(
     int           size,
     const double *positions,
     int *         ids)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto idsSize = static_cast<long unsigned>(size);
   auto posSize = static_cast<long unsigned>(impl->getMeshDimensions(meshName) * size);
   impl->setMeshVertices(meshName, {positions, posSize}, {ids, idsSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_getMeshVertexSize(
     const char *meshName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   return impl->getMeshVertexSize(meshName);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshEdge(
     const char *meshName,
     int         firstVertexID,
     int         secondVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshEdge(meshName, firstVertexID, secondVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshEdges(
     const char *meshName,
     int         size,
     const int * vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto verticesSize = static_cast<long unsigned>(size) * 2;
   impl->setMeshEdges(meshName, {vertices, verticesSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshTriangle(
@@ -186,19 +224,23 @@ void precicec_setMeshTriangle(
     int         firstVertexID,
     int         secondVertexID,
     int         thirdVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshTriangle(meshName, firstVertexID, secondVertexID, thirdVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshTriangles(
     const char *meshName,
     int         size,
     const int * vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto verticesSize = static_cast<long unsigned>(size) * 3;
   impl->setMeshTriangles(meshName, {vertices, verticesSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshQuad(
@@ -207,19 +249,23 @@ void precicec_setMeshQuad(
     int         secondVertexID,
     int         thirdVertexID,
     int         fourthVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshQuad(meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshQuads(
     const char *meshName,
     int         size,
     const int * vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto verticesSize = static_cast<long unsigned>(size) * 4;
   impl->setMeshQuads(meshName, {vertices, verticesSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshTetrahedron(
@@ -228,19 +274,23 @@ void precicec_setMeshTetrahedron(
     int         secondVertexID,
     int         thirdVertexID,
     int         fourthVertexID)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshTetrahedron(meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshTetrahedra(
     const char *meshName,
     int         size,
     const int * vertices)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto verticesSize = static_cast<long unsigned>(size) * 4;
   impl->setMeshTetrahedra(meshName, {vertices, verticesSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_writeData(
@@ -249,10 +299,12 @@ void precicec_writeData(
     int           size,
     const int *   valueIndices,
     const double *values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto dataSize = size * impl->getDataDimensions(meshName, dataName);
   impl->writeData(meshName, dataName, {valueIndices, static_cast<unsigned long>(size)}, {values, static_cast<unsigned long>(dataSize)});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_readData(
@@ -262,20 +314,24 @@ void precicec_readData(
     const int * valueIndices,
     double      relativeReadTime,
     double *    values)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto dataSize = size * impl->getDataDimensions(meshName, dataName);
   impl->readData(meshName, dataName, {valueIndices, static_cast<unsigned long>(size)}, relativeReadTime, {values, static_cast<unsigned long>(dataSize)});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precicec_requiresGradientDataFor(const char *meshName,
                                      const char *dataName)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->requiresGradientDataFor(meshName, dataName)) {
     return 1;
   }
   return 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_writeGradientData(
@@ -284,24 +340,30 @@ void precicec_writeGradientData(
     int           size,
     const int *   valueIndices,
     const double *gradients)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto gradientComponents = impl->getDataDimensions(meshName, dataName) * impl->getMeshDimensions(meshName);
   auto gradientSize       = size * gradientComponents;
   impl->writeGradientData(meshName, dataName, {valueIndices, static_cast<unsigned long>(size)}, {gradients, static_cast<unsigned long>(gradientSize)});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 const char *precicec_getVersionInformation()
-{
+try {
   return precice::versionInformation;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_setMeshAccessRegion(
     const char *  meshName,
     const double *boundingBox)
-{
+try {
   auto bbSize = static_cast<long unsigned>(impl->getMeshDimensions(meshName)) * 2;
   impl->setMeshAccessRegion(meshName, {boundingBox, bbSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicec_getMeshVertexIDsAndCoordinates(
@@ -309,9 +371,11 @@ void precicec_getMeshVertexIDsAndCoordinates(
     const int   size,
     int *       ids,
     double *    coordinates)
-{
+try {
   auto coordinatesSize = static_cast<long unsigned>(impl->getMeshDimensions(meshName) * size);
   impl->getMeshVertexIDsAndCoordinates(meshName, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 #ifdef __GNUC__

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -45,41 +45,51 @@ void precicef_create_(
     const int * solverProcessSize,
     int         participantNameLength,
     int         configFileNameLength)
-{
+try {
   impl.reset(new precice::Participant(
       precice::impl::strippedStringView(participantName, participantNameLength),
       precice::impl::strippedStringView(configFileName, configFileNameLength),
       *solverProcessIndex,
       *solverProcessSize));
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_initialize_()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->initialize();
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_advance_(
     const double *timeStepSize)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->advance(*timeStepSize);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_finalize_()
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->finalize();
   impl.reset();
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_get_mesh_dimensions_(
     const char *meshName,
     int *       dimensions,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   *dimensions = impl->getMeshDimensions(precice::impl::strippedStringView(meshName, meshNameLength));
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_get_data_dimensions_(
@@ -88,72 +98,88 @@ void precicef_get_data_dimensions_(
     int *       dimensions,
     int         meshNameLength,
     int         dataNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   *dimensions = impl->getDataDimensions(precice::impl::strippedStringView(meshName, meshNameLength), precice::impl::strippedStringView(dataName, dataNameLength));
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_is_coupling_ongoing_(
     int *isOngoing)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->isCouplingOngoing()) {
     *isOngoing = 1;
   } else {
     *isOngoing = 0;
   }
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_is_time_window_complete_(
     int *isComplete)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->isTimeWindowComplete()) {
     *isComplete = 1;
   } else {
     *isComplete = 0;
   }
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_get_max_time_step_size_(
     double *maxTimeStepSize)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   *maxTimeStepSize = impl->getMaxTimeStepSize();
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_requires_initial_data_(
     int *isRequired)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   *isRequired = impl->requiresInitialData() ? 1 : 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_requires_writing_checkpoint_(
     int *isRequired)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   *isRequired = impl->requiresWritingCheckpoint() ? 1 : 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_requires_reading_checkpoint_(
     int *isRequired)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   *isRequired = impl->requiresReadingCheckpoint() ? 1 : 0;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_requires_mesh_connectivity_for_(
     const char *meshName,
     int *       required,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->requiresMeshConnectivityFor(precice::impl::strippedStringView(meshName, meshNameLength))) {
     *required = 1;
   } else {
     *required = 0;
   }
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_vertex_(
@@ -161,20 +187,24 @@ void precicef_set_vertex_(
     const double *position,
     int *         vertexID,
     int           meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto sv           = precice::impl::strippedStringView(meshName, meshNameLength);
   auto positionSize = static_cast<unsigned long>(impl->getMeshDimensions(sv));
   *vertexID         = impl->setMeshVertex(sv, {position, positionSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_get_mesh_vertex_size_(
     const char *meshName,
     int *       meshSize,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   *meshSize = impl->getMeshVertexSize(precice::impl::strippedStringView(meshName, meshNameLength));
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_vertices_(
@@ -183,11 +213,13 @@ void precicef_set_vertices_(
     double *    coordinates,
     int *       ids,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto sv           = precice::impl::strippedStringView(meshName, meshNameLength);
   auto positionSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * *size);
   impl->setMeshVertices(sv, {coordinates, positionSize}, {ids, static_cast<unsigned long>(*size)});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_edge_(
@@ -195,9 +227,11 @@ void precicef_set_edge_(
     const int * firstVertexID,
     const int * secondVertexID,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshEdge(precice::impl::strippedStringView(meshName, meshNameLength), *firstVertexID, *secondVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_mesh_edges_(
@@ -205,10 +239,12 @@ void precicef_set_mesh_edges_(
     const int * size,
     const int * ids,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto idsSize = static_cast<unsigned long>(*size) * 2;
   impl->setMeshEdges(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_triangle_(
@@ -217,9 +253,11 @@ void precicef_set_triangle_(
     const int * secondVertexID,
     const int * thirdVertexID,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshTriangle(precice::impl::strippedStringView(meshName, meshNameLength), *firstVertexID, *secondVertexID, *thirdVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_mesh_triangles_(
@@ -227,10 +265,12 @@ void precicef_set_mesh_triangles_(
     const int * size,
     const int * ids,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto idsSize = static_cast<unsigned long>(*size) * 3;
   impl->setMeshTriangles(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_quad_(
@@ -240,9 +280,11 @@ void precicef_set_quad_(
     const int * thirdVertexID,
     const int * fourthVertexID,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshQuad(precice::impl::strippedStringView(meshName, meshNameLength), *firstVertexID, *secondVertexID, *thirdVertexID, *fourthVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_mesh_quads_(
@@ -250,10 +292,12 @@ void precicef_set_mesh_quads_(
     const int * size,
     const int * ids,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto idsSize = static_cast<unsigned long>(*size) * 4;
   impl->setMeshQuads(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_tetrahedron(
@@ -263,9 +307,11 @@ void precicef_set_tetrahedron(
     const int * thirdVertexID,
     const int * fourthVertexID,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   impl->setMeshTetrahedron(precice::impl::strippedStringView(meshName, meshNameLength), *firstVertexID, *secondVertexID, *thirdVertexID, *fourthVertexID);
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_mesh_tetrahedra_(
@@ -273,10 +319,12 @@ void precicef_set_mesh_tetrahedra_(
     const int * size,
     const int * ids,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto idsSize = static_cast<unsigned long>(*size) * 4;
   impl->setMeshTetrahedra(precice::impl::strippedStringView(meshName, meshNameLength), {ids, idsSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_write_data_(
@@ -287,7 +335,7 @@ void precicef_write_data_(
     double *    values,
     int         meshNameLength,
     int         dataNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto strippedMeshName = precice::impl::strippedStringView(meshName, meshNameLength);
   auto strippedDataName = precice::impl::strippedStringView(dataName, dataNameLength);
@@ -296,6 +344,8 @@ void precicef_write_data_(
                   strippedDataName,
                   {ids, static_cast<unsigned long>(*size)},
                   {values, static_cast<unsigned long>(dataSize)});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_read_data_(
@@ -307,7 +357,7 @@ void precicef_read_data_(
     double *      values,
     int           meshNameLength,
     int           dataNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto strippedMeshName = precice::impl::strippedStringView(meshName, meshNameLength);
   auto strippedDataName = precice::impl::strippedStringView(dataName, dataNameLength);
@@ -318,33 +368,41 @@ void precicef_read_data_(
       {ids, static_cast<unsigned long>(*size)},
       *relativeReadTime,
       {values, static_cast<unsigned long>(dataSize)});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 int precice::impl::strippedLength(
     const char *string,
     int         length)
-{
+try {
   int i = length - 1;
   while (((string[i] == ' ') || (string[i] == 0)) && (i >= 0)) {
     i--;
   }
   return i + 1;
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 std::string_view precice::impl::strippedStringView(const char *string, int length)
-{
+try {
   return {string, static_cast<std::string_view::size_type>(strippedLength(string, length))};
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_get_version_information_(
     char *versionInfo,
     int   lengthVersionInfo)
-{
+try {
   const std::string &versionInformation = precice::versionInformation;
   PRECICE_ASSERT(versionInformation.size() < (size_t) lengthVersionInfo, versionInformation.size(), lengthVersionInfo);
   for (size_t i = 0; i < versionInformation.size(); i++) {
     versionInfo[i] = versionInformation[i];
   }
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_requires_gradient_data_for_(
@@ -352,13 +410,15 @@ void precicef_requires_gradient_data_for_(
     const char *dataName, int *required,
     int meshNameLength,
     int dataNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   if (impl->requiresGradientDataFor(precice::impl::strippedStringView(meshName, meshNameLength), precice::impl::strippedStringView(dataName, dataNameLength))) {
     *required = 1;
   } else {
     *required = 0;
   }
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_write_gradient_data_(
@@ -369,7 +429,7 @@ void precicef_write_gradient_data_(
     const double *gradients,
     int           meshNameLength,
     int           dataNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto strippedMeshName   = precice::impl::strippedStringView(meshName, meshNameLength);
   auto strippedDataName   = precice::impl::strippedStringView(dataName, dataNameLength);
@@ -380,17 +440,21 @@ void precicef_write_gradient_data_(
                           strippedDataName,
                           {ids, static_cast<unsigned long>(*size)},
                           {gradients, static_cast<unsigned long>(gradientSize)});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_set_mesh_access_region_(
     const char *  meshName,
     const double *boundingBox,
     int           meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto sv     = precice::impl::strippedStringView(meshName, meshNameLength);
   auto bbSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * 2);
   impl->setMeshAccessRegion(sv, {boundingBox, bbSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 void precicef_get_mesh_vertex_ids_and_coordinates_(
@@ -399,11 +463,13 @@ void precicef_get_mesh_vertex_ids_and_coordinates_(
     int *       ids,
     double *    coordinates,
     int         meshNameLength)
-{
+try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto sv              = precice::impl::strippedStringView(meshName, meshNameLength);
   auto coordinatesSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * size);
   impl->getMeshVertexIDsAndCoordinates(sv, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
+} catch (::precice::Error &e) {
+  std::abort();
 }
 
 #ifdef __GNUC__

--- a/src/logging/LogMacros.hpp
+++ b/src/logging/LogMacros.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "precice/exceptions.hpp"
 #include "utils/fmt.hpp"
 
 #define PRECICE_LOG_LOCATION     \
@@ -12,11 +13,7 @@
 
 #define PRECICE_INFO(...) _log.info(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
 
-#define PRECICE_ERROR(...)                                                          \
-  do {                                                                              \
-    _log.error(PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__)); \
-    std::exit(-1);                                                                  \
-  } while (false)
+#define PRECICE_ERROR(...) ::precice::logging::logErrorAndThrow<::precice::Error>(_log, PRECICE_LOG_LOCATION, precice::utils::format_or_error(__VA_ARGS__))
 
 #define PRECICE_WARN_IF(condition, ...) \
   do {                                  \

--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <string_view>
 
 namespace precice::logging {
@@ -43,6 +44,14 @@ private:
   /// Pimpl to the logger implementation
   std::unique_ptr<LoggerImpl> _impl;
 };
+
+/// Utility function to log an error and throw an exception of given type
+template <class Error>
+inline void logErrorAndThrow(precice::logging::Logger &log, precice::logging::LogLocation location, const std::string &message)
+{
+  log.error(location, message);
+  throw Error{message};
+}
 
 } // namespace precice::logging
 

--- a/src/precice/exceptions.hpp
+++ b/src/precice/exceptions.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdexcept>
+
+#include "precice/export.h"
+
+namespace precice {
+
+class PRECICE_API Error : public std::runtime_error {
+public:
+  Error(const std::string &what_arg)
+      : std::runtime_error(what_arg){};
+};
+
+} // namespace precice

--- a/src/precice/precice.hpp
+++ b/src/precice/precice.hpp
@@ -2,4 +2,5 @@
 
 #include <precice/Participant.hpp>
 #include <precice/Version.h>
+#include <precice/exceptions.hpp>
 #include <precice/span.hpp>

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -256,6 +256,7 @@ target_sources(preciceCore
     src/precice/config/ParticipantConfiguration.cpp
     src/precice/config/ParticipantConfiguration.hpp
     src/precice/config/SharedPointer.hpp
+    src/precice/exceptions.hpp
     src/precice/impl/CommonErrorMessages.hpp
     src/precice/impl/DataContext.cpp
     src/precice/impl/DataContext.hpp
@@ -353,6 +354,7 @@ set_property(TARGET precice PROPERTY PUBLIC_HEADER
     src/precice/Participant.hpp
     src/precice/Tooling.hpp
     src/precice/Types.hpp
+    src/precice/exceptions.hpp
     src/precice/precice.hpp
     src/precice/span.hpp
     )

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -132,6 +132,8 @@ ConfigParser::ConfigParser(std::string_view filePath, const ConfigurationContext
 
   try {
     connectTags(context, DefTags, SubTags);
+  } catch (::precice::Error) {
+    throw;
   } catch (const std::exception &e) {
     PRECICE_ERROR("An unexpected exception occurred during configuration: {}.", e.what());
   }

--- a/tests/serial/lifecycle/ConstructNoConfig.cpp
+++ b/tests/serial/lifecycle/ConstructNoConfig.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+BOOST_AUTO_TEST_CASE(ConstructNoConfig)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  // tests a missing configuration file
+  BOOST_CHECK_THROW((precice::Participant{context.name, context.config(), context.rank, context.size}), ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/ConstructNullComm.cpp
+++ b/tests/serial/lifecycle/ConstructNullComm.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+BOOST_AUTO_TEST_CASE(ConstructNullComm)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  // tests passing null as communicator
+  BOOST_CHECK_THROW((precice::Participant{context.name, context.config(), context.rank, 3, nullptr}), ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/ConstructNullComm.xml
+++ b/tests/serial/lifecycle/ConstructNullComm.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration wait-in-finalize="yes">
+  <data:vector name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/serial/lifecycle/ConstructWrongCommSize.cpp
+++ b/tests/serial/lifecycle/ConstructWrongCommSize.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Lifecycle)
+BOOST_AUTO_TEST_CASE(ConstructWrongCommSize)
+{
+  PRECICE_TEST("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank));
+  // tests non-matching communicator sizes
+  BOOST_CHECK_THROW((precice::Participant{context.name, context.config(), context.rank, 3}), ::precice::Error);
+
+  BOOST_CHECK_THROW((precice::Participant{context.name, context.config(), context.rank, 5, context.comm()}), ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Lifecycle
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/lifecycle/ConstructWrongCommSize.xml
+++ b/tests/serial/lifecycle/ConstructWrongCommSize.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration wait-in-finalize="yes">
+  <data:vector name="DataOne" />
+  <data:scalar name="DataTwo" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="5" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -143,6 +143,7 @@ target_sources(testprecice
     tests/serial/initialize-data/helpers.cpp
     tests/serial/initialize-data/helpers.hpp
     tests/serial/lifecycle/ConstructAndExplicitFinalize.cpp
+    tests/serial/lifecycle/ConstructNoConfig.cpp
     tests/serial/lifecycle/ConstructOnly.cpp
     tests/serial/lifecycle/ConstructOnlyWait.cpp
     tests/serial/lifecycle/Full.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -146,6 +146,7 @@ target_sources(testprecice
     tests/serial/lifecycle/ConstructNoConfig.cpp
     tests/serial/lifecycle/ConstructOnly.cpp
     tests/serial/lifecycle/ConstructOnlyWait.cpp
+    tests/serial/lifecycle/ConstructWrongCommSize.cpp
     tests/serial/lifecycle/Full.cpp
     tests/serial/lifecycle/FullWait.cpp
     tests/serial/lifecycle/ImplicitFinalize.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -144,6 +144,7 @@ target_sources(testprecice
     tests/serial/initialize-data/helpers.hpp
     tests/serial/lifecycle/ConstructAndExplicitFinalize.cpp
     tests/serial/lifecycle/ConstructNoConfig.cpp
+    tests/serial/lifecycle/ConstructNullComm.cpp
     tests/serial/lifecycle/ConstructOnly.cpp
     tests/serial/lifecycle/ConstructOnlyWait.cpp
     tests/serial/lifecycle/ConstructWrongCommSize.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR changes the preCICE C++ API to throw a `precice::Error` from `precice/exceptions.hpp` instead of calling `std::abort` on error.
The new header is also part of the `precice/precice.hpp` header.

The C and Fortran APIs internally catch this exception and abort, hence maintaining previous behaviour.

I added tests that construct `Participant` with a missing config, passing null as communicator, and with an incorrect size.
The latter was actually incorrectly checked and lead to an assertion before the check was performed, so I also included the fix.

To use:

```cpp
BOOST_CHECK_THROW(mythingtotest(), ::precice::Error);
```

To check the message too:

```cpp
BOOST_CHECK_EXCEPTION(mythingtotest(), ::precice::Error, [](auto&e){ return strstr(e.what(), "match this") != nullptr;  });
```

## Motivation and additional information

We can now finally test failing inputs. 

Part of #280
Replaces #1594
Closes #1189

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
