### PR TITLE
Add support for remeshing of parallel coupling schemes

### DIFF
--- a/docs/changelog/2070.md
+++ b/docs/changelog/2070.md
@@ -1,0 +1,1 @@
+- Added experimental support for remeshing at runtime of parallel coupling schemes. Adding `<precice-configuration experimental="true" allow-remeshing="true" />` in the configuration allows calling `resetMesh()` for any provided mesh in the first iteration of a time-window.

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -40,7 +40,6 @@ public:
   {
     PRECICE_TRACE();
 
-    PRECICE_ASSERT(_weights.empty());
     _subVectorSizes = svs;
 
     size_t N = std::accumulate(_subVectorSizes.begin(), _subVectorSizes.end(), static_cast<std::size_t>(0));

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -298,6 +298,27 @@ void BaseCouplingScheme::initialize()
   _isInitialized = true;
 }
 
+void BaseCouplingScheme::reinitialize()
+{
+  PRECICE_TRACE();
+  PRECICE_ASSERT(isInitialized());
+
+  if (isImplicitCouplingScheme()) {
+    // overwrite past iteration with new samples
+    for (const auto &data : _allData | boost::adaptors::map_values) {
+      // TODO: reset CouplingData of changed meshes only #2102
+      data->reinitialize();
+    }
+
+    if (not doesFirstStep()) {
+      if (_acceleration) {
+        _acceleration->initialize(getAccelerationData());
+      }
+    }
+    initializeTXTWriters();
+  }
+}
+
 bool BaseCouplingScheme::sendsInitializedData() const
 {
   return _sendsInitializedData;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -178,6 +178,8 @@ public:
   /// @copydoc cplscheme::CouplingScheme::initialize()
   void initialize() override final;
 
+  void reinitialize() override final;
+
   ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override final;
 
   void firstExchange() override final;

--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -78,6 +78,12 @@ void CompositionalCouplingScheme::initialize()
   }
 }
 
+void CompositionalCouplingScheme::reinitialize()
+{
+  PRECICE_TRACE();
+  PRECICE_UNREACHABLE("Not implemented and not allowed");
+}
+
 bool CompositionalCouplingScheme::sendsInitializedData() const
 {
   PRECICE_TRACE();

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -77,6 +77,8 @@ public:
    */
   void initialize() final override;
 
+  void reinitialize() override final;
+
   /// Returns true, if any of the composed coupling schemes sendsInitializedData for this participant
   bool sendsInitializedData() const override final;
 

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -99,6 +99,21 @@ int CouplingData::meshDimensions() const
   return _mesh->getDimensions();
 }
 
+void CouplingData::reinitialize()
+{
+  // TODO port this to subcyling
+
+  // The mesh was reinitialized and new written data will be added later in advance().
+  // Meaning all samples are based on a different mesh.
+  // Without remapping, the best we can do is setting them to zero samples.
+  // We keep the timestamps not to break convergence measures, accelerations, and actions
+  auto zero = time::Sample(_data->getDimensions(), _mesh->nVertices());
+  zero.setZero();
+
+  _data->timeStepsStorage().setAllSamples(zero);
+  _previousTimeStepsStorage.setAllSamples(zero);
+}
+
 void CouplingData::storeIteration()
 {
   const auto &stamples = this->stamples();

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -70,6 +70,9 @@ public:
   /// Returns the dimensions of the current mesh (2D or 3D)
   int meshDimensions() const;
 
+  /// Reshape the past iterations and initial sample during remeshing
+  void reinitialize();
+
   /// store _data->values() in read-only variable _previousIteration for convergence checks etc.
   void storeIteration();
 

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -79,6 +79,11 @@ public:
   virtual void initialize() = 0;
 
   /**
+   * @brief Reinitializes the coupling scheme, coupling data, and acceleration schemes
+   */
+  virtual void reinitialize() = 0;
+
+  /**
    * @brief Returns whether this participant of the coupling scheme sends initialized data.
    *
    * @returns true, if this participant of the coupling scheme sends initialized data

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -58,7 +58,7 @@ public:
       m2n::M2NConfiguration::SharedPointer m2nConfig,
       config::PtrParticipantConfiguration  participantConfig);
 
-  void setExperimental(bool experimental);
+  void setRemeshing(bool allowed);
 
   /// Destructor, empty.
   virtual ~CouplingSchemeConfiguration() {}
@@ -82,6 +82,7 @@ public:
   void addCouplingScheme(const PtrCouplingScheme &cplScheme, const std::string &participantName);
 
 private:
+  bool                    _allowRemeshing = false;
   mutable logging::Logger _log{"cplscheme::CouplingSchemeConfiguration"};
 
   const std::string TAG;

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -36,6 +36,8 @@ public:
    */
   void initialize() override final;
 
+  void reinitialize() override final{};
+
   /**
    * @brief Not implemented.
    */

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -263,6 +263,7 @@ void Mesh::clear()
 
   for (mesh::PtrData &data : _data) {
     data->values().resize(0);
+    data->timeStepsStorage().clear();
   }
 }
 

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -120,6 +120,10 @@ void ProvidedPartition::prepare()
   PRECICE_INFO("Prepare partition for mesh {}", _mesh->getName());
   Event e("partition.prepareMesh." + _mesh->getName(), profiling::Synchronize);
 
+  PRECICE_ASSERT(_mesh->getGlobalNumberOfVertices() <= 0, _mesh->getGlobalNumberOfVertices());
+  PRECICE_ASSERT(_mesh->getVertexOffsets().empty(), _mesh->getVertexOffsets());
+  PRECICE_ASSERT(_mesh->getVertexDistribution().empty(), _mesh->getVertexDistribution());
+
   int numberOfVertices = _mesh->nVertices();
 
   if (utils::IntraComm::isPrimary()) {
@@ -143,7 +147,6 @@ void ProvidedPartition::prepare()
       globalNumberOfVertices += numberOfSecondaryRankVertices;
     }
     PRECICE_ASSERT(std::all_of(vertexOffsets.begin(), vertexOffsets.end(), [](auto i) { return i >= 0; }));
-    PRECICE_ASSERT(_mesh->getVertexOffsets().empty());
     _mesh->setVertexOffsets(vertexOffsets);
 
     // set and broadcast global number of vertices
@@ -203,9 +206,7 @@ void ProvidedPartition::prepare()
     _mesh->setVertexOffsets(std::move(vertexOffsets));
 
   } else {
-
     // The only rank of the participant contains all vertices
-    PRECICE_ASSERT(_mesh->getVertexDistribution().empty());
     _mesh->setVertexDistribution([&] {
       mesh::Mesh::VertexDistribution vertexDistribution;
       for (int i = 0; i < numberOfVertices; i++) {
@@ -214,15 +215,18 @@ void ProvidedPartition::prepare()
       }
       return vertexDistribution;
     }());
-    PRECICE_ASSERT(_mesh->getVertexOffsets().empty());
     _mesh->setVertexOffsets({numberOfVertices});
     _mesh->setGlobalNumberOfVertices(numberOfVertices);
+    PRECICE_ASSERT(!_mesh->getVertexDistribution().empty());
   }
 
   PRECICE_DEBUG("Set owner information");
   for (mesh::Vertex &v : _mesh->vertices()) {
     v.setOwner(true);
   }
+
+  PRECICE_ASSERT(_mesh->getGlobalNumberOfVertices() > 0);
+  PRECICE_ASSERT(!_mesh->getVertexOffsets().empty());
 }
 
 void ProvidedPartition::compute()
@@ -241,10 +245,11 @@ void ProvidedPartition::compute()
 void ProvidedPartition::compareBoundingBoxes()
 {
   PRECICE_TRACE();
-  if (_m2ns.empty())
-    return;
 
   _mesh->clearPartitioning();
+
+  if (_m2ns.empty())
+    return;
 
   //@todo coupling mode
 

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -85,6 +85,8 @@ void ReceivedPartition::communicate()
     PRECICE_ASSERT(globalNumberOfVertices >= 0);
     _mesh->setGlobalNumberOfVertices(globalNumberOfVertices);
   }
+
+  PRECICE_ASSERT(_mesh->getGlobalNumberOfVertices() >= 0);
 }
 
 void ReceivedPartition::compute()
@@ -209,7 +211,6 @@ void ReceivedPartition::compute()
       PRECICE_DEBUG("Send partition feedback to primary rank");
       utils::IntraComm::getCommunication()->sendRange(vertexIDs, 0);
     } else { // Primary
-
       mesh::Mesh::VertexDistribution vertexDistribution;
       int                            numberOfVertices = _mesh->nVertices();
       std::vector<VertexID>          vertexIDs(numberOfVertices, -1);
@@ -261,6 +262,11 @@ void ReceivedPartition::compute()
     utils::IntraComm::getCommunication()->broadcast(vertexOffsets);
     PRECICE_ASSERT(_mesh->getVertexOffsets().empty());
     _mesh->setVertexOffsets(std::move(vertexOffsets));
+  }
+
+  PRECICE_ASSERT(!_mesh->getVertexOffsets().empty());
+  if (!m2n().usesTwoLevelInitialization() && utils::IntraComm::isPrimary()) {
+    PRECICE_ASSERT(!_mesh->getVertexDistribution().empty());
   }
 }
 

--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -104,6 +104,11 @@ bool Participant::requiresMeshConnectivityFor(::precice::string_view meshName) c
   return _impl->requiresMeshConnectivityFor(toSV(meshName));
 }
 
