### PR TITLE
Reword receive-mesh docs

### DIFF
--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -126,56 +126,46 @@ ParticipantConfiguration::ParticipantConfiguration(
   tag.addSubtag(tagWatchIntegral);
 
   XMLTag tagProvideMesh(*this, TAG_PROVIDE_MESH, XMLTag::OCCUR_ARBITRARY);
-  doc = "Provide a mesh (see tag <mesh>) to other participants.";
+  doc = "Provide a mesh (see tag `<mesh>`) to other participants.";
   tagProvideMesh.setDocumentation(doc);
   attrName.setDocumentation("Name of the mesh to provide.");
   tagProvideMesh.addAttribute(attrName);
   tag.addSubtag(tagProvideMesh);
 
   XMLTag tagReceiveMesh(*this, TAG_RECEIVE_MESH, XMLTag::OCCUR_ARBITRARY);
-  doc = "Makes a remote mesh (see tag <mesh>) available to this participant.";
+  doc = "Makes a remote mesh (see tag `<mesh>`) available to this participant.";
   tagReceiveMesh.setDocumentation(doc);
   attrName.setDocumentation("Name of the mesh to receive.");
   tagReceiveMesh.addAttribute(attrName);
   auto attrFrom = XMLAttribute<std::string>(ATTR_FROM)
                       .setDocumentation("The name of the participant to receive the mesh from. "
-                                        "This participant needs to provide the mesh using <provide-mesh />.");
-  tagReceiveMesh.addAttribute(attrFrom);
-  auto attrSafetyFactor = makeXMLAttribute(ATTR_SAFETY_FACTOR, 0.5)
+                                        "This participant needs to provide the mesh using `<provide-mesh />`.");
+
+  auto attrDirectAccess = makeXMLAttribute(ATTR_DIRECT_ACCESS, false)
                               .setDocumentation(
-                                  "If a mesh is received from another partipant (see tag <from>), it needs to be"
-                                  "decomposed at the receiving participant. To speed up this process, "
-                                  "a geometric filter (see tag <geometric-filter>), i.e. filtering by bounding boxes around the local mesh, can be used. "
-                                  "This safety factor defines by which factor this local information is "
-                                  "increased. An example: 0.5 means that the bounding box is 150% of its original size.");
-  tagReceiveMesh.addAttribute(attrSafetyFactor);
+                                  "Controls direct access to a received mesh without having to map it to a provided mesh. "
+                                  "A received mesh needs to be decomposed using a region of interest, which cannot inferred, if there are no mappings to or from a provided mesh. "
+                                  "To manually provide the region use the API function `setMeshAccessRegion()`.");
+  tagReceiveMesh.addAttribute(attrDirectAccess);
 
   auto attrGeoFilter = XMLAttribute<std::string>(ATTR_GEOMETRIC_FILTER)
                            .setDocumentation(
-                               "If a mesh is received from another partipant (see tag <from>), it needs to be"
-                               "decomposed at the receiving participant. To speed up this process, "
-                               "a geometric filter, i.e. filtering by bounding boxes around the local mesh, can be used. "
-                               "Two different variants are implemented: a filter \"on-primary\" strategy, "
-                               "which is beneficial for a huge mesh and a low number of processors, and a filter "
-                               "\"on-secondary\" strategy, which performs better for a very high number of "
-                               "processors. Both result in the same distribution (if the safety factor is sufficiently large). "
-                               "\"on-primary\" is not supported if you use two-level initialization. "
-                               "For very asymmetric cases, the filter can also be switched off completely (\"no-filter\").")
+                               "A received mesh needs to be decomposed using a mapping-inferred region of interest, if it is not directly-accessed. "
+                               "A geometric filter based on bounding-boxes around the local mesh can speed up this process. "
+                               "`on-primary-rank` is beneficial for a huge mesh and a low number of processors, but is incompatible with two-level initialization. "
+                               "`on-secondary-ranks` performs better for a very high number of processors. "
+                               "Both result in the same distribution if the safety-factor is sufficiently large. "
+                               "`no-filter` may be useful for very asymmetric cases.")
                            .setOptions({VALUE_NO_FILTER, VALUE_FILTER_ON_PRIMARY_RANK, VALUE_FILTER_ON_SECONDARY_RANKS})
                            .setDefaultValue(VALUE_FILTER_ON_SECONDARY_RANKS);
   tagReceiveMesh.addAttribute(attrGeoFilter);
 
