### PR TITLE
Add noreturn to error logging

### DIFF
--- a/src/logging/Logger.hpp
+++ b/src/logging/Logger.hpp
@@ -47,7 +47,7 @@ private:
 
 /// Utility function to log an error and throw an exception of given type
 template <class Error>
-inline void logErrorAndThrow(precice::logging::Logger &log, precice::logging::LogLocation location, const std::string &message)
+inline void logErrorAndThrow [[noreturn]] (precice::logging::Logger &log, precice::logging::LogLocation location, const std::string &message)
 {
   log.error(location, message);
   throw Error{message};


### PR DESCRIPTION
## Main changes of this PR

This PR marks the `logging::logErrorAndThrow` function `[[noreturn]]`.

## Motivation and additional information

This silences a range of warnings as the compiler can now assume that a `PRECICE_ERROR` will not continue normal execution. 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
