### PR TITLE
Fix returns in bindings try blocks

### DIFF
--- a/extras/bindings/c/src/preciceC.cpp
+++ b/extras/bindings/c/src/preciceC.cpp
@@ -88,6 +88,7 @@ try {
   return impl->getMeshDimensions(meshName);
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 int precicec_getDataDimensions(const char *meshName, const char *dataName)
@@ -96,6 +97,7 @@ try {
   return impl->getDataDimensions(meshName, dataName);
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 int precicec_isCouplingOngoing()
@@ -107,6 +109,7 @@ try {
   return 0;
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 int precicec_isTimeWindowComplete()
@@ -118,6 +121,7 @@ try {
   return 0;
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 double precicec_getMaxTimeStepSize()
@@ -125,6 +129,7 @@ try {
   return impl->getMaxTimeStepSize();
 } catch (::precice::Error &e) {
   std::abort();
+  return -1.0;
 }
 
 int precicec_requiresInitialData()
@@ -133,6 +138,7 @@ try {
   return impl->requiresInitialData() ? 1 : 0;
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 int precicec_requiresWritingCheckpoint()
@@ -141,6 +147,7 @@ try {
   return impl->requiresWritingCheckpoint() ? 1 : 0;
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 int precicec_requiresReadingCheckpoint()
@@ -149,6 +156,7 @@ try {
   return impl->requiresReadingCheckpoint() ? 1 : 0;
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 int precicec_requiresMeshConnectivityFor(const char *meshName)
@@ -160,6 +168,7 @@ try {
   return 0;
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 int precicec_setMeshVertex(
@@ -171,6 +180,7 @@ try {
   return impl->setMeshVertex(meshName, {position, size});
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 void precicec_setMeshVertices(
@@ -194,6 +204,7 @@ try {
   return impl->getMeshVertexSize(meshName);
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 void precicec_setMeshEdge(
@@ -332,6 +343,7 @@ try {
   return 0;
 } catch (::precice::Error &e) {
   std::abort();
+  return -1;
 }
 
 void precicec_writeGradientData(
@@ -350,10 +362,8 @@ try {
 }
 
 const char *precicec_getVersionInformation()
-try {
+{
   return precice::versionInformation;
-} catch (::precice::Error &e) {
-  std::abort();
 }
 
 void precicec_setMeshAccessRegion(

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -375,21 +375,17 @@ try {
 int precice::impl::strippedLength(
     const char *string,
     int         length)
-try {
+{
   int i = length - 1;
   while (((string[i] == ' ') || (string[i] == 0)) && (i >= 0)) {
     i--;
   }
   return i + 1;
-} catch (::precice::Error &e) {
-  std::abort();
 }
 
 std::string_view precice::impl::strippedStringView(const char *string, int length)
-try {
+{
   return {string, static_cast<std::string_view::size_type>(strippedLength(string, length))};
-} catch (::precice::Error &e) {
-  std::abort();
 }
 
 void precicef_get_version_information_(

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -391,14 +391,8 @@ std::string_view precice::impl::strippedStringView(const char *string, int lengt
 void precicef_get_version_information_(
     char *versionInfo,
     int   lengthVersionInfo)
-try {
-  const std::string &versionInformation = precice::versionInformation;
-  PRECICE_ASSERT(versionInformation.size() < (size_t) lengthVersionInfo, versionInformation.size(), lengthVersionInfo);
-  for (size_t i = 0; i < versionInformation.size(); i++) {
-    versionInfo[i] = versionInformation[i];
-  }
-} catch (::precice::Error &e) {
-  std::abort();
+{
+  std::strncpy(versionInfo, precice::versionInformation, lengthVersionInfo);
 }
 
 void precicef_requires_gradient_data_for_(


### PR DESCRIPTION
## Main changes of this PR

This PR fixes compiler errors due to missing return statements after `std::abort` in the C bindings, which is a workaround for compilers like gcc 10 that don't take the `noreturn` into account. Also removes some unnecessary try blocks in the Fortran bindings.


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
