### PR TITLE
Replace Ginkgo triangular solver by dense BLAS trsv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,7 @@ endif()
     endif()
 
     find_package(hipsolver REQUIRED)
+    find_package(hipblas REQUIRED)
   endif()
 
   if(PRECICE_WITH_OPENMP)
@@ -448,7 +449,7 @@ if (PRECICE_FEATURE_GINKGO_MAPPING)
     target_compile_definitions(preciceCore PUBLIC PRECICE_WITH_HIP)
     set(_hiplist ${PROJECT_SOURCE_DIR}/src/mapping/device/HipQRSolver.hip.cpp)
     target_sources(preciceCore PRIVATE ${_hiplist})
-    target_link_libraries(preciceCore PRIVATE hip::device Ginkgo::ginkgo roc::hipsolver)
+    target_link_libraries(preciceCore PUBLIC hip::device Ginkgo::ginkgo roc::hipsolver roc::hipblas)
 
     message(STATUS "Enabled HIP support for preCICE via the Ginkgo library.")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,7 +441,7 @@ if (PRECICE_FEATURE_GINKGO_MAPPING)
     # Required to make nvcc happy
     target_compile_definitions(preciceCore PRIVATE BOOST_PP_VARIADICS=1)
     target_sources(preciceCore PRIVATE ${PROJECT_SOURCE_DIR}/src/mapping/device/CudaQRSolver.cuh ${PROJECT_SOURCE_DIR}/src/mapping/device/CudaQRSolver.cu)
-    target_link_libraries(preciceCore PUBLIC cusolver cublas)
+    target_link_libraries(preciceCore PRIVATE cusolver cublas)
     message(STATUS "Enabled CUDA support for preCICE via the Ginkgo library.")
   endif()
 
@@ -449,7 +449,7 @@ if (PRECICE_FEATURE_GINKGO_MAPPING)
     target_compile_definitions(preciceCore PUBLIC PRECICE_WITH_HIP)
     set(_hiplist ${PROJECT_SOURCE_DIR}/src/mapping/device/HipQRSolver.hip.cpp)
     target_sources(preciceCore PRIVATE ${_hiplist})
-    target_link_libraries(preciceCore PUBLIC hip::device Ginkgo::ginkgo roc::hipsolver roc::hipblas)
+    target_link_libraries(preciceCore PRIVATE hip::device Ginkgo::ginkgo roc::hipsolver roc::hipblas)
 
     message(STATUS "Enabled HIP support for preCICE via the Ginkgo library.")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,7 +440,7 @@ if (PRECICE_FEATURE_GINKGO_MAPPING)
     # Required to make nvcc happy
     target_compile_definitions(preciceCore PRIVATE BOOST_PP_VARIADICS=1)
     target_sources(preciceCore PRIVATE ${PROJECT_SOURCE_DIR}/src/mapping/device/CudaQRSolver.cuh ${PROJECT_SOURCE_DIR}/src/mapping/device/CudaQRSolver.cu)
-    target_link_libraries(preciceCore PRIVATE cusolver)
+    target_link_libraries(preciceCore PUBLIC cusolver cublas)
     message(STATUS "Enabled CUDA support for preCICE via the Ginkgo library.")
   endif()
 

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -185,7 +185,6 @@ else()
 endif()
 
 # Add solverdummy tests
-
 add_precice_test_build_solverdummy(cpp)
 add_precice_test_build_solverdummy(c)
 add_precice_test_build_solverdummy(fortran)

--- a/docs/changelog/2079.md
+++ b/docs/changelog/2079.md
@@ -1,0 +1,1 @@
+- Replaced Ginkgo's triangular solver by cublas and hipblas implementations. Using the Cuda/HIP QR decomposition requires now the Cuda/HIP blas library.

--- a/src/mapping/GinkgoRadialBasisFctSolver.hpp
+++ b/src/mapping/GinkgoRadialBasisFctSolver.hpp
@@ -418,8 +418,8 @@ GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::GinkgoRadialBasisFctSolver(
 
     _dQ_T_Rhs = gko::share(GinkgoVector::create(_deviceExecutor, gko::dim<2>{_decompMatrixQ_T->get_size()[0], 1}));
 
-    auto triangularSolverFactory = triangular::build().on(_deviceExecutor);
-    _triangularSolver            = gko::share(triangularSolverFactory->generate(_decompMatrixR));
+    // auto triangularSolverFactory = triangular::build().on(_deviceExecutor);
+    // _triangularSolver            = gko::share(triangularSolverFactory->generate(_decompMatrixR));
   } else {
     PRECICE_UNREACHABLE("Unknown solver type");
   }
