### PR TITLE
Fix boolean default values in config reference

### DIFF
--- a/src/xml/Printer.cpp
+++ b/src/xml/Printer.cpp
@@ -65,25 +65,24 @@ std::ostream &printDTD(std::ostream &out, const XMLAttribute<ATTRIBUTE_T> &attr,
 template <typename ATTRIBUTE_T>
 std::ostream &printMD(std::ostream &out, const XMLAttribute<ATTRIBUTE_T> &attr)
 {
-  out << "| " << attr.getName() << " | " << utils::getTypeName(attr.getDefaultValue()) << " | " << attr.getUserDocumentation() << " | ";
+  fmt::print(out,
+             "| {} | {} | {} |",
+             attr.getName(),
+             utils::getTypeName(attr.getDefaultValue()),
+             attr.getUserDocumentation());
+
   if (attr.hasDefaultValue()) {
-    out << '`' << attr.getDefaultValue() << '`';
+    fmt::print(out, " `{}` |", attr.getDefaultValue());
   } else {
-    out << "_none_";
+    out << " _none_ |";
   }
-  out << " | ";
 
   const auto &options = attr.getOptions();
   if (options.empty()) {
-    out << "none";
+    out << " none |";
   } else {
-    out << '`' << options.front() << '`';
-    for (auto iter = ++options.cbegin(); iter != options.cend(); ++iter) {
-      out << ", " << '`' << *iter << '`';
-    }
+    fmt::print(out, " `{}` |", fmt::join(options, "`, `"));
   }
-
-  out << " |";
   return out;
 }
 
@@ -93,7 +92,7 @@ std::ostream &printExample(std::ostream &out, const XMLAttribute<ATTRIBUTE_T> &a
 {
   out << attr.getName() << "=\"";
   if (attr.hasDefaultValue()) {
-    out << attr.getDefaultValue();
+    fmt::print(out, "{}", attr.getDefaultValue());
   } else {
     out << '{' << utils::getTypeName(attr.getDefaultValue()) << '}';
   }


### PR DESCRIPTION
## Main changes of this PR

This PR fixes the appearance of boolean default values to using `true`/`false` instead of 1/0.

## Motivation and additional information

Makes the reference easier to digest.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