+void Participant::resetMesh(::precice::string_view meshName)
+{
+  return _impl->resetMesh(toSV(meshName));
+}
+
 bool Participant::requiresGradientDataFor(::precice::string_view meshName,
                                           ::precice::string_view dataName) const
 {

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -526,13 +526,33 @@ public:
   bool requiresMeshConnectivityFor(::precice::string_view meshName) const;
 
   /**
+   * @brief Removes all vertices and connectivity information from the mesh
+   *
+   * @experimental
+   *
+   * Allows redefining a mesh during runtime.
+   * After the call to resetMesh(), the mesh vertices need to be set with setMeshVertex() and setMeshVertices() again.
+   * Connectivity information may be set as well.
+   *
+   * Reading data from this mesh using readData() is not possible until the next call to advance().
+   *
+   * @param[in] meshName the name of the mesh to reset
+   *
+   * @pre initialize() has been called
+   * @pre isCouplingOngoing() is true
+   *
+   * @post previously returned vertex ids from setMeshVertex() and setMeshVertices() of the given mesh are invalid.
+   */
+  void resetMesh(::precice::string_view meshName);
+
+  /**
    * @brief Creates a mesh vertex
    *
    * @param[in] meshName the name of the mesh to add the vertex to.
    * @param[in] position the coordinates of the vertex.
    * @returns the id of the created vertex
    *
-   * @pre initialize() has not yet been called
+   * @pre either initialize() has not yet been called or resetMesh(meshName) has been called since the last call to initialize() or advance()
    * @pre position.size() == getMeshDimensions(meshName)
    *
    * @see getMeshDimensions()
@@ -564,7 +584,7 @@ public:
    *
    * @param[out] ids The ids of the created vertices
    *
-   * @pre initialize() has not yet been called
+   * @pre either initialize() has not yet been called or resetMesh(meshName) has been called since the last call to initialize() or advance()
    * @pre \p coordinates.size() == getMeshDimensions(meshName) * ids.size()
    *
    * @see getDimensions()
@@ -834,6 +854,7 @@ public:
    *
    * @pre every VertexID in ids is a return value of setMeshVertex or setMeshVertices
    * @pre values.size() == getDataDimensions(meshName, dataName) * ids.size()
+   * @pre resetMesh(meshName) has not been called since the last call to Participant::initialize() or Participant::advance()
    *
    * @post values contain the read data as specified in the above format.
    *

--- a/src/precice/config/Configuration.cpp
+++ b/src/precice/config/Configuration.cpp
@@ -39,6 +39,10 @@ Configuration::Configuration()
                               .setDocumentation("Enable experimental features.");
   _tag.addAttribute(attrExperimental);
 
+  auto attrRemeshing = xml::makeXMLAttribute("allow-remeshing", false)
+                           .setDocumentation("Enable experimental remeshing feature, requires experimental to be true.");
+  _tag.addAttribute(attrRemeshing);
+
   auto attrWaitInFinalize = xml::makeXMLAttribute("wait-in-finalize", false)
                                 .setDocumentation("Connected participants wait for each other in finalize, which can be helpful in SLURM sessions.");
   _tag.addAttribute(attrWaitInFinalize);
@@ -64,7 +68,12 @@ void Configuration::xmlTagCallback(const xml::ConfigurationContext &context, xml
   PRECICE_TRACE(tag.getName());
   if (tag.getName() == "precice-configuration") {
     _experimental = tag.getBooleanAttributeValue("experimental");
+    _remeshing    = tag.getBooleanAttributeValue("allow-remeshing");
+
+    PRECICE_CHECK(!_remeshing || _experimental, "Remeshing is considered an experimental feature. Please enable <precice-configuration experimental=\"1\" >.");
     _participantConfiguration->setExperimental(_experimental);
+    _participantConfiguration->setRemeshing(_remeshing);
+    _couplingSchemeConfiguration->setRemeshing(_remeshing);
     _waitInFinalize = tag.getBooleanAttributeValue("wait-in-finalize");
   } else {
     PRECICE_UNREACHABLE("Received callback from unknown tag '{}'.", tag.getName());

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -56,6 +56,12 @@ public:
     return _experimental;
   }
 
+  /// @brief Returns whether experimental remeshing is allowed or not
+  bool allowsRemeshing() const
+  {
+    return _remeshing;
+  }
+
   /// @brief Returns whether participants wait for each other in finalize
   bool waitInFinalize() const
   {
@@ -113,6 +119,9 @@ private:
 
   /// Allow the use of experimental features
   bool _experimental = false;
+
+  /// Allow the use of experimental remeshing features
+  bool _remeshing = false;
 
   /// Synchronize participants in finalize
   bool _waitInFinalize = false;

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -232,6 +232,12 @@ void ParticipantConfiguration::setExperimental(
   _mappingConfig->setExperimental(_experimental);
 }
 
+void ParticipantConfiguration::setRemeshing(
+    bool allowed)
+{
+  _remeshing = allowed;
+}
+
 void ParticipantConfiguration::xmlTagCallback(
     const xml::ConfigurationContext &context,
     xml::XMLTag &                    tag)

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -29,6 +29,7 @@ public:
       mesh::PtrMeshConfiguration meshConfiguration);
 
   void setExperimental(bool experimental);
+  void setRemeshing(bool allowed);
 
   /**
    * @brief Callback function required for use of automatic configuration.
@@ -114,6 +115,7 @@ private:
   const std::string VALUE_CSV = "csv";
 
   bool _experimental = false;
+  bool _remeshing    = false;
 
   mesh::PtrMeshConfiguration _meshConfig;
 

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -322,6 +322,9 @@ private:
   /// Are experimental API calls allowed?
   bool _allowsExperimental = false;
 
+  /// Are experimental remeshing API calls allowed?
+  bool _allowsRemeshing = false;
+
   /// Are participants waiting for each other in finalize?
   bool _waitInFinalize = false;
 
@@ -449,6 +452,28 @@ private:
 
   /// Discards send (currently write) data of a participant after a given time when another iteration is required
   void trimSendDataAfter(double time);
+
+  /** Allreduce of the amount of changed meshes on each rank.
+   * @return the total amount of changed meshes of all ranks on each rank
+   */
+  int getTotalMeshChanges() const;
+
+  /** Exchanges request to remesh with all connecting participants.
+   *
+   * @param[in] requestReinit does this participant request to remesh?
+   *
+   * @return does any participant request to remesh?
+   */
+  bool reinitHandshake(bool requestReinit) const;
+
+  /// Reinitializes preCICE
+  void reinitialize();
+
+  /// Connect participants including repartitioning
+  void setupCommunication();
+
+  /// Setup mesh watcher such as WatchPoints
+  void setupWatcher();
 
   /// To allow white box tests.
   friend struct Integration::Serial::Whitebox::TestConfigurationPeano;

--- a/src/testing/QuickTest.hpp
+++ b/src/testing/QuickTest.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <precice/Participant.hpp>
+#include <string>
+#include <vector>
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+namespace precice::testing {
+
+struct QuickTest {
+
+  struct Mesh {
+    std::string name;
+  };
+
+  struct ReadData {
+    std::string name;
+  };
+
+  struct WriteData {
+    std::string name;
+  };
+
+  QuickTest(Participant &p, Mesh m, ReadData r)
+      : interface(p), meshName(m.name), readDataName(r.name)
+  {
+  }
+
+  QuickTest(Participant &p, Mesh m, WriteData w)
+      : interface(p), meshName(m.name), writeDataName(w.name)
+  {
+  }
+
+  QuickTest(Participant &p, Mesh m, ReadData r, WriteData w)
+      : interface(p), meshName(m.name), readDataName(r.name), writeDataName(w.name)
+  {
+  }
+
+  QuickTest &setVertices(const std::vector<double> &pos)
+  {
+    auto n = pos.size() / interface.getMeshDimensions(meshName);
+    vertexIDs.resize(n, -1);
+    interface.setMeshVertices(meshName, pos, vertexIDs);
+    return *this;
+  }
+
+  QuickTest &initialize()
+  {
+    interface.initialize();
+    return *this;
+  }
+
+  QuickTest &resetMesh()
+  {
+    BOOST_TEST_MESSAGE("Remeshing");
+    interface.resetMesh(meshName);
+    return *this;
+  }
+
+  QuickTest &readCheckpoint()
+  {
+    interface.requiresReadingCheckpoint();
+    return *this;
+  }
+
+  QuickTest &writeCheckpoint()
+  {
+    interface.requiresWritingCheckpoint();
+    return *this;
+  }
+
+  void finalize()
+  {
+    interface.finalize();
+  }
+
+  QuickTest &advance()
+  {
+    interface.advance(interface.getMaxTimeStepSize());
+    return *this;
+  }
+
+  QuickTest &advance(double dt)
+  {
+    interface.advance(dt);
+    return *this;
+  }
+
+  QuickTest &write(const std::vector<double> &data)
+  {
+    interface.writeData(meshName, writeDataName, vertexIDs, data);
+    return *this;
+  }
+
+  QuickTest &writeAll(double d)
+  {
+    std::vector<double> data(vertexIDs.size() * interface.getDataDimensions(meshName, writeDataName), d);
+    interface.writeData(meshName, writeDataName, vertexIDs, data);
+    return *this;
+  }
+
+  std::vector<double> read()
+  {
+    auto                n = vertexIDs.size() * interface.getDataDimensions(meshName, readDataName);
+    std::vector<double> result(n, -0.0);
+    interface.readData(meshName, readDataName, vertexIDs, interface.getMaxTimeStepSize(), result);
+    return result;
+  }
+
+  QuickTest &expect(const std::vector<double> &expected)
+  {
+    auto data = read();
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    return *this;
+  }
+
+  QuickTest &expectAll(double e)
+  {
+    auto                data = read();
+    std::vector<double> expected(vertexIDs.size() * interface.getDataDimensions(meshName, readDataName), e);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    return *this;
+  }
+
+  QuickTest &expectReadCheckpoint()
+  {
+    BOOST_TEST(interface.requiresReadingCheckpoint());
+    BOOST_TEST(!interface.requiresWritingCheckpoint());
+    return *this;
+  }
+
+  QuickTest &expectWriteCheckpoint()
+  {
+    BOOST_TEST(!interface.requiresReadingCheckpoint());
+    BOOST_TEST(interface.requiresWritingCheckpoint());
+    return *this;
+  }
+
+  QuickTest &expectCouplingCompleted()
+  {
+    BOOST_TEST(!interface.isCouplingOngoing());
+    return *this;
+  }
+
+  Participant &         interface;
+  std::string           meshName;
+  std::string           readDataName  = "unused";
+  std::string           writeDataName = "unused";
+  std::vector<VertexID> vertexIDs;
+};
+
+inline QuickTest::Mesh operator""_mesh(const char *name, std::size_t)
+{
+  return {name};
+}
+
+inline QuickTest::ReadData operator""_read(const char *name, std::size_t)
+{
+  return {name};
+}
+
+inline QuickTest::WriteData operator""_write(const char *name, std::size_t)
+{
+  return {name};
+}
+
+} // namespace precice::testing

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -87,6 +87,7 @@ target_sources(testprecice
     src/testing/GlobalFixtures.cpp
     src/testing/ParallelCouplingSchemeFixture.cpp
     src/testing/ParallelCouplingSchemeFixture.hpp
+    src/testing/QuickTest.hpp
     src/testing/SerialCouplingSchemeFixture.cpp
     src/testing/SerialCouplingSchemeFixture.hpp
     src/testing/TestContext.cpp

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -49,6 +49,13 @@ void Storage::setSampleAtTime(double time, const Sample &sample)
   }
 }
 