@@ -489,8 +489,8 @@ Eigen::VectorXd GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::solveConsis
   }
 
   if (GinkgoSolverType::QR == _solverType) {
-    _decompMatrixQ_T->apply(dRhs, _dQ_T_Rhs);
-    _triangularSolver->apply(_dQ_T_Rhs, _rbfCoefficients);
+    // Upper Trs U x = b
+    solvewithQRDecompositionCuda(_ginkgoParameter.deviceId, gko::lend(_decompMatrixR), gko::lend(_rbfCoefficients), gko::lend(_dQ_T_Rhs), gko::lend(_decompMatrixQ_T), gko::lend(dRhs));
   } else {
     _solveRBFSystem(dRhs);
   }
@@ -543,8 +543,7 @@ Eigen::VectorXd GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::solveConser
   _matrixA->transpose()->apply(dRhs, dAu);
 
   if (GinkgoSolverType::QR == _solverType) {
-    _decompMatrixQ_T->apply(dAu, _dQ_T_Rhs);
-    _triangularSolver->apply(_dQ_T_Rhs, _rbfCoefficients);
+    solvewithQRDecompositionCuda(_ginkgoParameter.deviceId, gko::lend(_decompMatrixR), gko::lend(_rbfCoefficients), gko::lend(_dQ_T_Rhs), gko::lend(_decompMatrixQ_T), gko::lend(dAu));
   } else {
     _solveRBFSystem(dAu);
   }

