### PR TITLE
Allow multiple direct mesh accesses per mesh

### DIFF
--- a/docs/changelog/2072.md
+++ b/docs/changelog/2072.md
@@ -1,0 +1,1 @@
+- Enabled calling `setMeshAccessRegion` once per mesh instead of once per participant.

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -890,8 +890,8 @@ public:
    * on the receiving side, since the associated data values of the
    * filtered vertices are filled with zero data.
    *
-   * @note This function can only be called once per participant and
-   * rank and trying to call it more than once results in an error.
+   * @note This function can only be called once per mesh and rank
+   * and trying to call it more than once results in an error.
    *
    * @note If you combine the direct access with a mpping (say you want
    * to read data from a defined mesh, as usual, but you want to directly

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -35,6 +35,9 @@ struct MeshContext {
   /// bounding-boxes.
   bool allowDirectAccess = false;
 
+  /// setMeshAccessRegion may only be called once per mesh(context)
+  bool accessRegionDefined = false;
+
   /// True, if accessor does create the mesh.
   bool provideMesh = false;
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1153,10 +1153,11 @@ void ParticipantImpl::setMeshAccessRegion(
   PRECICE_REQUIRE_MESH_USE(meshName);
   PRECICE_CHECK(_state != State::Finalized, "setMeshAccessRegion() cannot be called after finalize().");
   PRECICE_CHECK(_state != State::Initialized, "setMeshAccessRegion() needs to be called before initialize().");
-  PRECICE_CHECK(!_accessRegionDefined, "setMeshAccessRegion may only be called once.");
 
   // Get the related mesh
   MeshContext & context = _accessor->meshContext(meshName);
+
+  PRECICE_CHECK(!context.accessRegionDefined, "setMeshAccessRegion was already defined for mesh \"{}\" and may only be called once per mesh.", context.mesh->getName());
   mesh::PtrMesh mesh(context.mesh);
   int           dim = mesh->getDimensions();
   PRECICE_CHECK(boundingBox.size() == static_cast<unsigned long>(dim) * 2,
@@ -1179,7 +1180,7 @@ void ParticipantImpl::setMeshAccessRegion(
   // Expand the mesh associated bounding box
   mesh->expandBoundingBox(providedBoundingBox);
   // and set a flag so that we know the function was called
-  _accessRegionDefined = true;
+  context.accessRegionDefined = true;
 }
 
 void ParticipantImpl::getMeshVertexIDsAndCoordinates(

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1155,7 +1155,7 @@ void ParticipantImpl::setMeshAccessRegion(
   PRECICE_CHECK(_state != State::Initialized, "setMeshAccessRegion() needs to be called before initialize().");
 
   // Get the related mesh
-  MeshContext & context = _accessor->meshContext(meshName);
+  MeshContext &context = _accessor->meshContext(meshName);
 
   PRECICE_CHECK(!context.accessRegionDefined, "setMeshAccessRegion was already defined for mesh \"{}\" and may only be called once per mesh.", context.mesh->getName());
   mesh::PtrMesh mesh(context.mesh);

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1157,7 +1157,7 @@ void ParticipantImpl::setMeshAccessRegion(
   // Get the related mesh
   MeshContext &context = _accessor->meshContext(meshName);
 
-  PRECICE_CHECK(!context.accessRegionDefined, "setMeshAccessRegion was already defined for mesh \"{}\" and may only be called once per mesh.", context.mesh->getName());
+  PRECICE_CHECK(!context.accessRegionDefined, "A mesh access region was already defined for mesh \"{}\". setMeshAccessRegion may only be called once per mesh.", context.mesh->getName());
   mesh::PtrMesh mesh(context.mesh);
   int           dim = mesh->getDimensions();
   PRECICE_CHECK(boundingBox.size() == static_cast<unsigned long>(dim) * 2,

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -325,9 +325,6 @@ private:
   /// Are participants waiting for each other in finalize?
   bool _waitInFinalize = false;
 
-  /// setMeshAccessRegion may only be called once
-  mutable bool _accessRegionDefined = false;
-
   /// The current State of the Participant
   State _state{State::Constructed};
 


### PR DESCRIPTION
## Main changes of this PR

Allows multiple direct mesh accesses per mesh.

## Motivation and additional information

In #1033 we restricted the call of `setMeshAccessRegion` to a single call per participant per rank. I don't remember the motivation for this restriction, but it is highly inconsistent with the rest of our configuration. I don't see a clear reason for this restriction and there might be very well use cases for this, which would look like

```xml
  <participant name="SolverOne">
    <receive-mesh name="MeshTwo" from="SolverTwo" direct-access="true" />
    <receive-mesh name="MeshTwoB" from="SolverTwo" direct-access="true" />
```

i.e., a participant wants to access different meshes in a direct way. I have a test case using this for the indirect mesh access. The PR here is essentially an isolated fix, which was fixed as part of the (yet to come) indirect mesh access.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits. -> formatting is broken on Ubuntu 24.04
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite. -> coming with indirect access
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
