### PR TITLE
Refactor Quasi-Newton to make it more compatible with Waveform iterations

### DIFF
--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -42,22 +42,4 @@ void Acceleration::applyRelaxation(double omega, DataMap &cplData)
     couplingData.sample() = couplingData.timeStepsStorage().last().sample;
   }
 }
-
-void Acceleration::concatenateCouplingData(
-    const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const
-{
-  Eigen::Index offset = 0;
-  for (auto id : dataIDs) {
-    Eigen::Index size      = cplData.at(id)->values().size();
-    auto &       values    = cplData.at(id)->values();
-    const auto & oldValues = cplData.at(id)->previousIteration();
-    PRECICE_ASSERT(targetValues.size() >= offset + size, "Target vector was not initialized.", targetValues.size(), offset + size);
-    PRECICE_ASSERT(targetOldValues.size() >= offset + size, "Target vector was not initialized.");
-    for (Eigen::Index i = 0; i < size; i++) {
-      targetValues(i + offset)    = values(i);
-      targetOldValues(i + offset) = oldValues(i);
-    }
-    offset += size;
-  }
-}
 } // namespace precice::acceleration

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -64,9 +64,6 @@ protected:
   /// Checks if all dataIDs are contained in cplData
   void checkDataIDs(const DataMap &cplData) const;
 
-  /// Concatenates all coupling data involved into a single vector
-  void concatenateCouplingData(const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const;
-
   /// performs a relaxation given a relaxation factor omega
   static void applyRelaxation(double omega, DataMap &cplData);
 };

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -66,6 +66,10 @@ protected:
 
   /// performs a relaxation given a relaxation factor omega
   static void applyRelaxation(double omega, DataMap &cplData);
+
+  /// @brief Concatenates the data and old data in cplData into two long vectors
+  virtual void concatenateCouplingData(
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const = 0;
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -119,4 +119,21 @@ void AitkenAcceleration::iterationsConverged(
   _oldResiduals = Eigen::VectorXd::Constant(_oldResiduals.size(), std::numeric_limits<double>::max());
 }
 
+void AitkenAcceleration::concatenateCouplingData(
+    const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const
+{
+  Eigen::Index offset = 0;
+  for (auto id : dataIDs) {
+    Eigen::Index size      = cplData.at(id)->values().size();
+    auto &       values    = cplData.at(id)->values();
+    const auto & oldValues = cplData.at(id)->previousIteration();
+    PRECICE_ASSERT(targetValues.size() >= offset + size, "Target vector was not initialized.", targetValues.size(), offset + size);
+    PRECICE_ASSERT(targetOldValues.size() >= offset + size, "Target vector was not initialized.");
+    for (Eigen::Index i = 0; i < size; i++) {
+      targetValues(i + offset)    = values(i);
+      targetOldValues(i + offset) = oldValues(i);
+    }
+    offset += size;
+  }
+}
 } // namespace precice::acceleration

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -37,7 +37,7 @@ public:
       const DataMap &cpldata);
 
 protected:
