### PR TITLE
Keep order of attributes in markdown docs

### DIFF
--- a/src/xml/Printer.cpp
+++ b/src/xml/Printer.cpp
@@ -267,33 +267,38 @@ std::ostream &printMD(std::ostream &out, const XMLTag &tag, int level, std::map<
   out << "**Example:**  \n```xml\n";
   printExample(out, tag, 0) << "\n```\n\n";
 
-  if (!(tag.getDoubleAttributes().empty() &&
-        tag.getIntAttributes().empty() &&
-        tag.getStringAttributes().empty() &&
-        tag.getBooleanAttributes().empty() &&
-        tag.getEigenVectorXdAttributes().empty())) {
+  if (auto attributes = tag.getAttributes();
+      !attributes.empty()) {
     out << "| Attribute | Type | Description | Default | Options |\n";
     out << "| --- | --- | --- | --- | --- |\n";
-    for (const auto &pair : tag.getDoubleAttributes()) {
-      printMD(out, pair.second) << '\n';
-    }
 
-    for (const auto &pair : tag.getIntAttributes()) {
-      printMD(out, pair.second) << '\n';
+    for (const auto &name : tag.getAttributes()) {
+      if (auto iter = tag.getDoubleAttributes().find(name);
+          iter != tag.getDoubleAttributes().end()) {
+        printMD(out, iter->second) << '\n';
+        continue;
+      }
+      if (auto iter = tag.getIntAttributes().find(name);
+          iter != tag.getIntAttributes().end()) {
+        printMD(out, iter->second) << '\n';
+        continue;
+      }
+      if (auto iter = tag.getStringAttributes().find(name);
+          iter != tag.getStringAttributes().end()) {
+        printMD(out, iter->second) << '\n';
+        continue;
+      }
+      if (auto iter = tag.getBooleanAttributes().find(name);
+          iter != tag.getBooleanAttributes().end()) {
+        printMD(out, iter->second) << '\n';
+        continue;
+      }
+      if (auto iter = tag.getEigenVectorXdAttributes().find(name);
+          iter != tag.getEigenVectorXdAttributes().end()) {
+        printMD(out, iter->second) << '\n';
+      }
     }
-
-    for (const auto &pair : tag.getStringAttributes()) {
-      printMD(out, pair.second) << '\n';
-    }
-
-    for (const auto &pair : tag.getBooleanAttributes()) {
-      printMD(out, pair.second) << '\n';
-    }
-
-    for (const auto &pair : tag.getEigenVectorXdAttributes()) {
-      printMD(out, pair.second) << '\n';
-    }
-    out << "\n";
+    out << '\n';
   }
 
   if (not tag.getSubtags().empty()) {

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -54,8 +54,8 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<double> &attribute)
 {
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
-  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
-  _attributes.insert(name);
+  PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
+  _attributes.push_back(name);
   _doubleAttributes.insert(std::pair<std::string, XMLAttribute<double>>(name, attribute));
   return *this;
 }
@@ -64,8 +64,8 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<int> &attribute)
 {
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
-  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
-  _attributes.insert(name);
+  PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
+  _attributes.push_back(name);
   _intAttributes.insert(std::pair<std::string, XMLAttribute<int>>(name, attribute));
   return *this;
 }
@@ -74,8 +74,8 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<std::string> &attribute)
 {
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
-  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
-  _attributes.insert(name);
+  PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
+  _attributes.push_back(name);
   _stringAttributes.insert(std::pair<std::string, XMLAttribute<std::string>>(name, attribute));
   return *this;
 }
@@ -84,8 +84,8 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<bool> &attribute)
 {
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
-  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
-  _attributes.insert(name);
+  PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
+  _attributes.push_back(name);
   _booleanAttributes.insert(std::pair<std::string, XMLAttribute<bool>>(name, attribute));
   return *this;
 }
@@ -94,8 +94,8 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute)
 {
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
-  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
-  _attributes.insert(name);
+  PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
+  _attributes.push_back(name);
   _eigenVectorXdAttributes.insert(
       std::pair<std::string, XMLAttribute<Eigen::VectorXd>>(name, attribute));
   return *this;
@@ -104,13 +104,13 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute)
 void XMLTag::addAttributeHint(std::string name, std::string message)
 {
   PRECICE_TRACE(name);
-  PRECICE_ASSERT(_attributes.count(name) == 0 && _attributeHints.count(name) == 0);
+  PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
   _attributeHints.emplace(std::move(name), std::move(message));
 }
 
 bool XMLTag::hasAttribute(const std::string &attributeName)
 {
-  return utils::contained(attributeName, _attributes);
+  return std::find(_attributes.begin(), _attributes.end(), attributeName) != _attributes.end();
 }
 
 double XMLTag::getDoubleAttributeValue(const std::string &name, std::optional<double> default_value) const
@@ -194,7 +194,7 @@ void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttribute
   for (auto &element : aAttributes) {
     auto name = element.first;
 
-    if (not utils::contained(name, _attributes)) {
+    if (not hasAttribute(name)) {
       // check existing hints
       if (auto pos = _attributeHints.find(name);
           pos != _attributeHints.end()) {

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -180,6 +180,11 @@ public:
 
   bool getBooleanAttributeValue(const std::string &name, std::optional<bool> default_value = std::nullopt) const;
 
+  std::vector<std::string> getAttributes() const
+  {
+    return _attributes;
+  }
+
   const AttributeMap<double> &getDoubleAttributes() const
   {
     return _doubleAttributes;
@@ -260,7 +265,7 @@ private:
 
   std::map<std::string, bool> _configuredNamespaces;
 
-  std::set<std::string> _attributes;
+  std::vector<std::string> _attributes;
 
   AttributeMap<double> _doubleAttributes;
 


### PR DESCRIPTION
## Main changes of this PR

This PR keeps the order of attributes in the Markdown docs as defined in the code.

## Motivation and additional information

This allows using the order of definition to better explain various attributes

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