+void Storage::setAllSamples(const Sample &sample)
+{
+  for (auto &stample : _stampleStorage) {
+    stample.sample = sample;
+  }
+}
+
 void Storage::setInterpolationDegree(int interpolationDegree)
 {
   PRECICE_ASSERT(interpolationDegree >= Time::MIN_WAVEFORM_DEGREE);

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -39,6 +39,16 @@ public:
    */
   void setSampleAtTime(double time, const Sample &sample);
 
+  /**
+   * @brief Overrides all existing samples
+   *
+   * This keeps time stamps, but overwrites all samples with a given one.
+   * Required in reinitialization
+   *
+   * @param sample new sample value
+   */
+  void setAllSamples(const Sample &sample);
+
   void setInterpolationDegree(int interpolationDegree);
 
   int getInterpolationDegree() const;

--- a/tests/remeshing/ReadAfterReset.cpp
+++ b/tests/remeshing/ReadAfterReset.cpp
@@ -1,0 +1,49 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_CASE(ReadAfterReset)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    QuickTest(participant, "MA"_mesh, "D"_write)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .write({0.01, 0.02})
+        .advance()
+        .write({0.11, 0.12})
+        .advance()
+        .finalize();
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    auto qt = QuickTest(participant, "MB"_mesh, "D"_read)
+                  .setVertices({0.0, y, 1.0, y})
+                  .initialize()
+                  .advance()
+                  .expect({0.01, 0.02})
+
+                  .resetMesh()
+                  .setVertices({0.0, y});
+
+    BOOST_CHECK_THROW(qt.read(), ::precice::Error);
+
+    qt.advance()
+        .expect({0.11})
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/ReadAfterReset.xml
+++ b/tests/remeshing/ReadAfterReset.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/ResetAfterSubcycling.cpp
+++ b/tests/remeshing/ResetAfterSubcycling.cpp
@@ -1,0 +1,43 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_CASE(ResetAfterSubcycling)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  auto qt = [&] {
+    if (context.isNamed("A")) {
+      return QuickTest(participant, "MA"_mesh, "DB"_read, "DA"_write);
+    }
+    return QuickTest(participant, "MB"_mesh, "DA"_read, "DB"_write);
+  }();
+
+  qt.setVertices({0.0, y, 1.0, y})
+      .initialize()
+      // TW 1 It 1 currently not allowed
+      .writeCheckpoint()
+      .readCheckpoint()
+      .advance()
+      // TW 1 It 2
+      .writeCheckpoint()
+      .expect({0.00, 0.00})
+      .readCheckpoint()
+      .advance()
+      // TW 2 It 1 time window complete
+      .writeCheckpoint()
+      .advance(0.5); // Subcycle first
+  BOOST_CHECK_THROW(qt.resetMesh(), ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/ResetAfterSubcycling.xml
+++ b/tests/remeshing/ResetAfterSubcycling.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/ResetWhileIterating.cpp
+++ b/tests/remeshing/ResetWhileIterating.cpp
@@ -1,0 +1,57 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_CASE(ResetWhileIterating)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  auto qt = [&] {
+    if (context.isNamed("A")) {
+      return QuickTest(participant, "MA"_mesh, "DB"_read, "DA"_write);
+    }
+    return QuickTest(participant, "MB"_mesh, "DA"_read, "DB"_write);
+  }();
+
+  qt.setVertices({0.0, y, 1.0, y})
+      .initialize()
+      // TW 1 It 1 currently not allowed
+      .writeCheckpoint();
+  BOOST_CHECK_THROW(qt.resetMesh(), ::precice::Error);
+  qt.readCheckpoint()
+      .advance()
+      // TW 1 It 2
+      .writeCheckpoint()
+      .expect({0.00, 0.00});
+  BOOST_CHECK_THROW(qt.resetMesh(), ::precice::Error);
+  qt.readCheckpoint()
+      .advance()
+      // TW 2 It 1 time window complete
+      .writeCheckpoint()
+      .resetMesh()
+      .setVertices({0.0, y, 1.0, y})
+      .readCheckpoint()
+      .advance()
+      // TW 2 It 2
+      .writeCheckpoint()
+      .expect({0.00, 0.00});
+  BOOST_CHECK_THROW(qt.resetMesh(), ::precice::Error);
+  qt.readCheckpoint()
+      .advance()
+      // Done
+      .expectCouplingCompleted();
+  BOOST_CHECK_THROW(qt.resetMesh(), ::precice::Error);
+  qt.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/ResetWhileIterating.xml
+++ b/tests/remeshing/ResetWhileIterating.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/SubcylingAfterReset.cpp
+++ b/tests/remeshing/SubcylingAfterReset.cpp
@@ -1,0 +1,45 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_CASE(SubcylingAfterReset)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  auto qt = [&] {
+    if (context.isNamed("A")) {
+      return QuickTest(participant, "MA"_mesh, "DB"_read, "DA"_write);
+    }
+    return QuickTest(participant, "MB"_mesh, "DA"_read, "DB"_write);
+  }();
+
+  qt.setVertices({0.0, y, 1.0, y})
+      .initialize()
+      // TW 1 It 1 currently not allowed
+      .writeCheckpoint();
+  qt.readCheckpoint()
+      .advance()
+      // TW 1 It 2
+      .writeCheckpoint()
+      .expect({0.00, 0.00});
+  qt.readCheckpoint()
+      .advance()
+      // TW 2 It 1 time window complete
+      .writeCheckpoint()
+      .resetMesh()
+      .setVertices({0.0, y, 1.0, y})
+      .readCheckpoint();
+  BOOST_CHECK_THROW(qt.advance(0.5), ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/SubcylingAfterReset.xml
+++ b/tests/remeshing/SubcylingAfterReset.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshBoth)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changemapping::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth2LI.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth2LI.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshBoth2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changemapping::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth2LI.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshBothSerial.cpp
@@ -1,0 +1,51 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    QuickTest(participant, "MA"_mesh, "D"_write)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .write({0.01, 0.02})
+        .advance()
+        .resetMesh()
+        .setVertices({0.0, y, 1.0, y, 2.0, y})
+        .write({0.11, 0.12, 0.13})
+        .advance()
+        .finalize();
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    QuickTest(participant, "MB"_mesh, "D"_read)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .advance()
+        .expect({0.01, 0.02})
+        .resetMesh()
+        .setVertices({1.0, y, 2.0, y, 3.0, y})
+        .advance()
+        .expect({0.12, 0.13, 0.13})
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshBothSerial.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshInput)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changemapping::runResetInput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput2LI.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshInput2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changemapping::runResetInput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput2LI.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshInput2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshInputSerial.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshInputSerial.cpp
@@ -1,0 +1,50 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshInputSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double y = 0.0;
+
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    QuickTest(participant, "MA"_mesh, "D"_write)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .write({0.01, 0.02})
+        .advance()
+        .resetMesh()
+        .setVertices({0.0, y, 0.5, y, 1.0, y})
+        .write({0.11, 0.12, 0.13})
+        .advance()
+        .finalize();
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    QuickTest(participant, "MB"_mesh, "D"_read)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .advance()
+        .expect({0.01, 0.02})
+        .advance()
+        .expect({0.11, 0.13})
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshInputSerial.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshInputSerial.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshOutput)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changemapping::runResetOutput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput2LI.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshOutput2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changemapping::runResetOutput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput2LI.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutputSerial.cpp
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutputSerial.cpp
@@ -1,0 +1,50 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshOutputSerial)
+{
+  using namespace precice::testing;
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  constexpr double y = 0.0;
+
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    QuickTest(participant, "MA"_mesh, "D"_write)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .write({0.01, 0.02})
+        .advance()
+        .write({0.11, 0.12})
+        .advance()
+        .finalize();
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    QuickTest(participant, "MB"_mesh, "D"_read)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .advance()
+        .expect({0.01, 0.02})
+        .resetMesh()
+        .setVertices({0.0, y, 1.0, y, 2.0, y})
+        .advance()
+        .expect({0.11, 0.12, 0.12})
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutputSerial.xml
+++ b/tests/remeshing/parallel-explicit/changed-mapping/RemeshOutputSerial.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth.cpp
+++ b/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(OverlapBoth)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changepartition::runOverlapBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth.xml
+++ b/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth2LI.cpp
+++ b/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(OverlapBoth2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changepartition::runOverlapBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth2LI.xml
+++ b/tests/remeshing/parallel-explicit/changed-partition/OverlapBoth2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs.cpp
+++ b/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(ScatterOutputs)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changepartition::runScatterOutputs(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs.xml
+++ b/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs2LI.cpp
+++ b/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(ScatterOutputs2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changepartition::runScatterOutputs(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs2LI.xml
+++ b/tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs.cpp
+++ b/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(SwapOutputs)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changepartition::runSwapOutputs(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs.xml
+++ b/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs2LI.cpp
+++ b/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs2LI.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(SwapOutputs2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::changepartition::runSwapOutputs(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs2LI.xml
+++ b/tests/remeshing/parallel-explicit/changed-partition/SwapOutputs2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/helper.hpp
+++ b/tests/remeshing/parallel-explicit/helper.hpp
@@ -1,0 +1,536 @@
+#pragma once
+
+#include <string>
+
+#include <precice/Participant.hpp>
+#include "testing/QuickTest.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+namespace precice::tests::remesh::parallelExplicit {
+
+using testing::QuickTest;
+using testing::operator""_mesh;
+using testing::operator""_read;
+using testing::operator""_write;
+
+namespace noop {
+
+inline void runResetInput(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .resetMesh()
+          .setVertices({0.0, y, 1.0, y})
+          .write({0.11, 0.12})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y})
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .advance()
+          .expect({0.11, 0.12})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .advance()
+          .expect({1.11, 1.12})
+          .finalize();
+    }
+  }
+}
+
+inline void runResetOutput(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .write({0.11, 0.12})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .resetMesh()
+          .setVertices({0.0, y, 1.0, y})
+          .advance()
+          .expect({0.11, 0.12})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y})
+          .advance()
+          .expect({1.11, 1.12})
+          .finalize();
+    }
+  }
+}
+
+inline void runResetBoth(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+  Participant      p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .resetMesh()
+          .setVertices({0.0, y, 1.0, y})
+          .write({0.11, 0.12})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y})
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .resetMesh()
+          .setVertices({0.0, y, 1.0, y})
+          .advance()
+          .expect({0.11, 0.12})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y})
+          .advance()
+          .expect({1.11, 1.12})
+          .finalize();
+    }
+  }
+}
+} // namespace noop
+
+namespace changemapping {
+
+inline void runResetInput(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .resetMesh()
+          .setVertices({1.0, y})
+          .write({0.11})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .advance()
+          .expect({0.11, 0.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .advance()
+          .expect({1.11, 1.12})
+          .finalize();
+    }
+  }
+}
+
+inline void runResetOutput(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .write({0.11, 0.12})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .resetMesh()
+          .setVertices({1.0, y})
+          .advance()
+          .expect({0.12})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .resetMesh()
+          .setVertices({2.0, y})
+          .advance()
+          .expect({1.11})
+          .finalize();
+    }
+  }
+}
+
+inline void runResetBoth(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+  Participant      p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .resetMesh()
+          .setVertices({-1.0, y, 0, y})
+          .write({0.11, 0.12})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .resetMesh()
+          .setVertices({3.0, y, 4.0, y})
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .resetMesh()
+          .setVertices({0.0, y, 1.0, y})
+          .advance()
+          .expect({0.12, 0.12})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y})
+          .advance()
+          .expect({1.11, 1.11})
+          .finalize();
+    }
+  }
+}
+} // namespace changemapping
+
+namespace changepartition {
+
+inline void runOverlapBoth(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+  Participant      p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .resetMesh()
+          .setVertices({0.0, y, 1.0, y, 2.0, y})
+          .write({0.11, 0.12, 0.13})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .resetMesh()
+          .setVertices({3.0, y})
+          .write({1.11})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .resetMesh()
+          .setVertices({0.0, y})
+          .advance()
+          .expect({0.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .resetMesh()
+          .setVertices({1.0, y, 2.0, y, 3.0, y})
+          .advance()
+          .expect({0.12, 0.13, 1.11})
+          .finalize();
+    }
+  }
+}
+
+inline void runSwapOutputs(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .write({0.11, 0.12})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y})
+          .advance()
+          .expect({1.11, 1.12})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .resetMesh()
+          .setVertices({0.0, y, 1.0, y})
+          .advance()
+          .expect({0.11, 0.12})
+          .finalize();
+    }
+  }
+}
+
+inline void runScatterOutputs(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .write({0.01, 0.02})
+          .advance()
+          .write({0.11, 0.12})
+          .advance()
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "D"_write)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .write({1.01, 1.02})
+          .advance()
+          .write({1.11, 1.12})
+          .advance()
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({0.0, y, 1.0, y})
+          .initialize()
+          .advance()
+          .expect({0.01, 0.02})
+          .resetMesh()
+          .setVertices({0.0, y, 2.0, y})
+          .advance()
+          .expect({0.11, 1.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "D"_read)
+          .setVertices({2.0, y, 3.0, y})
+          .initialize()
+          .advance()
+          .expect({1.01, 1.02})
+          .resetMesh()
+          .setVertices({1.0, y, 3.0, y})
+          .advance()
+          .expect({0.12, 1.12})
+          .finalize();
+    }
+  }
+}
+} // namespace changepartition
+} // namespace precice::tests::remesh::parallelExplicit

