### PR TITLE
Conservative unity builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ option(PRECICE_ALWAYS_VALIDATE_LIBS "Validate libraries even after the validatat
 option(PRECICE_BINDINGS_C "Enable the native C bindings" ON)
 option(PRECICE_BINDINGS_FORTRAN "Enable the native Fortran bindings" ON)
 option(PRECICE_BUILD_TOOLS "Build the \"precice-tools\" executable" ON)
+option(PRECICE_BUILD_UNITY "Use unity builds in preCICE" ON)
 option(PRECICE_FEATURE_LIBBACKTRACE_STACKTRACES "Enable libbacktrace for stacktrace generation." OFF)
 
 option(CMAKE_INTERPROCEDURAL_OPTIMIZATION "Enable interprocedural optimization for all targets." OFF)
@@ -357,8 +358,6 @@ set_target_properties(preciceCore PROPERTIES
   POSITION_INDEPENDENT_CODE YES
   CXX_VISIBILITY_PRESET default
   VISIBILITY_INLINES_HIDDEN NO
-  UNITY_BUILD Yes
-  UNITY_BUILD_MODE GROUP
   )
 
 if(NOT ${Kokkos_VERSION} VERSION_LESS 4.4)
@@ -523,13 +522,19 @@ configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJE
 configure_file("${PROJECT_SOURCE_DIR}/src/testing/SourceLocation.hpp.in" "${PROJECT_BINARY_DIR}/src/testing/SourceLocation.hpp" @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
 
-get_target_property(_precice_sources preciceCore SOURCES)
-foreach(SOURCE_FILE IN LISTS _precice_sources)
-  if(SOURCE_FILE MATCHES "^src/([a-z0-9]+)/")
-    set_source_files_properties(${SOURCE_FILE} PROPERTIES UNITY_GROUP "${CMAKE_MATCH_1}")
-  endif()
-endforeach()
-unset(_precice_sources)
+if(PRECICE_BUILD_UNITY)
+  set_target_properties(preciceCore PROPERTIES
+    UNITY_BUILD Yes
+    UNITY_BUILD_MODE GROUP
+  )
+  get_target_property(_precice_sources preciceCore SOURCES)
+  foreach(SOURCE_FILE IN LISTS _precice_sources)
+    if(SOURCE_FILE MATCHES "^src/([a-z0-9]+)/")
+      set_source_files_properties(${SOURCE_FILE} PROPERTIES UNITY_GROUP "${CMAKE_MATCH_1}")
+    endif()
+  endforeach()
+  unset(_precice_sources)
+endif()
 
 # Configure version file generation
 include(GenerateVersionInformation)
@@ -582,8 +587,6 @@ IF (BUILD_TESTING)
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED Yes
     CXX_EXTENSIONS No
-    UNITY_BUILD Yes
-    UNITY_BUILD_MODE GROUP
     )
   target_include_directories(testprecice PRIVATE
     ${preCICE_SOURCE_DIR}/src
@@ -595,13 +598,19 @@ IF (BUILD_TESTING)
   include(${CMAKE_CURRENT_LIST_DIR}/src/tests.cmake)
   include(${CMAKE_CURRENT_LIST_DIR}/tests/tests.cmake)
 
-  # Add integration tests from tests/ sources to a single unity group
-  get_target_property(_testprecice_sources testprecice SOURCES)
-  foreach(SOURCE_FILE IN LISTS _testprecice_sources)
-    if(SOURCE_FILE MATCHES "^tests/")
-      set_source_files_properties(${SOURCE_FILE} PROPERTIES UNITY_GROUP "integration")
-    endif()
-  endforeach()
+  if(PRECICE_BUILD_UNITY)
+    set_target_properties(testprecice PROPERTIES
+      UNITY_BUILD Yes
+      UNITY_BUILD_MODE GROUP
+      )
+    # Add integration tests from tests/ sources to a single unity group
+    get_target_property(_testprecice_sources testprecice SOURCES)
+    foreach(SOURCE_FILE IN LISTS _testprecice_sources)
+      if(SOURCE_FILE MATCHES "^tests/")
+        set_source_files_properties(${SOURCE_FILE} PROPERTIES UNITY_GROUP "integration")
+      endif()
+    endforeach()
+  endif()
 
 else(BUILD_TESTING)
   message(STATUS "Excluding test sources")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,8 @@ set_target_properties(preciceCore PROPERTIES
   POSITION_INDEPENDENT_CODE YES
   CXX_VISIBILITY_PRESET default
   VISIBILITY_INLINES_HIDDEN NO
+  UNITY_BUILD Yes
+  UNITY_BUILD_MODE GROUP
   )
 
 if(NOT ${Kokkos_VERSION} VERSION_LESS 4.4)
@@ -520,6 +522,14 @@ include(${CMAKE_CURRENT_LIST_DIR}/src/sources.cmake)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/impl/versions.hpp.in" "${PROJECT_BINARY_DIR}/src/precice/impl/versions.hpp" @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/src/testing/SourceLocation.hpp.in" "${PROJECT_BINARY_DIR}/src/testing/SourceLocation.hpp" @ONLY)
 configure_file("${PROJECT_SOURCE_DIR}/src/precice/Version.h.in" "${PROJECT_BINARY_DIR}/src/precice/Version.h" @ONLY)
+
+get_target_property(_precice_sources preciceCore SOURCES)
+foreach(SOURCE_FILE IN LISTS _precice_sources)
+  if(SOURCE_FILE MATCHES "^src/([a-z0-9]+)/")
+    set_source_files_properties(${SOURCE_FILE} PROPERTIES UNITY_GROUP "${CMAKE_MATCH_1}")
+  endif()
+endforeach()
+unset(_precice_sources)
 
 # Configure version file generation
 include(GenerateVersionInformation)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -572,6 +572,8 @@ IF (BUILD_TESTING)
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED Yes
     CXX_EXTENSIONS No
+    UNITY_BUILD Yes
+    UNITY_BUILD_MODE GROUP
     )
   target_include_directories(testprecice PRIVATE
     ${preCICE_SOURCE_DIR}/src
@@ -582,6 +584,15 @@ IF (BUILD_TESTING)
   # Test Sources Configuration
   include(${CMAKE_CURRENT_LIST_DIR}/src/tests.cmake)
   include(${CMAKE_CURRENT_LIST_DIR}/tests/tests.cmake)
+
+  # Add integration tests from tests/ sources to a single unity group
+  get_target_property(_testprecice_sources testprecice SOURCES)
+  foreach(SOURCE_FILE IN LISTS _testprecice_sources)
+    if(SOURCE_FILE MATCHES "^tests/")
+      set_source_files_properties(${SOURCE_FILE} PROPERTIES UNITY_GROUP "integration")
+    endif()
+  endforeach()
+
 else(BUILD_TESTING)
   message(STATUS "Excluding test sources")
 endif(BUILD_TESTING)

--- a/docs/changelog/2068.md
+++ b/docs/changelog/2068.md
@@ -1,0 +1,1 @@
+- Added support for using unity builds via the CMake option `PRECICE_BUILD_UNITY`, which is enabled by default.

--- a/tests/parallel/map-initial-data/NonZeroData.cpp
+++ b/tests/parallel/map-initial-data/NonZeroData.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(NonZeroData)
 {
   PRECICE_TEST("One"_on(1_rank), "Two"_on(2_ranks));
 
-  testMapInitialData(context, 1.0, 1.0, 2, 0);
+  testMapInitialDataP(context, 1.0, 1.0, 2, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END() // MapInitialData

--- a/tests/parallel/map-initial-data/ZeroData.cpp
+++ b/tests/parallel/map-initial-data/ZeroData.cpp
@@ -10,7 +10,7 @@ BOOST_AUTO_TEST_CASE(ZeroData)
 {
   PRECICE_TEST("One"_on(1_rank), "Two"_on(2_ranks));
 
-  testMapInitialData(context, 0.0, 0.0, 1, 0); // End of time window is not zero
+  testMapInitialDataP(context, 0.0, 0.0, 1, 0); // End of time window is not zero
 }
 
 BOOST_AUTO_TEST_SUITE_END() // MapInitialData

--- a/tests/parallel/map-initial-data/helper.hpp
+++ b/tests/parallel/map-initial-data/helper.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#ifndef YEO
+#define YEO
 
 #include <precice/precice.hpp>
 
@@ -17,7 +19,7 @@
  *
  * The mapping is either a read or a write mapping.
  */
-inline void testMapInitialData(
+inline void testMapInitialDataP(
     precice::testing::TestContext &context,
     double                         dataToWrite,
     double                         dataToExpect,
@@ -69,3 +71,4 @@ inline void testMapInitialData(
   p.advance(p.getMaxTimeStepSize());
   BOOST_REQUIRE(!p.isCouplingOngoing());
 }
+#endif


### PR DESCRIPTION
## Main changes of this PR

This PR adds support for unity building all integration tests and src module like `mapping` or `com`.

Unit tests are mixing namespaces to an extent that they are a hassle to unit building them.
 
Locally observed build times (Debug) using 5900X:

Setup | user time | total
---|---|---
stock | 1631 | 1:25
unity safe integration tests | 1447 | 1:16
unity all integration tests | 824 | 0:52
unity integration + src modules (this PR) | 538 | 0:46

Roughly comparing to `develop`:

- Bare run 5m to 4m
- MPI run 14m to 8m
- Full run 13-16m to 7-9m
- Total CI 200m to 120m

## Motivation and additional information

This should reduce the compile time significantly at the cost of a higher peak memory consumption.

After some testing even for Release builds, peak memory is not significantly different to building before.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