-  auto attrDirectAccess = makeXMLAttribute(ATTR_DIRECT_ACCESS, false)
+  tagReceiveMesh.addAttribute(attrFrom);
+  auto attrSafetyFactor = makeXMLAttribute(ATTR_SAFETY_FACTOR, 0.5)
                               .setDocumentation(
-                                  "If a mesh is received from another partipant (see tag <from>), it needs to be"
-                                  "decomposed at the receiving participant. In case a mapping is defined, the "
-                                  "mesh is decomposed according to the local provided mesh associated to the mapping. "
-                                  "In case no mapping has been defined (you want to access "
-                                  "the mesh and related data direct), there is no obvious way on how to decompose the "
-                                  "mesh, since no mesh needs to be provided by the participant. For this purpose, bounding "
-                                  "boxes can be defined (see API function \"setMeshAccessRegion\") and used by selecting "
-                                  "the option direct-access=\"true\".");
-  tagReceiveMesh.addAttribute(attrDirectAccess);
+                                  "The safety-factor of the geometric-filter uniformly scales the bounding box by the given factor. "
+                                  "A safety-factor of `0.5` means that the bounding box is 150% of its original size.");
+  tagReceiveMesh.addAttribute(attrSafetyFactor);
 
   tag.addSubtag(tagReceiveMesh);
 

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -163,7 +163,7 @@ ParticipantConfiguration::ParticipantConfiguration(
   tagReceiveMesh.addAttribute(attrFrom);
   auto attrSafetyFactor = makeXMLAttribute(ATTR_SAFETY_FACTOR, 0.5)
                               .setDocumentation(
-                                  "The safety-factor of the geometric-filter uniformly scales the bounding box by the given factor. "
+                                  "The safety factor of the geometric filter uniformly scales the rank-local bounding box by the given factor. "
                                   "A safety-factor of `0.5` means that the bounding box is 150% of its original size.");
   tagReceiveMesh.addAttribute(attrSafetyFactor);
 

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -144,18 +144,18 @@ ParticipantConfiguration::ParticipantConfiguration(
   auto attrDirectAccess = makeXMLAttribute(ATTR_DIRECT_ACCESS, false)
                               .setDocumentation(
                                   "Controls direct access to a received mesh without having to map it to a provided mesh. "
-                                  "A received mesh needs to be decomposed using a region of interest, which cannot inferred, if there are no mappings to or from a provided mesh. "
-                                  "To manually provide the region use the API function `setMeshAccessRegion()`.");
+                                  "A received mesh needs to be decomposed in preCICE using a region of interest, which cannot be inferred, if there are no mappings to or from a provided mesh. "
+                                  "In such cases the API function `setMeshAccessRegion()` must be used to define the region of interest.");
   tagReceiveMesh.addAttribute(attrDirectAccess);
 
   auto attrGeoFilter = XMLAttribute<std::string>(ATTR_GEOMETRIC_FILTER)
                            .setDocumentation(
-                               "A received mesh needs to be decomposed using a mapping-inferred region of interest, if it is not directly-accessed. "
+                               "For parallel execution, a received mesh needs to be decomposed. "
                                "A geometric filter based on bounding-boxes around the local mesh can speed up this process. "
                                "`on-primary-rank` is beneficial for a huge mesh and a low number of processors, but is incompatible with two-level initialization. "
                                "`on-secondary-ranks` performs better for a very high number of processors. "
                                "Both result in the same distribution if the safety-factor is sufficiently large. "
-                               "`no-filter` may be useful for very asymmetric cases.")
+                               "`no-filter` may be useful for very asymmetric cases and for debugging.")
                            .setOptions({VALUE_NO_FILTER, VALUE_FILTER_ON_PRIMARY_RANK, VALUE_FILTER_ON_SECONDARY_RANKS})
                            .setDefaultValue(VALUE_FILTER_ON_SECONDARY_RANKS);
   tagReceiveMesh.addAttribute(attrGeoFilter);

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -152,6 +152,7 @@ ParticipantConfiguration::ParticipantConfiguration(
                            .setDocumentation(
                                "For parallel execution, a received mesh needs to be decomposed. "
                                "A geometric filter based on bounding-boxes around the local mesh can speed up this process. "
+                               "This setting controls if and where this filter is applied. "
                                "`on-primary-rank` is beneficial for a huge mesh and a low number of processors, but is incompatible with two-level initialization. "
                                "`on-secondary-ranks` performs better for a very high number of processors. "
                                "Both result in the same distribution if the safety-factor is sufficiently large. "


### PR DESCRIPTION
## Main changes of this PR

This PR rewords the receive-mesh XML documentation, which was pretty confusing and repetitive.

Open for debate as this touches direct-access and 2LI.

An alternative would be to move more information into the description of the tag.

**What it looks like**

Ideally the order of attributes would be `name`, `direct-access`, `geometric-filter`, `safety-factor`.

![image](https://github.com/user-attachments/assets/cdb181f8-484f-4366-98bc-ba3328c1f10d)


## Motivation and additional information

Clarify what things do.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I sticked to C++17 features.
* [x] I sticked to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