--- a/tests/remeshing/parallel-explicit/noop/RemeshBoth.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshBoth.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshBoth)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::noop::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshBoth.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshBoth.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshBoth2LI.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshBoth2LI.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshBoth2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::noop::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshBoth2LI.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshBoth2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshBothSerial.cpp
@@ -1,0 +1,51 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    QuickTest(participant, "MA"_mesh, "D"_write)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .write({0.01, 0.02})
+        .advance()
+        .resetMesh()
+        .setVertices({0.0, y, 1.0, y})
+        .write({0.11, 0.12})
+        .advance()
+        .finalize();
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    QuickTest(participant, "MB"_mesh, "D"_read)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .advance()
+        .expect({0.01, 0.02})
+        .resetMesh()
+        .setVertices({0.0, y, 1.0, y})
+        .advance()
+        .expect({0.11, 0.12})
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshBothSerial.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshInput.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshInput.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshInput)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::noop::runResetInput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshInput.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshInput.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshInput2LI.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshInput2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshInput2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::noop::runResetInput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshInput2LI.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshInput2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshInputSerial.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshInputSerial.cpp
@@ -1,0 +1,49 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshInputSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  using namespace precice::testing;
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    QuickTest(participant, "MA"_mesh, "D"_write)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .write({0.01, 0.02})
+        .advance()
+        .resetMesh()
+        .setVertices({0.0, y, 1.0, y})
+        .write({0.11, 0.12})
+        .advance()
+        .finalize();
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    QuickTest(participant, "MB"_mesh, "D"_read)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .advance()
+        .expect({0.01, 0.02})
+        .advance()
+        .expect({0.11, 0.12})
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshInputSerial.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshInputSerial.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshOutput.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshOutput.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshOutput)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::noop::runResetOutput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshOutput.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshOutput.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshOutput2LI.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshOutput2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshOutput2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelExplicit::noop::runResetOutput(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshOutput2LI.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshOutput2LI.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets use-two-level-initialization="yes" connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/noop/RemeshOutputSerial.cpp
+++ b/tests/remeshing/parallel-explicit/noop/RemeshOutputSerial.cpp
@@ -1,0 +1,49 @@
+#ifndef PRECICE_NO_MPI
+
+#include "precice/Participant.hpp"
+#include "testing/QuickTest.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshOutputSerial)
+{
+  using namespace precice::testing;
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  constexpr double     y = 0.0;
+  precice::Participant participant{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    QuickTest(participant, "MA"_mesh, "D"_write)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .write({0.01, 0.02})
+        .advance()
+        .write({0.11, 0.12})
+        .advance()
+        .finalize();
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    QuickTest(participant, "MB"_mesh, "D"_read)
+        .setVertices({0.0, y, 1.0, y})
+        .initialize()
+        .advance()
+        .expect({0.01, 0.02})
+        .resetMesh()
+        .setVertices({0.0, y, 1.0, y})
+        .advance()
+        .expect({0.11, 0.12})
+        .finalize();
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/noop/RemeshOutputSerial.xml
+++ b/tests/remeshing/parallel-explicit/noop/RemeshOutputSerial.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="D" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="D" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <write-data name="D" mesh="MA" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <read-data name="D" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets connector="A" acceptor="B" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="D" mesh="MA" from="A" to="B" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/two-meshes/LocalMapping.cpp
+++ b/tests/remeshing/parallel-explicit/two-meshes/LocalMapping.cpp
@@ -1,0 +1,159 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(TwoMeshes)
+BOOST_AUTO_TEST_CASE(LocalMapping)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+
+  std::vector<double>   coords{1.0, 0.0, 2.0, 0.0}, coords2{0.5, 0.0, 1.5, 0.0, 2.5, 0.0};
+  std::array<double, 2> data, expected;
+  std::array<double, 3> data2, expected2;
+
+  if (context.isNamed("A")) {
+    std::vector<precice::VertexID> a1ids(2), a2ids(2);
+    p.setMeshVertices("MA1", coords, a1ids);
+    p.setMeshVertices("MA2", coords, a2ids);
+    p.initialize();
+
+    data.fill(-1);
+    expected.fill(0);
+    p.readData("MA1", "DB", a1ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(0);
+    p.readData("MA2", "DB", a2ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(1.1);
+    p.writeData("MA1", "DA1", a1ids, data);
+    data.fill(1.2);
+    p.writeData("MA2", "DA2", a2ids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    // We remesh MA1 in this time window
+
+    data.fill(-1);
+    expected.fill(1);
+    p.readData("MA1", "DB", a1ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(1);
+    p.readData("MA2", "DB", a2ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    // Remesh MA1
+    p.resetMesh("MA1");
+    a1ids.resize(3);
+    p.setMeshVertices("MA1", coords2, a1ids);
+
+    data2.fill(2.1);
+    p.writeData("MA1", "DA1", a1ids, data2);
+    data.fill(2.2);
+    p.writeData("MA2", "DA2", a2ids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    // Normal time window
+    data2.fill(-1);
+    expected2.fill(2);
+    p.readData("MA1", "DB", a1ids, p.getMaxTimeStepSize(), data2);
+    BOOST_TEST(data2 == expected2, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(2);
+    p.readData("MA2", "DB", a2ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data2.fill(3.1);
+    p.writeData("MA1", "DA1", a1ids, data2);
+    data.fill(3.2);
+    p.writeData("MA2", "DA2", a2ids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    BOOST_REQUIRE(!p.isCouplingOngoing());
+
+    data2.fill(-1);
+    expected2.fill(3);
+    p.readData("MA1", "DB", a1ids, 0, data2);
+    BOOST_TEST(data2 == expected2, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(3);
+    p.readData("MA2", "DB", a2ids, 0, data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+  } else {
+    std::vector<precice::VertexID> bids(2);
+    p.setMeshVertices("MB", coords, bids);
+    p.initialize();
+
+    data.fill(-1);
+    expected.fill(0);
+    p.readData("MB", "DA1", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    p.readData("MB", "DA2", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(1);
+    p.writeData("MB", "DB", bids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    data.fill(-1);
+    expected.fill(1.1);
+    p.readData("MB", "DA1", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(1.2);
+    p.readData("MB", "DA2", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(2);
+    p.writeData("MB", "DB", bids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    data.fill(-1);
+    expected.fill(2.1);
+    p.readData("MB", "DA1", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(2.2);
+    p.readData("MB", "DA2", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(3);
+    p.writeData("MB", "DB", bids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    BOOST_REQUIRE(!p.isCouplingOngoing());
+
+    data.fill(-1);
+    expected.fill(3.1);
+    p.readData("MB", "DA1", bids, 0, data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(3.2);
+    p.readData("MB", "DA2", bids, 0, data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // TwoMeshes
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/two-meshes/LocalMapping.xml
+++ b/tests/remeshing/parallel-explicit/two-meshes/LocalMapping.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DA1" />
+  <data:scalar name="DA2" />
+  <data:scalar name="DB" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA1" />
+    <use-data name="DA2" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA1" dimensions="2">
+    <use-data name="DA1" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA2" dimensions="2">
+    <use-data name="DA2" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA1" />
+    <provide-mesh name="MA2" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA1" mesh="MA1" />
+    <write-data name="DA2" mesh="MA2" />
+    <read-data name="DB" mesh="MA1" />
+    <read-data name="DB" mesh="MA2" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA1" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA2" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MA1" to="MB" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MA2" to="MB" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA1" mesh="MB" />
+    <read-data name="DA2" mesh="MB" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="3" />
+    <time-window-size value="1" />
+    <exchange data="DA1" mesh="MB" from="A" to="B" />
+    <exchange data="DA2" mesh="MB" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-explicit/two-meshes/RemoteMapping.cpp
+++ b/tests/remeshing/parallel-explicit/two-meshes/RemoteMapping.cpp
@@ -1,0 +1,159 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelExplicit)
+BOOST_AUTO_TEST_SUITE(TwoMeshes)
+BOOST_AUTO_TEST_CASE(RemoteMapping)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+
+  std::vector<double>   coords{1.0, 0.0, 2.0, 0.0}, coords2{0.5, 0.0, 1.5, 0.0, 2.5, 0.0};
+  std::array<double, 2> data, expected;
+  std::array<double, 3> data2, expected2;
+
+  if (context.isNamed("A")) {
+    std::vector<precice::VertexID> a1ids(2), a2ids(2);
+    p.setMeshVertices("MA1", coords, a1ids);
+    p.setMeshVertices("MA2", coords, a2ids);
+    p.initialize();
+
+    data.fill(-1);
+    expected.fill(0);
+    p.readData("MA1", "DB", a1ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(0);
+    p.readData("MA2", "DB", a2ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(1.1);
+    p.writeData("MA1", "DA1", a1ids, data);
+    data.fill(1.2);
+    p.writeData("MA2", "DA2", a2ids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    // We remesh MA1 in this time window
+
+    data.fill(-1);
+    expected.fill(1);
+    p.readData("MA1", "DB", a1ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(1);
+    p.readData("MA2", "DB", a2ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    // Remesh MA1
+    p.resetMesh("MA1");
+    a1ids.resize(3);
+    p.setMeshVertices("MA1", coords2, a1ids);
+
+    data2.fill(2.1);
+    p.writeData("MA1", "DA1", a1ids, data2);
+    data.fill(2.2);
+    p.writeData("MA2", "DA2", a2ids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    // Normal time window
+    data2.fill(-1);
+    expected2.fill(2);
+    p.readData("MA1", "DB", a1ids, p.getMaxTimeStepSize(), data2);
+    BOOST_TEST(data2 == expected2, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(2);
+    p.readData("MA2", "DB", a2ids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data2.fill(3.1);
+    p.writeData("MA1", "DA1", a1ids, data2);
+    data.fill(3.2);
+    p.writeData("MA2", "DA2", a2ids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    BOOST_REQUIRE(!p.isCouplingOngoing());
+
+    data2.fill(-1);
+    expected2.fill(3);
+    p.readData("MA1", "DB", a1ids, 0, data2);
+    BOOST_TEST(data2 == expected2, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(3);
+    p.readData("MA2", "DB", a2ids, 0, data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+  } else {
+    std::vector<precice::VertexID> bids(2);
+    p.setMeshVertices("MB", coords, bids);
+    p.initialize();
+
+    data.fill(-1);
+    expected.fill(0);
+    p.readData("MB", "DA1", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    p.readData("MB", "DA2", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(1);
+    p.writeData("MB", "DB", bids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    data.fill(-1);
+    expected.fill(1.1);
+    p.readData("MB", "DA1", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(1.2);
+    p.readData("MB", "DA2", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(2);
+    p.writeData("MB", "DB", bids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    data.fill(-1);
+    expected.fill(2.1);
+    p.readData("MB", "DA1", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(2.2);
+    p.readData("MB", "DA2", bids, p.getMaxTimeStepSize(), data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+
+    data.fill(3);
+    p.writeData("MB", "DB", bids, data);
+
+    p.advance(p.getMaxTimeStepSize());
+
+    BOOST_REQUIRE(!p.isCouplingOngoing());
+
+    data.fill(-1);
+    expected.fill(3.1);
+    p.readData("MB", "DA1", bids, 0, data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+    data.fill(-1);
+    expected.fill(3.2);
+    p.readData("MB", "DA2", bids, 0, data);
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // TwoMeshes
+BOOST_AUTO_TEST_SUITE_END() // ParallelExplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-explicit/two-meshes/RemoteMapping.xml
+++ b/tests/remeshing/parallel-explicit/two-meshes/RemoteMapping.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DA1" />
+  <data:scalar name="DA2" />
+  <data:scalar name="DB" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA1" />
+    <use-data name="DA2" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA1" dimensions="2">
+    <use-data name="DA1" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA2" dimensions="2">
+    <use-data name="DA2" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA1" />
+    <provide-mesh name="MA2" />
+    <write-data name="DA1" mesh="MA1" />
+    <write-data name="DA2" mesh="MA2" />
+    <read-data name="DB" mesh="MA1" />
+    <read-data name="DB" mesh="MA2" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA1" from="A" />
+    <receive-mesh name="MA2" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA1" mesh="MB" />
+    <read-data name="DA2" mesh="MB" />
+    <mapping:nearest-neighbor direction="write" from="MB" to="MA1" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MB" to="MA2" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MA1" to="MB" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MA2" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="3" />
+    <time-window-size value="1" />
+    <exchange data="DA1" mesh="MA1" from="A" to="B" />
+    <exchange data="DA2" mesh="MA2" from="A" to="B" />
+    <exchange data="DB" mesh="MA1" from="B" to="A" />
+    <exchange data="DB" mesh="MA2" from="B" to="A" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshBothSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(IQNILS)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetBothIQNILS(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // IQNILS
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshBothSerial.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:IQN-ILS>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshFirstSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshFirstSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(IQNILS)
+BOOST_AUTO_TEST_CASE(RemeshFirstSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAIQNILS(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // IQNILS
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshFirstSerial.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:IQN-ILS>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshSecondSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshSecondSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(IQNILS)
+BOOST_AUTO_TEST_CASE(RemeshSecondSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAIQNILS(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // IQNILS
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshSecondSerial.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:IQN-ILS>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+    </acceleration:IQN-ILS>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshBothSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(IQNIMVJ)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetBothIQNIMVJ(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // IQNIMVJ
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshBothSerial.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:IQN-IMVJ>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+    </acceleration:IQN-IMVJ>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshFirstSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshFirstSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(IQNIMVJ)
+BOOST_AUTO_TEST_CASE(RemeshFirstSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAIQNIMVJ(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // IQNIMVJ
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshFirstSerial.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:IQN-IMVJ>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+    </acceleration:IQN-IMVJ>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshSecondSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshSecondSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(IQNIMVJ)
+BOOST_AUTO_TEST_CASE(RemeshSecondSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAIQNIMVJ(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // IQNIMVJ
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshSecondSerial.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:IQN-IMVJ>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+    </acceleration:IQN-IMVJ>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshBothSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(Aitken)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetBothAitken(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // Constant
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshBothSerial.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:aitken>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+      <initial-relaxation value="0.5" />
+    </acceleration:aitken>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshFirstSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshFirstSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(Aitken)
+BOOST_AUTO_TEST_CASE(RemeshFirstSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAAitken(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // Constant
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshFirstSerial.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:aitken>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+      <initial-relaxation value="0.5" />
+    </acceleration:aitken>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshSecondSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshSecondSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(Aitken)
+BOOST_AUTO_TEST_CASE(RemeshSecondSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAAitken(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // Constant
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshSecondSerial.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:aitken>
+      <data name="DA" mesh="MA" />
+      <data name="DB" mesh="MB" />
+      <initial-relaxation value="0.5" />
+    </acceleration:aitken>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshBothSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(Constant)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetBothConstant(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // Constant
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshBothSerial.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:constant>
+      <relaxation value="0.5" />
+    </acceleration:constant>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshFirstSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshFirstSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(Constant)
+BOOST_AUTO_TEST_CASE(RemeshFirstSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAConstant(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // Constant
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshFirstSerial.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:constant>
+      <relaxation value="0.5" />
+    </acceleration:constant>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshSecondSerial.cpp
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshSecondSerial.cpp
@@ -1,0 +1,23 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Acceleration)
+BOOST_AUTO_TEST_SUITE(Constant)
+BOOST_AUTO_TEST_CASE(RemeshSecondSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::acceleration::runResetAConstant(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // Constant
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshSecondSerial.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="4" />
+    <time-window-size value="1" />
+    <max-iterations value="3" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+    <acceleration:constant>
+      <relaxation value="0.5" />
+    </acceleration:constant>
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/acceleration/helper.hpp
+++ b/tests/remeshing/parallel-implicit/acceleration/helper.hpp
@@ -1,0 +1,365 @@
+#pragma once
+
+#include <string>
+
+#include <precice/Participant.hpp>
+#include "testing/QuickTest.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+namespace precice::tests::remesh::parallelImplicit {
+
+using testing::QuickTest;
+using testing::operator""_mesh;
+using testing::operator""_read;
+using testing::operator""_write;
+
+namespace acceleration {
+
+// The data written in the acceleration tests are always 40, 30, 15
+// first, second, third, and forth are read data from the first, second, third and forth iteration
+// The end of a timewindow and the end of the simulation are never accelerated and thus 15
+
+inline void runResetA(testing::TestContext &context, double first, double second, double third, double forth)
+{
+  constexpr double y = 0.0;
+
+  BOOST_REQUIRE(context.size == 1);
+  BOOST_REQUIRE(context.rank == 0);
+  Participant p{context.name, context.config(), 0, 1};
+
+  // A - Adaptive Geometry
+  if (context.isNamed("A")) {
+    QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expectAll(00.00)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15)
+        .resetMesh()
+        .setVertices({2.0, y})
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectCouplingCompleted()
+        .expectAll(15)
+        .finalize();
+  }
+  // B - Changing Geometry
+  if (context.isNamed("B")) {
+    QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expectAll(00.00)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectCouplingCompleted()
+        .expectAll(15)
+        .finalize();
+  }
+}
+
+inline void runResetAConstant(testing::TestContext &context)
+{
+  runResetA(context, 20, 25, 27.5, 28.75);
+}
+
+inline void runResetAAitken(testing::TestContext &context)
+{
+  runResetA(context, 20, 26.666666666, 27.5, 28.888888888);
+}
+
+inline void runResetAIQNILS(testing::TestContext &context)
+{
+  runResetA(context, 4, 11.4285714285714, 23.280254777, 26.324041811);
+}
+
+inline void runResetAIQNIMVJ(testing::TestContext &context)
+{
+  runResetA(context, 4, 11.428571428, 6.560509554, -120.204081632);
+}
+
+inline void runResetBoth(testing::TestContext &context, double first, double second, double third, double forth)
+{
+  constexpr double y = 0.0;
+
+  BOOST_REQUIRE(context.size == 1);
+  BOOST_REQUIRE(context.rank == 0);
+  Participant p{context.name, context.config(), 0, 1};
+
+  // A - Adaptive Geometry
+  if (context.isNamed("A")) {
+    QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expectAll(00.00)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00) // end of lw
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00) // end of lw
+        .resetMesh()
+        .setVertices({2.0, y})
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00) // end sample
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectCouplingCompleted()
+        .expectAll(15.00) // end sample
+        .finalize();
+  }
+  // B - Changing Geometry
+  if (context.isNamed("B")) {
+    QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expectAll(00.00)
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00) // end of tw
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00) // end of tw
+        .resetMesh()
+        .setVertices({2.0, y, 3.0, y})
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(first)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(second)
+        .writeAll(15.00)
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expectAll(15.00) // end of tw
+        .writeAll(40.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(third)
+        .writeAll(30.00)
+        .advance()
+
+        .expectReadCheckpoint()
+        .expectAll(forth)
+        .writeAll(15.00)
+        .advance()
+
+        .expectCouplingCompleted()
+        .expectAll(15.00) // end sample
+        .finalize();
+  }
+}
+
+inline void runResetBothConstant(testing::TestContext &context)
+{
+  runResetBoth(context, 20, 25, 27.5, 28.75);
+}
+
+inline void runResetBothAitken(testing::TestContext &context)
+{
+  runResetBoth(context, 20, 26.666666666, 27.5, 28.888888888);
+}
+
+inline void runResetBothIQNILS(testing::TestContext &context)
+{
+  runResetBoth(context, 4, 11.4285714285714, 23.280254777, 26.324041811);
+}
+
+inline void runResetBothIQNIMVJ(testing::TestContext &context)
+{
+  runResetBoth(context, 4, 11.4285714285714, 6.560509554, -120.204081632);
+}
+} // namespace acceleration
+} // namespace precice::tests::remesh::parallelImplicit

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshBoth)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth2LI.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshBoth2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBothSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBothSerial.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshFirst)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshFirst2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirstSerial.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirstSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshFirstSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirstSerial.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshSecond)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshSecond2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecondSerial.cpp
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecondSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedMapping)
+BOOST_AUTO_TEST_CASE(RemeshSecondSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::changemapping::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedMapping
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecondSerial.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(OverlapBoth)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runOverlapBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(OverlapBoth2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runOverlapBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(ScatterFirst)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runScatterA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(ScatterFirst2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runScatterA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(ScatterSecond)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runScatterA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(ScatterSecond2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runScatterA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapFirst.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapFirst.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(SwapFirst)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runSwapA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapFirst.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapFirst.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapFirst2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapFirst2LI.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(SwapFirst2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runSwapA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapFirst2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapSecond.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapSecond.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(SwapSecond)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runSwapA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapSecond.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapSecond.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapSecond2LI.cpp
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapSecond2LI.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(ChangedPartition)
+BOOST_AUTO_TEST_CASE(SwapSecond2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::changepartition::runSwapA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // ChangedPartition
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapSecond2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/convergence/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshBothSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Convergence)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::convergence::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/convergence/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshBothSerial.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <absolute-convergence-measure limit="0.1" data="DA" mesh="MA" />
+    <absolute-convergence-measure limit="0.1" data="DB" mesh="MB" />
+    <max-iterations value="4" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/convergence/RemeshFirstSerial.cpp
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshFirstSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Convergence)
+BOOST_AUTO_TEST_CASE(RemeshFirstSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::convergence::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/convergence/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshFirstSerial.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <absolute-convergence-measure limit="0.1" data="DA" mesh="MA" />
+    <absolute-convergence-measure limit="0.1" data="DB" mesh="MB" />
+    <max-iterations value="4" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/convergence/RemeshSecondSerial.cpp
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshSecondSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Convergence)
+BOOST_AUTO_TEST_CASE(RemeshSecondSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::convergence::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Convergence
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/convergence/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshSecondSerial.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <absolute-convergence-measure limit="0.1" data="DA" mesh="MA" />
+    <absolute-convergence-measure limit="0.1" data="DB" mesh="MB" />
+    <max-iterations value="4" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/helper.hpp
+++ b/tests/remeshing/parallel-implicit/helper.hpp
@@ -1,0 +1,1068 @@
+#pragma once
+
+#include <string>
+
+#include <precice/Participant.hpp>
+#include "testing/QuickTest.hpp"
+#include "testing/TestContext.hpp"
+#include "testing/Testing.hpp"
+
+namespace precice::tests::remesh::parallelImplicit {
+
+using testing::QuickTest;
+using testing::operator""_mesh;
+using testing::operator""_read;
+using testing::operator""_write;
+
+/* data format 12.34
+ * 1 = rank
+ * 2 = vertex x coordinate
+ * 3 = time window starting with 0
+ * 4 = iteration starting with 0
+ */
+
+namespace noop {
+
+inline void runResetA(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({1.0, y, 2.0, y})
+          .write({01.10, 02.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10, 02.10})
+          .write({01.11, 02.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11, 02.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .resetMesh()
+          .setVertices({3.0, y, 4.0, y})
+          .write({13.10, 14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.10, 14.10})
+          .write({13.11, 14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({13.11, 14.11})
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .write({01.10, 02.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10, 02.10})
+          .write({01.11, 02.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11, 02.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .write({13.10, 14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.10, 14.10})
+          .write({13.11, 14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({13.11, 14.11})
+          .finalize();
+    }
+  }
+}
+
+inline void runResetBoth(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  auto qt = context.isNamed("A") ? QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write) : QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write);
+
+  if (context.isPrimary()) {
+    qt.setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expect({00.00, 00.00})
+        .write({01.00, 02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.00, 02.00})
+        .write({01.01, 02.01})
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expect({01.01, 02.01})
+        .resetMesh()
+        .setVertices({1.0, y, 2.0, y})
+        .write({01.10, 02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.10, 02.10})
+        .write({01.11, 02.11})
+        .advance()
+
+        .expectCouplingCompleted()
+        .expect({01.11, 02.11})
+        .finalize();
+  } else {
+    qt.setVertices({3.0, y, 4.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expect({00.00, 00.00})
+        .write({13.00, 14.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({13.00, 14.00})
+        .write({13.01, 14.01})
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expect({13.01, 14.01})
+        .resetMesh()
+        .setVertices({3.0, y, 4.0, y})
+        .write({13.10, 14.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({13.10, 14.10})
+        .write({13.11, 14.11})
+        .advance()
+
+        .expectCouplingCompleted()
+        .expect({13.11, 14.11})
+        .finalize();
+  }
+}
+} // namespace noop
+
+namespace changemapping {
+
+inline void runResetA(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({2.0, y})
+          .write({02.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({02.10})
+          .write({02.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({02.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .resetMesh()
+          .setVertices({3.0, y})
+          .write({13.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.10})
+          .write({13.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({13.11})
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .write({01.10, 02.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({02.10, 02.10})
+          .write({01.11, 02.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({02.11, 02.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .write({13.10, 14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.10, 13.10})
+          .write({13.11, 14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({13.11, 13.11})
+          .finalize();
+    }
+  }
+}
+
+inline void runResetBoth(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  if (context.isNamed("A")) {
+    QuickTest qt(p, "MA"_mesh, "DB"_read, "DA"_write);
+    if (context.isPrimary()) {
+      qt.setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({1.0, y})
+          .write({01.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({02.10})
+          .write({01.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({02.11})
+          .finalize();
+    } else {
+      qt.setVertices({4.0, y, 5.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({14.00, 15.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({14.00, 15.00})
+          .write({14.01, 15.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({14.01, 15.01})
+          .resetMesh()
+          .setVertices({4.0, y})
+          .write({14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({15.10})
+          .write({14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({15.11})
+          .finalize();
+    }
+  } else {
+    QuickTest qt(p, "MB"_mesh, "DA"_read, "DB"_write);
+    if (context.isPrimary()) {
+      qt.setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({2.0, y})
+          .write({02.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10})
+          .write({02.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11})
+          .finalize();
+    } else {
+      qt.setVertices({4.0, y, 5.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({14.00, 15.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({14.00, 15.00})
+          .write({14.01, 15.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({14.01, 15.01})
+          .resetMesh()
+          .setVertices({5.0, y})
+          .write({15.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({14.10})
+          .write({15.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({14.11})
+          .finalize();
+    }
+  }
+}
+
+} // namespace changemapping
+
+namespace changepartition {
+
+/// Changes partitioning from 12|34 to 1|234 and 123|4
+inline void runOverlapBoth(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({1.0, y, 2.0, y, 3.0, y})
+          .write({01.10, 02.10, 03.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10, 12.10, 13.10})
+          .write({01.11, 02.11, 03.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11, 12.11, 13.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .resetMesh()
+          .setVertices({4.0, y})
+          .write({14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({14.10})
+          .write({14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({14.11})
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({1.0, y})
+          .write({01.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10})
+          .write({01.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y, 4.0, y})
+          .write({12.10, 13.10, 14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({02.10, 03.10, 14.10})
+          .write({12.11, 13.11, 14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({02.11, 03.11, 14.11})
+          .finalize();
+    }
+  }
+}
+
+/// Changes partitioning of A from 12|34 to 34|12
+inline void runSwapA(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({3.0, y, 4.0, y})
+          .write({03.10, 04.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.10, 14.10})
+          .write({03.11, 04.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({13.11, 14.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .resetMesh()
+          .setVertices({1.0, y, 2.0, y})
+          .write({11.10, 12.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10, 02.10})
+          .write({11.11, 12.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11, 02.11})
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .write({01.10, 02.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({11.10, 12.10})
+          .write({01.11, 02.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({11.11, 12.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .write({13.10, 14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({03.10, 04.10})
+          .write({13.11, 14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({03.11, 04.11})
+          .finalize();
+    }
+  }
+}
+
+/// Changes partitioning of A from 12|34 to 13|24
+inline void runScatterA(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  Participant p{context.name, context.config(), context.rank, context.size};
+
+  // A - Static Geometry
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .resetMesh()
+          .setVertices({1.0, y, 3.0, y})
+          .write({01.10, 03.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10, 13.10})
+          .write({01.11, 03.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11, 13.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .resetMesh()
+          .setVertices({2.0, y, 4.0, y})
+          .write({12.10, 14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({02.10, 14.10})
+          .write({12.11, 14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({02.11, 14.11})
+          .finalize();
+    }
+  }
+  // B - Adaptive Geometry
+  if (context.isNamed("B")) {
+    if (context.isPrimary()) {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({1.0, y, 2.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({01.00, 02.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.00, 02.00})
+          .write({01.01, 02.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({01.01, 02.01})
+          .write({01.10, 02.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({01.10, 12.10})
+          .write({01.11, 02.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({01.11, 12.11})
+          .finalize();
+    } else {
+      QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+          .setVertices({3.0, y, 4.0, y})
+          .initialize()
+          .expectWriteCheckpoint()
+          .expect({00.00, 00.00})
+          .write({13.00, 14.00})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({13.00, 14.00})
+          .write({13.01, 14.01})
+          .advance()
+
+          .expectWriteCheckpoint()
+          .expect({13.01, 14.01})
+          .write({13.10, 14.10})
+          .advance()
+
+          .expectReadCheckpoint()
+          .expect({03.10, 14.10})
+          .write({13.11, 14.11})
+          .advance()
+
+          .expectCouplingCompleted()
+          .expect({03.11, 14.11})
+          .finalize();
+    }
+  }
+}
+
+} // namespace changepartition
+
+namespace convergence {
+
+inline void runResetA(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  BOOST_REQUIRE(context.size == 1);
+  BOOST_REQUIRE(context.rank == 0);
+  Participant p{context.name, context.config(), 0, 1};
+
+  // The data format uses the following format:
+  //  0 xpos . (00 | 10 | 11 )
+
+  // A - Adaptive Geometry
+  if (context.isNamed("A")) {
+    QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expect({00.00, 00.00})
+        .write({01.00, 02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.00, 02.00})
+        .write({01.10, 02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.10, 02.10})
+        .write({01.11, 02.11})
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expect({01.11, 02.11})
+        .resetMesh()
+        .setVertices({2.0, y})
+        .write({02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.00})
+        .write({02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.10})
+        .write({02.11})
+        .advance()
+
+        .expectCouplingCompleted()
+        .expect({02.11})
+        .finalize();
+  }
+  // B - Changing Geometry
+  if (context.isNamed("B")) {
+    QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expect({00.00, 00.00})
+        .write({01.00, 02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.00, 02.00})
+        .write({01.10, 02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.10, 02.10})
+        .write({01.11, 02.11})
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expect({01.11, 02.11})
+        .write({01.00, 02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.00, 02.00})
+        .write({01.10, 02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.10, 02.10})
+        .write({01.11, 02.11})
+        .advance()
+
+        .expectCouplingCompleted()
+        .expect({02.11, 02.11})
+        .finalize();
+  }
+}
+
+inline void runResetBoth(testing::TestContext &context)
+{
+  constexpr double y = 0.0;
+
+  BOOST_REQUIRE(context.size == 1);
+  BOOST_REQUIRE(context.rank == 0);
+  Participant p{context.name, context.config(), 0, 1};
+
+  // The data format uses the following format:
+  //  0 xpos . (00 | 10 | 11 )
+
+  // A - Adaptive Geometry
+  if (context.isNamed("A")) {
+    QuickTest(p, "MA"_mesh, "DB"_read, "DA"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expect({00.00, 00.00})
+        .write({01.00, 02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.00, 02.00})
+        .write({01.10, 02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.10, 02.10})
+        .write({01.11, 02.11})
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expect({01.11, 02.11})
+        .resetMesh()
+        .setVertices({2.0, y})
+        .write({02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.00})
+        .write({02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.10})
+        .write({02.11})
+        .advance()
+
+        .expectCouplingCompleted()
+        .expect({02.11})
+        .finalize();
+  }
+  // B - Changing Geometry
+  if (context.isNamed("B")) {
+    QuickTest(p, "MB"_mesh, "DA"_read, "DB"_write)
+        .setVertices({1.0, y, 2.0, y})
+        .initialize()
+        .expectWriteCheckpoint()
+        .expect({00.00, 00.00})
+        .write({01.00, 02.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.00, 02.00})
+        .write({01.10, 02.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({01.10, 02.10})
+        .write({01.11, 02.11})
+        .advance()
+
+        .expectWriteCheckpoint()
+        .expect({01.11, 02.11})
+        .resetMesh()
+        .setVertices({1., y, 2., y, 3., y})
+        .write({01.00, 02.00, 03.00})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.00, 02.00, 02.00})
+        .write({01.10, 02.10, 03.10})
+        .advance()
+
+        .expectReadCheckpoint()
+        .expect({02.10, 02.10, 02.10})
+        .write({01.11, 02.11, 03.11})
+        .advance()
+
+        .expectCouplingCompleted()
+        .expect({02.11, 02.11, 02.11})
+        .finalize();
+  }
+}
+
+} // namespace convergence
+
+} // namespace precice::tests::remesh::parallelImplicit

--- a/tests/remeshing/parallel-implicit/noop/RemeshBoth.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBoth.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshBoth)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::noop::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshBoth.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBoth.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshBoth2LI.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBoth2LI.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshBoth2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::noop::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshBoth2LI.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBoth2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshBothSerial.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBothSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshBothSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::noop::runResetBoth(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBothSerial.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirst.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirst.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshFirst)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::noop::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirst.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirst.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirst2LI.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirst2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshFirst2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::noop::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirst2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirstSerial.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirstSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshFirstSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::noop::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirstSerial.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="A" second="B" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecond.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecond.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshSecond)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::noop::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecond.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecond.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecond2LI.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecond2LI.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include "../helper.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshSecond2LI)
+{
+  PRECICE_TEST("A"_on(2_ranks), "B"_on(2_ranks));
+  precice::tests::remesh::parallelImplicit::noop::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecond2LI.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets
+    use-two-level-initialization="yes"
+    acceptor="B"
+    connector="A"
+    exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecondSerial.cpp
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecondSerial.cpp
@@ -1,0 +1,21 @@
+#ifndef PRECICE_NO_MPI
+
+#include "../helper.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Remeshing)
+BOOST_AUTO_TEST_SUITE(ParallelImplicit)
+BOOST_AUTO_TEST_SUITE(Noop)
+BOOST_AUTO_TEST_CASE(RemeshSecondSerial)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+  precice::tests::remesh::parallelImplicit::noop::runResetA(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Noop
+BOOST_AUTO_TEST_SUITE_END() // ParallelImplicit
+BOOST_AUTO_TEST_SUITE_END() // Remeshing
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecondSerial.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="yes" allow-remeshing="yes">
+  <data:scalar name="DB" />
+  <data:scalar name="DA" />
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+    <use-data name="DB" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="B" />
+    <write-data name="DA" mesh="MA" />
+    <read-data name="DB" mesh="MA" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="MB" />
+    <receive-mesh name="MA" from="A" />
+    <write-data name="DB" mesh="MB" />
+    <read-data name="DA" mesh="MB" />
+    <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+
+  <coupling-scheme:parallel-implicit>
+    <participants first="B" second="A" />
+    <max-time-windows value="2" />
+    <time-window-size value="1" />
+    <max-iterations value="2" />
+    <exchange data="DA" mesh="MA" from="A" to="B" />
+    <exchange data="DB" mesh="MB" from="B" to="A" />
+  </coupling-scheme:parallel-implicit>
+</precice-configuration>

--- a/tests/serial/circular/helper.hpp
+++ b/tests/serial/circular/helper.hpp
@@ -7,7 +7,7 @@
 #include <precice/precice.hpp>
 #include <vector>
 
-namespace tests {
+namespace precice::tests {
 inline void cyclicExplicit(TestContext &context)
 {
   precice::Participant interface{
@@ -57,4 +57,4 @@ inline void cyclicExplicit(TestContext &context)
 
   BOOST_TEST_REQUIRE(!interface.isCouplingOngoing());
 }
-} // namespace tests
+} // namespace precice::tests

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -92,6 +92,82 @@ target_sources(testprecice
     tests/quasi-newton/serial/TestQN7.cpp
     tests/quasi-newton/serial/TestQN8.cpp
     tests/quasi-newton/serial/TestQN9.cpp
+    tests/remeshing/ReadAfterReset.cpp
+    tests/remeshing/ResetAfterSubcycling.cpp
+    tests/remeshing/ResetWhileIterating.cpp
+    tests/remeshing/SubcylingAfterReset.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshBoth2LI.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshBothSerial.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshInput.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshInput2LI.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshInputSerial.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshOutput2LI.cpp
+    tests/remeshing/parallel-explicit/changed-mapping/RemeshOutputSerial.cpp
+    tests/remeshing/parallel-explicit/changed-partition/OverlapBoth.cpp
+    tests/remeshing/parallel-explicit/changed-partition/OverlapBoth2LI.cpp
+    tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs.cpp
+    tests/remeshing/parallel-explicit/changed-partition/ScatterOutputs2LI.cpp
+    tests/remeshing/parallel-explicit/changed-partition/SwapOutputs.cpp
+    tests/remeshing/parallel-explicit/changed-partition/SwapOutputs2LI.cpp
+    tests/remeshing/parallel-explicit/helper.hpp
+    tests/remeshing/parallel-explicit/noop/RemeshBoth.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshBoth2LI.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshBothSerial.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshInput.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshInput2LI.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshInputSerial.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshOutput.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshOutput2LI.cpp
+    tests/remeshing/parallel-explicit/noop/RemeshOutputSerial.cpp
+    tests/remeshing/parallel-explicit/two-meshes/LocalMapping.cpp
+    tests/remeshing/parallel-explicit/two-meshes/RemoteMapping.cpp
+    tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshBothSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshFirstSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshSecondSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshBothSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshFirstSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshSecondSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/aitken/RemeshBothSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/aitken/RemeshFirstSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/aitken/RemeshSecondSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/constant/RemeshBothSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/constant/RemeshFirstSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/constant/RemeshSecondSerial.cpp
+    tests/remeshing/parallel-implicit/acceleration/helper.hpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth2LI.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshBothSerial.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst2LI.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshFirstSerial.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond2LI.cpp
+    tests/remeshing/parallel-implicit/changed-mapping/RemeshSecondSerial.cpp
+    tests/remeshing/parallel-implicit/changed-partition/OverlapBoth.cpp
+    tests/remeshing/parallel-implicit/changed-partition/OverlapBoth2LI.cpp
+    tests/remeshing/parallel-implicit/changed-partition/ScatterFirst.cpp
+    tests/remeshing/parallel-implicit/changed-partition/ScatterFirst2LI.cpp
+    tests/remeshing/parallel-implicit/changed-partition/ScatterSecond.cpp
+    tests/remeshing/parallel-implicit/changed-partition/ScatterSecond2LI.cpp
+    tests/remeshing/parallel-implicit/changed-partition/SwapFirst.cpp
+    tests/remeshing/parallel-implicit/changed-partition/SwapFirst2LI.cpp
+    tests/remeshing/parallel-implicit/changed-partition/SwapSecond.cpp
+    tests/remeshing/parallel-implicit/changed-partition/SwapSecond2LI.cpp
+    tests/remeshing/parallel-implicit/convergence/RemeshBothSerial.cpp
+    tests/remeshing/parallel-implicit/convergence/RemeshFirstSerial.cpp
+    tests/remeshing/parallel-implicit/convergence/RemeshSecondSerial.cpp
+    tests/remeshing/parallel-implicit/helper.hpp
+    tests/remeshing/parallel-implicit/noop/RemeshBoth.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshBoth2LI.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshBothSerial.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshFirst.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshFirst2LI.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshFirstSerial.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshSecond.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshSecond2LI.cpp
+    tests/remeshing/parallel-implicit/noop/RemeshSecondSerial.cpp
     tests/serial/AitkenAcceleration.cpp
     tests/serial/ImplicitCheckpointing.cpp
     tests/serial/PreconditionerBug.cpp
@@ -327,4 +403,4 @@ target_sources(testprecice
     )
 
 # Contains the list of integration test suites
-set(PRECICE_TEST_SUITES GeometricMultiscale Parallel QuasiNewton Serial)
+set(PRECICE_TEST_SUITES GeometricMultiscale Parallel QuasiNewton Remeshing Serial)


### PR DESCRIPTION
## Main changes of this PR

This PR adds support for highly experimental support for remeshing.

As this feature **requires** additional synchronization points, it is off by default.

To enable it, one needs to activate experimental features and allow remeshing globally.

```xml
<precice-configuration experimental="1" allow-remeshing="1" >
```

This allows calling `resetMesh()` and disallows the use of serial coupling schemes as well as coupling scheme compositions and multi coupling schemes.

## Motivation and additional information

See #225

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## TODO

* [x] Disable handshakes when subcycling
* [x] Port or reimplement integration tests from the previous version(2)
* [x] Add tests for parallel implicit coupling
* [ ] ~~Add tests for multi coupling~~
* [x] Cleanup history