### PR TITLE
Use dot as CWD in config

### DIFF
--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -32,7 +32,7 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
     tags.push_back(tag);
   }
 
-  auto attrLocation = XMLAttribute<std::string>(ATTR_LOCATION, "")
+  auto attrLocation = XMLAttribute<std::string>(ATTR_LOCATION, ".")
                           .setDocumentation("Directory to export the files to.");
 
   auto attrEveryNTimeWindows = makeXMLAttribute(ATTR_EVERY_N_TIME_WINDOWS, 1)

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -204,7 +204,7 @@ ParticipantConfiguration::ParticipantConfiguration(
                                "for the InfiniBand on SuperMUC. ");
     tagIntraComm.addAttribute(attrNetwork);
 
-    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, ".")
                                      .setDocumentation(
                                          "Directory where connection information is exchanged. By default, the "
                                          "directory of startup is chosen.");
@@ -219,7 +219,7 @@ ParticipantConfiguration::ParticipantConfiguration(
     doc += "Use this tag to use MPI with separated communication spaces instead instead.";
     tagIntraComm.setDocumentation(doc);
 
-    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, "")
+    auto attrExchangeDirectory = makeXMLAttribute(ATTR_EXCHANGE_DIRECTORY, ".")
                                      .setDocumentation(
                                          "Directory where connection information is exchanged. By default, the "
                                          "directory of startup is chosen.");


### PR DESCRIPTION
## Main changes of this PR

Changes empty export location and intra-comm exchange directory to ".", which is the standard for the current working directory.

## Motivation and additional information

Continuation of #2087

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

