### PR TITLE
Upgrade clang format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 repos:
 # Official repo for the clang-format hook
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: 'v8.0.1'
+  rev: 'v18.1.8'
   hooks:
   - id: clang-format
     exclude: "^thirdparty"
+    types_or: [c, c++]
 # Official repo for default hooks
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: 'v4.3.0'


### PR DESCRIPTION
## Main changes of this PR

This PR upgrades the clang format hook to the latest version 18.1.8.

Once we are ready to apply this, we need to rebase the PR, apply the formatting, and commit the changes.

## Motivation and additional information

The configuration remains unchanged, yet the pointer alignment now works in more cases, which visually changes many function signatures.

The previous version assumes `setuptools` to be installed, which was removed from newer python versions.
https://github.com/precice/precice-pre-commit-hooks/pull/2

Replaces https://github.com/precice/precice/pull/1276 except for the style changes.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
