### PR TITLE
Remove sync events in serial

### DIFF
--- a/src/profiling/Event.cpp
+++ b/src/profiling/Event.cpp
@@ -11,7 +11,7 @@ Event::Event(std::string_view eventName, Options options)
   auto &er   = EventRegistry::instance();
   auto  name = std::string(EventRegistry::instance().prefix).append(eventName);
   _eid       = er.nameToID(name);
-  if (_synchronize) {
+  if (_synchronize && er.parallel()) {
     _sid = er.nameToID(name + ".sync");
   }
   start();
@@ -33,7 +33,7 @@ void Event::start()
     return;
   }
 
-  if (_synchronize && ::precice::utils::IntraComm::willSynchronize()) {
+  if (_synchronize && registry.parallel() && ::precice::utils::IntraComm::willSynchronize()) {
     // We need to synchronize, so we record a sync event
     PRECICE_ASSERT(_sid != -1);
     registry.putCritical(StartEntry{_sid, Clock::now()});

--- a/src/profiling/EventUtils.hpp
+++ b/src/profiling/EventUtils.hpp
@@ -131,6 +131,12 @@ public:
     return _mode == Mode::All || (ec == EventClass::Fundamental && _mode == Mode::Fundamental);
   }
 
+  /// Is the solver running in parallel?
+  inline bool parallel() const
+  {
+    return _size > 1;
+  }
+
   int nameToID(std::string_view name);
 
   /// Currently active prefix. Changing that applies only to newly created events.


### PR DESCRIPTION
## Main changes of this PR

This PR removes sync events in serial.

## Motivation and additional information

Closes #2077

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