--- a/src/mapping/GinkgoRadialBasisFctSolver.hpp
+++ b/src/mapping/GinkgoRadialBasisFctSolver.hpp
@@ -488,11 +488,11 @@ Eigen::VectorXd GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::solveConsis
     // Upper Trs U x = b
     if ("cuda-executor" == _ginkgoParameter.executor) {
 #ifdef PRECICE_WITH_CUDA
-      solvewithQRDecompositionCuda(_ginkgoParameter.deviceId, _decompMatrixR.get(), _rbfCoefficients.get(), _dQ_T_Rhs.get(), _decompMatrixQ_T.get(), dRhs.get());
+      solvewithQRDecompositionCuda(_deviceExecutor, _decompMatrixR.get(), _rbfCoefficients.get(), _dQ_T_Rhs.get(), _decompMatrixQ_T.get(), dRhs.get());
 #endif
     } else if ("hip-executor" == _ginkgoParameter.executor) {
 #ifdef PRECICE_WITH_HIP
-      // solvewithQRDecompositionHip(_ginkgoParameter.deviceId, gko::lend(_decompMatrixR), gko::lend(_rbfCoefficients), gko::lend(_dQ_T_Rhs), gko::lend(_decompMatrixQ_T), gko::lend(dRhs));
+      solvewithQRDecompositionHip(_deviceExecutor, _decompMatrixR.get(), _rbfCoefficients.get(), _dQ_T_Rhs.get(), _decompMatrixQ_T.get(), dRhs.get());
 #endif
     } else {
       PRECICE_UNREACHABLE("Not implemented");
@@ -551,11 +551,11 @@ Eigen::VectorXd GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::solveConser
   if (GinkgoSolverType::QR == _solverType) {
     if ("cuda-executor" == _ginkgoParameter.executor) {
 #ifdef PRECICE_WITH_CUDA
-      solvewithQRDecompositionCuda(_ginkgoParameter.deviceId, _decompMatrixR.get(), _rbfCoefficients.get(), _dQ_T_Rhs.get(), _decompMatrixQ_T.get(), dAu.get());
+      solvewithQRDecompositionCuda(_deviceExecutor, _decompMatrixR.get(), _rbfCoefficients.get(), _dQ_T_Rhs.get(), _decompMatrixQ_T.get(), dAu.get());
 #endif
     } else if ("hip-executor" == _ginkgoParameter.executor) {
 #ifdef PRECICE_WITH_HIP
-      solvewithQRDecompositionHip(_ginkgoParameter.deviceId, _decompMatrixR.get(), _rbfCoefficients.get(), _dQ_T_Rhs.get(), _decompMatrixQ_T.get(), dAu.get());
+      solvewithQRDecompositionHip(_deviceExecutor, _decompMatrixR.get(), _rbfCoefficients.get(), _dQ_T_Rhs.get(), _decompMatrixQ_T.get(), dAu.get());
 #endif
     } else {
       PRECICE_UNREACHABLE("Not implemented");

--- a/src/mapping/device/CudaQRSolver.cu
+++ b/src/mapping/device/CudaQRSolver.cu
@@ -86,11 +86,9 @@ void computeQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, Gink
   cusolverDnDestroy(solverHandle);
 }
 
-void solvewithQRDecompositionCuda(const int deviceId, gko::matrix::Dense<> *U, gko::matrix::Dense<> *x, gko::matrix::Dense<> *rhs, gko::matrix::Dense<> *matQ, gko::matrix::Dense<> *in_vec)
+void solvewithQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, gko::matrix::Dense<> *U, gko::matrix::Dense<> *x, gko::matrix::Dense<> *rhs, gko::matrix::Dense<> *matQ, gko::matrix::Dense<> *in_vec)
 {
-  int backupDeviceId{};
-  cudaGetDevice(&backupDeviceId);
-  cudaSetDevice(deviceId);
+  auto scope_guard = exec->get_scoped_device_id_guard();
 
   cublasHandle_t handle;
   cublasStatus_t cublasStatus = cublasCreate(&handle);
@@ -106,23 +104,27 @@ void solvewithQRDecompositionCuda(const int deviceId, gko::matrix::Dense<> *U, g
                              rhs->get_values(), 1);
   assert(cublasStatus == CUBLAS_STATUS_SUCCESS);
 
-  // this works
-  cublasSideMode_t  side  = CUBLAS_SIDE_LEFT;
   cublasFillMode_t  uplo  = CUBLAS_FILL_MODE_LOWER;
   cublasOperation_t trans = CUBLAS_OP_T;
 
   // unit triangular = diag = 1
   cublasDiagType_t diag    = CUBLAS_DIAG_NON_UNIT;
-  double           alpha   = 1.0;
   int              rows    = rhs->get_size()[0];
-  int              columns = 1;
   const int        lda     = max(1, rows);
-  const int        ldb     = max(1, rows);
 
   cublasStatus = cublasDtrsv(handle, uplo,
                              trans, diag,
                              rows, U->get_values(), lda,
                              rhs->get_values(), 1);
+  assert(cublasStatus == CUBLAS_STATUS_SUCCESS);
+
+  // In case we refactor the code in the future to make use of
+  // dtrsm instead of dtrsv (processing vector data as a whole),
+  // the following holds
+  // double           alpha   = 1.0;
+  // int              columns = 1;
+  // const int        ldb     = max(1, rows);
+  // cublasSideMode_t  side  = CUBLAS_SIDE_LEFT;
   // cublasStatus = cublasDtrsm(handle,
   //                            side,
   //                            uplo,
@@ -134,11 +136,10 @@ void solvewithQRDecompositionCuda(const int deviceId, gko::matrix::Dense<> *U, g
   //                            U->get_values(), lda,
   //                            rhs->get_values(),
   //                            ldb);
-  assert(cublasStatus == CUBLAS_STATUS_SUCCESS);
+
   cudaDeviceSynchronize();
   *x           = *rhs;
   cublasStatus = cublasDestroy(handle);
   assert(cublasStatus == CUBLAS_STATUS_SUCCESS);
-  cudaSetDevice(backupDeviceId);
 }
 #endif

--- a/src/mapping/device/CudaQRSolver.cu
+++ b/src/mapping/device/CudaQRSolver.cu
@@ -86,7 +86,7 @@ void computeQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, Gink
   cusolverDnDestroy(solverHandle);
 }
 
-void solvewithQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, gko::matrix::Dense<> *U, gko::matrix::Dense<> *x, gko::matrix::Dense<> *rhs, gko::matrix::Dense<> *matQ, gko::matrix::Dense<> *in_vec)
+void solvewithQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *U, GinkgoVector *x, GinkgoVector *rhs, GinkgoMatrix *matQ, GinkgoVector *in_vec)
 {
   auto scope_guard = exec->get_scoped_device_id_guard();
 

--- a/src/mapping/device/CudaQRSolver.cuh
+++ b/src/mapping/device/CudaQRSolver.cuh
@@ -8,6 +8,6 @@
 */
 void computeQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *A_Q, GinkgoVector *R);
 
