### PR TITLE
Catch Error in check

### DIFF
--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <precice/Exceptions.hpp>
 #include <precice/Tooling.hpp>
 #include <stdexcept>
 #include <string>
@@ -56,7 +57,10 @@ int main(int argc, char **argv)
         return 1;
       }
     }
-    precice::tooling::checkConfiguration(file, participant, size);
+    try {
+      precice::tooling::checkConfiguration(file, participant, size);
+    } catch (const ::precice::Error &) {
+    }
     return 0;
   }
 


### PR DESCRIPTION
## Main changes of this PR

Catches `precice::Error` in check invocation.

## Motivation and additional information

Prevents coredump on error

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