-  /// @brief Concatenates the data and old data in cplData into two long vectors
+  /// @copydoc acceleration::Acceleration::concatenateCouplingData
   void concatenateCouplingData(
       const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final;
 

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -36,6 +36,11 @@ public:
   virtual void iterationsConverged(
       const DataMap &cpldata);
 
+protected:
+  /// @brief Concatenates the data and old data in cplData into two long vectors
+  void concatenateCouplingData(
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const;
+
 private:
   logging::Logger _log{"acceleration::AitkenAcceleration"};
 

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -39,7 +39,7 @@ public:
 protected:
   /// @brief Concatenates the data and old data in cplData into two long vectors
   void concatenateCouplingData(
-      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const;
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final;
 
 private:
   logging::Logger _log{"acceleration::AitkenAcceleration"};

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -322,8 +322,11 @@ void BaseQNAcceleration::performAcceleration(
     _oldXTilde           = _values;           // Store x tilde of primary and secondary data
     _oldPrimaryResiduals = _primaryResiduals; // Store current residual of primary data
 
-    // Perform relaxation on all of the coupling data
-    applyRelaxation(_initialRelaxation, cplData);
+    // Perform constant relaxation
+    // with residual: x_new = x_old + omega * res
+    _residuals *= _initialRelaxation;
+    _residuals += _oldValues;
+    _values = _residuals;
 
   } else {
     PRECICE_DEBUG("   Performing quasi-Newton Step");

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -322,11 +322,8 @@ void BaseQNAcceleration::performAcceleration(
     _oldXTilde           = _values;           // Store x tilde of primary and secondary data
     _oldPrimaryResiduals = _primaryResiduals; // Store current residual of primary data
 
-    // Perform constant relaxation
-    // with residual: x_new = x_old + omega * res
-    _residuals *= _initialRelaxation;
-    _residuals += _oldValues;
-    _values = _residuals;
+    // Perform relaxation on all of the coupling data
+    applyRelaxation(_initialRelaxation, cplData);
 
   } else {
     PRECICE_DEBUG("   Performing quasi-Newton Step");

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -383,7 +383,7 @@ void BaseQNAcceleration::performAcceleration(
      *               Thus, the pseudo inverse needs to be reverted before using it.
      */
     Eigen::VectorXd xUpdate = Eigen::VectorXd::Zero(_values.size());
-    computeQNUpdate(cplData, xUpdate);
+    computeQNUpdate(xUpdate);
 
     /**
      * apply quasiNewton update
@@ -663,5 +663,24 @@ void BaseQNAcceleration::writeInfo(
   }
   _infostringstream << std::flush;
 }
+
+void BaseQNAcceleration::concatenateCouplingData(
+    const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const
+{
+  Eigen::Index offset = 0;
+  for (auto id : dataIDs) {
+    Eigen::Index size      = cplData.at(id)->values().size();
+    auto &       values    = cplData.at(id)->values();
+    const auto & oldValues = cplData.at(id)->previousIteration();
+    PRECICE_ASSERT(targetValues.size() >= offset + size, "Target vector was not initialized.", targetValues.size(), offset + size);
+    PRECICE_ASSERT(targetOldValues.size() >= offset + size, "Target vector was not initialized.");
+    for (Eigen::Index i = 0; i < size; i++) {
+      targetValues(i + offset)    = values(i);
+      targetOldValues(i + offset) = oldValues(i);
+    }
+    offset += size;
+  }
+}
+
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -272,7 +272,7 @@ protected:
 
   /// @brief Concatenates the data and old data in cplData into two long vectors
   void concatenateCouplingData(
-      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const;
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final;
 
   int its = 0, tWindows = 0;
 

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -262,13 +262,17 @@ protected:
   virtual void applyFilter();
 
   /// Computes the quasi-Newton update using the specified pp scheme (IQNIMVJ, IQNILS)
-  virtual void computeQNUpdate(const DataMap &cplData, Eigen::VectorXd &xUpdate) = 0;
+  virtual void computeQNUpdate(Eigen::VectorXd &xUpdate) = 0;
 
   /// Removes one iteration from V,W matrices and adapts _matrixCols.
   virtual void removeMatrixColumn(int columnIndex);
 
-  /// Wwrites info to the _infostream (also in parallel)
+  /// Writes info to the _infostream (also in parallel)
   void writeInfo(const std::string &s, bool allProcs = false);
+
+  /// @brief Concatenates the data and old data in cplData into two long vectors
+  void concatenateCouplingData(
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const;
 
   int its = 0, tWindows = 0;
 

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -270,7 +270,7 @@ protected:
   /// Writes info to the _infostream (also in parallel)
   void writeInfo(const std::string &s, bool allProcs = false);
 
-  /// @brief Concatenates the data and old data in cplData into two long vectors
+  /// @copydoc acceleration::Acceleration::concatenateCouplingData
   void concatenateCouplingData(
       const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final;
 

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -29,6 +29,14 @@ public:
   {
   }
 
+protected:
+  /// @copydoc acceleration::Acceleration::concatenateCouplingData
+  void concatenateCouplingData(
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const override final
+  {
+    // function not needed in ConstantRelaxationAcceleration
+  }
+
 private:
   logging::Logger _log{"acceleration::ConstantRelaxationAcceleration"};
 

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -27,6 +27,7 @@ public:
 
   virtual void iterationsConverged(const DataMap &cplData) override
   {
+    // function not needed in ConstantRelaxationAcceleration
   }
 
 protected:

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -52,7 +52,7 @@ void IQNILSAcceleration::updateDifferenceMatrices(
   BaseQNAcceleration::updateDifferenceMatrices(cplData);
 }
 
-void IQNILSAcceleration::computeQNUpdate(const DataMap &cplData, Eigen::VectorXd &xUpdate)
+void IQNILSAcceleration::computeQNUpdate(Eigen::VectorXd &xUpdate)
 {
   PRECICE_TRACE();
   PRECICE_DEBUG("   Compute Newton factors");

--- a/src/acceleration/IQNILSAcceleration.hpp
+++ b/src/acceleration/IQNILSAcceleration.hpp
@@ -56,7 +56,7 @@ private:
   virtual void updateDifferenceMatrices(const DataMap &cplData);
 
   /// computes the IQN-ILS update using QR decomposition
-  virtual void computeQNUpdate(const DataMap &cplData, Eigen::VectorXd &xUpdate);
+  virtual void computeQNUpdate(Eigen::VectorXd &xUpdate);
 
   /// Removes one iteration from V,W matrices and adapts _matrixCols.
   virtual void removeMatrixColumn(int columnIndex);

--- a/src/acceleration/IQNIMVJAcceleration.cpp
+++ b/src/acceleration/IQNIMVJAcceleration.cpp
@@ -196,9 +196,7 @@ void IQNIMVJAcceleration::updateDifferenceMatrices(
 }
 
 // ==================================================================================
-void IQNIMVJAcceleration::computeQNUpdate(
-    const DataMap &  cplData,
-    Eigen::VectorXd &xUpdate)
+void IQNIMVJAcceleration::computeQNUpdate(Eigen::VectorXd &xUpdate)
 {
   /**
    * The inverse Jacobian
@@ -218,9 +216,9 @@ void IQNIMVJAcceleration::computeQNUpdate(
    *             using it in multiplications with the other matrices.
    */
   if (_alwaysBuildJacobian) {
-    computeNewtonUpdate(cplData, xUpdate);
+    computeNewtonUpdate(xUpdate);
   } else {
-    computeNewtonUpdateEfficient(cplData, xUpdate);
+    computeNewtonUpdateEfficient(xUpdate);
   }
 }
 
@@ -343,9 +341,7 @@ void IQNIMVJAcceleration::buildJacobian()
 }
 
 // ==================================================================================
-void IQNIMVJAcceleration::computeNewtonUpdateEfficient(
-    const DataMap &  cplData,
-    Eigen::VectorXd &xUpdate)
+void IQNIMVJAcceleration::computeNewtonUpdateEfficient(Eigen::VectorXd &xUpdate)
 {
   PRECICE_TRACE();
 
@@ -443,7 +439,7 @@ void IQNIMVJAcceleration::computeNewtonUpdateEfficient(
 }
 
 // ==================================================================================
-void IQNIMVJAcceleration::computeNewtonUpdate(const DataMap &cplData, Eigen::VectorXd &xUpdate)
+void IQNIMVJAcceleration::computeNewtonUpdate(Eigen::VectorXd &xUpdate)
 {
   PRECICE_TRACE();
 

--- a/src/acceleration/IQNIMVJAcceleration.hpp
+++ b/src/acceleration/IQNIMVJAcceleration.hpp
@@ -141,7 +141,7 @@ private:
   /** @brief: computes the IQNIMVJ update using QR decomposition of V,
    *        furthermore it updates the inverse of the system jacobian
    */
-  virtual void computeQNUpdate(const DataMap &cplData, Eigen::VectorXd &xUpdate);
+  virtual void computeQNUpdate(Eigen::VectorXd &xUpdate);
 
   /// @brief: updates the V, W matrices (as well as the matrices for the secondary data)
   virtual void updateDifferenceMatrices(const DataMap &cplData);
@@ -153,7 +153,7 @@ private:
    *  This method rebuilds the Jacobian matrix and the matrix W_til in each iteration
    *  which is not necessary and thus inefficient.
    */
-  void computeNewtonUpdate(const DataMap &cplData, Eigen::VectorXd &update);
+  void computeNewtonUpdate(Eigen::VectorXd &update);
 
   /** @brief: computes the quasi-Newton update vector based on the same numerics as above.
    *  However, it exploits the fact that the matrix W_til can be updated according to V and W
@@ -163,7 +163,7 @@ private:
    *  The Jacobian matrix only needs to be set up in the very last iteration of one time window, i.e.
    *  in iterationsConverged.
    */
-  void computeNewtonUpdateEfficient(const DataMap &cplData, Eigen::VectorXd &update);
+  void computeNewtonUpdateEfficient(Eigen::VectorXd &update);
 
   /** @brief: computes the pseudo inverse of V multiplied with V^T, i.e., Z = (V^TV)^-1V^T via QR-dec
    */


### PR DESCRIPTION
## Main changes of this PR

Moves concatenate coupling data into Aitken and BaseQNAcceleration to make it easier to first only support waveform iterations in the Quasi-Newton methods

Moves the initialization of vectors, matrices and preconditioners into their own function. The reason behind this change is that the vector and preconditioner initialization needs to know the time grid of the Quasi-Newton method, which is determined after the first waveform iteration.

Fixes some small errors

## Motivation and additional information

This pull request refactors Quasi-Newton methods to make them more compatible with Waveform iterations and to make #2005 easier to review.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I sticked to C++17 features.
* [ ] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