-void solvewithQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, gko::matrix::Dense<> *U, gko::matrix::Dense<> *x, gko::matrix::Dense<> *rhs, gko::matrix::Dense<> *matQ,  gko::matrix::Dense<> *in_vec);
+void solvewithQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *U, GinkgoVector *x, GinkgoVector *rhs, GinkgoMatrix *matQ,  GinkgoVector *in_vec);
 
 #endif

--- a/src/mapping/device/CudaQRSolver.cuh
+++ b/src/mapping/device/CudaQRSolver.cuh
@@ -8,4 +8,6 @@
 */
 void computeQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *A_Q, GinkgoVector *R);
 
+void solvewithQRDecompositionCuda(const int deviceId, gko::matrix::Dense<> *U, gko::matrix::Dense<> *x, gko::matrix::Dense<> *rhs, gko::matrix::Dense<> *matQ,  gko::matrix::Dense<> *in_vec);
+
 #endif

--- a/src/mapping/device/CudaQRSolver.cuh
+++ b/src/mapping/device/CudaQRSolver.cuh
@@ -8,6 +8,6 @@
 */
 void computeQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *A_Q, GinkgoVector *R);
 
-void solvewithQRDecompositionCuda(const int deviceId, gko::matrix::Dense<> *U, gko::matrix::Dense<> *x, gko::matrix::Dense<> *rhs, gko::matrix::Dense<> *matQ,  gko::matrix::Dense<> *in_vec);
+void solvewithQRDecompositionCuda(const std::shared_ptr<gko::Executor> &exec, gko::matrix::Dense<> *U, gko::matrix::Dense<> *x, gko::matrix::Dense<> *rhs, gko::matrix::Dense<> *matQ,  gko::matrix::Dense<> *in_vec);
 
 #endif

--- a/src/mapping/device/HipQRSolver.hip.cpp
+++ b/src/mapping/device/HipQRSolver.hip.cpp
@@ -1,10 +1,11 @@
 #ifdef PRECICE_WITH_HIP
 
-#include "mapping/device/HipQRSolver.hip.hpp"
 #include <ginkgo/ginkgo.hpp>
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 #include <hipsolver/hipsolver.h>
+#include "mapping/device/HipQRSolver.hip.hpp"
+#include <hipblas/hipblas.h>
 
 void computeQRDecompositionHip(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *A_Q, GinkgoVector *R)
 {

--- a/src/mapping/device/HipQRSolver.hip.hpp
+++ b/src/mapping/device/HipQRSolver.hip.hpp
@@ -8,4 +8,5 @@
 */
 void computeQRDecompositionHip(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *A_Q, GinkgoVector *R);
 
+void solvewithQRDecompositionHip(const std::shared_ptr<gko::Executor> &exec, GinkgoMatrix *U, GinkgoVector *x, GinkgoVector *rhs, GinkgoMatrix *matQ,  GinkgoVector *in_vec);
 #endif


### PR DESCRIPTION
## Main changes of this PR

.. to replace the Ginkgo triangular solver (only relevant for the QR-decomposition).

## Motivation and additional information

More of a performance regression (loosely related to #2051)

The mapData timings
[comparison-mapt.pdf](https://github.com/user-attachments/files/17029800/comparison-mapt.pdf)

and triangular solve timings
[comparison-trsvt.pdf](https://github.com/user-attachments/files/17029795/comparison-trsvt.pdf)

I started a discussion in the Ginkgo project, let's see if I get some feedback there.

I still need to clean-up the current state. Also (FYI) the assembly timings:


[comparison-assemblyt.pdf](https://github.com/user-attachments/files/17029820/comparison-assemblyt.pdf)


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
