### PR TITLE
Cleanup XML attribute handling and fix order

### DIFF
--- a/src/io/tests/ExportConfigurationTest.cpp
+++ b/src/io/tests/ExportConfigurationTest.cpp
@@ -1,5 +1,4 @@
 #include <list>
-#include <string>
 #include "io/ExportContext.hpp"
 #include "io/SharedPointer.hpp"
 #include "io/config/ExportConfiguration.hpp"
@@ -8,32 +7,36 @@
 #include "xml/XMLTag.hpp"
 
 BOOST_AUTO_TEST_SUITE(IOTests)
+BOOST_AUTO_TEST_SUITE(Configuration)
 
 using namespace precice;
 
-BOOST_AUTO_TEST_CASE(Configuration)
+BOOST_AUTO_TEST_CASE(VTKEvery10)
 {
   PRECICE_TEST(1_rank);
   using xml::XMLTag;
-  XMLTag tag = xml::getRootTag();
-  {
-    io::ExportConfiguration config(tag);
-    xml::configure(tag, xml::ConfigurationContext{}, testing::getPathToSources() + "/io/tests/config1.xml");
-    BOOST_TEST(config.exportContexts().size() == 1);
-    const io::ExportContext &context = config.exportContexts().front();
-    BOOST_TEST(context.type == "vtk");
-    BOOST_TEST(context.everyNTimeWindows == 10);
-  }
-  {
-    tag.clear();
-    io::ExportConfiguration config(tag);
-    xml::configure(tag, xml::ConfigurationContext{}, testing::getPathToSources() + "/io/tests/config2.xml");
-    BOOST_TEST(config.exportContexts().size() == 1);
-    const io::ExportContext &context = config.exportContexts().front();
-    BOOST_TEST(context.type == "vtk");
-    BOOST_TEST(context.everyNTimeWindows == 1);
-    BOOST_TEST(context.location == "somepath");
-  }
+  XMLTag                  tag = xml::getRootTag();
+  io::ExportConfiguration config(tag);
+  xml::configure(tag, xml::ConfigurationContext{}, testing::getPathToSources() + "/io/tests/config1.xml");
+  BOOST_TEST(config.exportContexts().size() == 1);
+  const io::ExportContext &econtext = config.exportContexts().front();
+  BOOST_TEST(econtext.type == "vtk");
+  BOOST_TEST(econtext.everyNTimeWindows == 10);
 }
 
+BOOST_AUTO_TEST_CASE(VTKLocation)
+{
+  PRECICE_TEST(1_rank);
+  using xml::XMLTag;
+  XMLTag                  tag = xml::getRootTag();
+  io::ExportConfiguration config(tag);
+  xml::configure(tag, xml::ConfigurationContext{}, testing::getPathToSources() + "/io/tests/config2.xml");
+  BOOST_TEST(config.exportContexts().size() == 1);
+  const io::ExportContext &econtext = config.exportContexts().front();
+  BOOST_TEST(econtext.type == "vtk");
+  BOOST_TEST(econtext.everyNTimeWindows == 1);
+  BOOST_TEST(econtext.location == "somepath");
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Configuration
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -310,7 +310,7 @@ void ParticipantConfiguration::xmlTagCallback(
     WatchPointConfig config;
     config.name        = tag.getStringAttributeValue(ATTR_NAME);
     config.nameMesh    = tag.getStringAttributeValue(ATTR_MESH);
-    config.coordinates = tag.getEigenVectorXdAttributeValue(ATTR_COORDINATE, _meshConfig->getMesh(config.nameMesh)->getDimensions());
+    config.coordinates = tag.getEigenVectorXdAttributeValue(ATTR_COORDINATE);
     _watchPointConfigs.push_back(config);
   } else if (tag.getName() == TAG_WATCH_INTEGRAL) {
     WatchIntegralConfig config;
@@ -671,7 +671,9 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                   "Participant \"{}\" defines watchpoint \"{}\" for the received mesh \"{}\", which is not allowed. "
                   "Please move the watchpoint definition to the participant providing mesh \"{}\".",
                   participant->getName(), config.name, config.nameMesh, config.nameMesh);
-
+    PRECICE_CHECK(config.coordinates.size() == meshContext.mesh->getDimensions(),
+                  "Provided coordinate to watch is {}D, which does not match the dimension of the {}D mesh \"{}\".",
+                  config.coordinates.size(), meshContext.mesh->getDimensions(), meshContext.mesh->getName());
     std::string filename = "precice-" + participant->getName() + "-watchpoint-" + config.name + ".log";
     participant->addWatchPoint(std::make_shared<impl::WatchPoint>(config.coordinates, meshContext.mesh, std::move(filename)));
   }

--- a/src/xml/ValueParser.cpp
+++ b/src/xml/ValueParser.cpp
@@ -58,9 +58,6 @@ void readValueSpecific(const std::string &rawValue, Eigen::VectorXd &value)
   boost::split(
       components, rawValue, [](char c) { return c == ';'; }, boost::algorithm::token_compress_on);
   const int size = components.size();
-  if (size < 2 || size > 3) {
-    throw std::runtime_error{"The value \"" + rawValue + "\" is not a 2D or 3D vector."};
-  }
 
   Eigen::VectorXd vec(size);
   for (int i = 0; i != size; ++i) {

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -1,9 +1,7 @@
 #include "xml/XMLTag.hpp"
 #include <Eigen/Core>
-#include <ostream>
 #include <utility>
 #include "logging/LogMacros.hpp"
-#include "utils/Helpers.hpp"
 #include "utils/assertion.hpp"
 #include "xml/ConfigParser.hpp"
 
@@ -55,8 +53,7 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<double> &attribute)
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
   PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
-  _attributes.push_back(name);
-  _doubleAttributes.insert(std::pair<std::string, XMLAttribute<double>>(name, attribute));
+  _attributes.emplace_back(attribute);
   return *this;
 }
 
@@ -65,8 +62,7 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<int> &attribute)
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
   PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
-  _attributes.push_back(name);
-  _intAttributes.insert(std::pair<std::string, XMLAttribute<int>>(name, attribute));
+  _attributes.emplace_back(attribute);
   return *this;
 }
 
@@ -75,8 +71,7 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<std::string> &attribute)
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
   PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
-  _attributes.push_back(name);
-  _stringAttributes.insert(std::pair<std::string, XMLAttribute<std::string>>(name, attribute));
+  _attributes.emplace_back(attribute);
   return *this;
 }
 
@@ -85,8 +80,7 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<bool> &attribute)
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
   PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
-  _attributes.push_back(name);
-  _booleanAttributes.insert(std::pair<std::string, XMLAttribute<bool>>(name, attribute));
+  _attributes.emplace_back(attribute);
   return *this;
 }
 
@@ -95,9 +89,7 @@ XMLTag &XMLTag::addAttribute(const XMLAttribute<Eigen::VectorXd> &attribute)
   const auto &name = attribute.getName();
   PRECICE_TRACE(name);
   PRECICE_ASSERT(!hasAttribute(name) && _attributeHints.count(name) == 0);
-  _attributes.push_back(name);
-  _eigenVectorXdAttributes.insert(
-      std::pair<std::string, XMLAttribute<Eigen::VectorXd>>(name, attribute));
+  _attributes.emplace_back(attribute);
   return *this;
 }
 
@@ -108,17 +100,25 @@ void XMLTag::addAttributeHint(std::string name, std::string message)
   _attributeHints.emplace(std::move(name), std::move(message));
 }
 
-bool XMLTag::hasAttribute(const std::string &attributeName)
+namespace {
+auto findAttribute(const XMLTag::Attributes &attributes, const std::string &name)
 {
-  return std::find(_attributes.begin(), _attributes.end(), attributeName) != _attributes.end();
+  return std::find_if(attributes.begin(), attributes.end(), [&name](const auto &attribute) { return getName(attribute) == name; });
+}
+} // namespace
+
+bool XMLTag::hasAttribute(const std::string &attributeName) const
+{
+  return findAttribute(_attributes, attributeName) != _attributes.end();
 }
 
 double XMLTag::getDoubleAttributeValue(const std::string &name, std::optional<double> default_value) const
 {
-  std::map<std::string, XMLAttribute<double>>::const_iterator iter;
-  iter = _doubleAttributes.find(name);
-  if (iter != _doubleAttributes.end()) {
-    return iter->second.getValue();
+  PRECICE_TRACE(name);
+  if (auto iter = findAttribute(_attributes, name);
+      iter != _attributes.end()) {
+    PRECICE_ASSERT(std::holds_alternative<XMLAttribute<double>>(*iter));
+    return std::get<XMLAttribute<double>>(*iter).getValue();
   }
   if (default_value) {
     return default_value.value();
@@ -128,10 +128,11 @@ double XMLTag::getDoubleAttributeValue(const std::string &name, std::optional<do
 
 int XMLTag::getIntAttributeValue(const std::string &name, std::optional<int> default_value) const
 {
-  std::map<std::string, XMLAttribute<int>>::const_iterator iter;
-  iter = _intAttributes.find(name);
-  if (iter != _intAttributes.end()) {
-    return iter->second.getValue();
+  PRECICE_TRACE(name);
+  if (auto iter = findAttribute(_attributes, name);
+      iter != _attributes.end()) {
+    PRECICE_ASSERT(std::holds_alternative<XMLAttribute<int>>(*iter));
+    return std::get<XMLAttribute<int>>(*iter).getValue();
   }
   if (default_value) {
     return default_value.value();
@@ -141,10 +142,11 @@ int XMLTag::getIntAttributeValue(const std::string &name, std::optional<int> def
 
 std::string XMLTag::getStringAttributeValue(const std::string &name, std::optional<std::string> default_value) const
 {
-  std::map<std::string, XMLAttribute<std::string>>::const_iterator iter;
-  iter = _stringAttributes.find(name);
-  if (iter != _stringAttributes.end()) {
-    return iter->second.getValue();
+  PRECICE_TRACE(name);
+  if (auto iter = findAttribute(_attributes, name);
+      iter != _attributes.end()) {
+    PRECICE_ASSERT(std::holds_alternative<XMLAttribute<std::string>>(*iter));
+    return std::get<XMLAttribute<std::string>>(*iter).getValue();
   }
   if (default_value) {
     return default_value.value();
@@ -154,10 +156,11 @@ std::string XMLTag::getStringAttributeValue(const std::string &name, std::option
 
 bool XMLTag::getBooleanAttributeValue(const std::string &name, std::optional<bool> default_value) const
 {
-  std::map<std::string, XMLAttribute<bool>>::const_iterator iter;
-  iter = _booleanAttributes.find(name);
-  if (iter != _booleanAttributes.end()) {
-    return iter->second.getValue();
+  PRECICE_TRACE(name);
+  if (auto iter = findAttribute(_attributes, name);
+      iter != _attributes.end()) {
+    PRECICE_ASSERT(std::holds_alternative<XMLAttribute<bool>>(*iter));
+    return std::get<XMLAttribute<bool>>(*iter).getValue();
   }
   if (default_value) {
     return default_value.value();
@@ -165,151 +168,61 @@ bool XMLTag::getBooleanAttributeValue(const std::string &name, std::optional<boo
   PRECICE_UNREACHABLE("The XMLAttribute doesn't exist, check its default.");
 }
 
-Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name, int dimensions) const
+Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name) const
 {
-  PRECICE_TRACE(name, dimensions);
-  // std::map<std::string, XMLAttribute<utils::DynVector> >::const_iterator iter;
-  auto iter = _eigenVectorXdAttributes.find(name);
-  PRECICE_ASSERT(iter != _eigenVectorXdAttributes.end());
-  const auto size = iter->second.getValue().size();
-  PRECICE_CHECK(size == dimensions,
-                "Vector attribute \"{}\" of tag <{}> is {}D, "
-                "which does not match the dimension of the {}D precice-configuration.",
-                name, getFullName(), size, dimensions);
-
-  // Read only first "dimensions" components of the parsed vector values
-  Eigen::VectorXd        result(dimensions);
-  const Eigen::VectorXd &parsed = iter->second.getValue();
-  for (int i = 0; i < dimensions; i++) {
-    result[i] = parsed[i];
+  PRECICE_TRACE(name);
+  if (auto iter = findAttribute(_attributes, name);
+      iter != _attributes.end()) {
+    PRECICE_ASSERT(std::holds_alternative<XMLAttribute<Eigen::VectorXd>>(*iter));
+    return std::get<XMLAttribute<Eigen::VectorXd>>(*iter).getValue();
   }
-  PRECICE_DEBUG("Returning value = {}", result);
-  return result;
+  PRECICE_UNREACHABLE("The XMLAttribute doesn't exist, check its default.");
 }
 
 void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttributes)
 {
   PRECICE_TRACE();
 
-  for (auto &element : aAttributes) {
-    auto name = element.first;
-
-    if (not hasAttribute(name)) {
-      // check existing hints
-      if (auto pos = _attributeHints.find(name);
-          pos != _attributeHints.end()) {
-        PRECICE_ERROR("The tag <{}> in the configuration contains the attribute \"{}\". {}", _fullName, name, pos->second);
-      }
-
-      auto matches = utils::computeMatches(name, _attributes);
-      if (!matches.empty() && matches.front().distance < 3) {
-        matches.erase(std::remove_if(matches.begin(), matches.end(), [](auto &m) { return m.distance > 2; }), matches.end());
-        std::vector<std::string> stringMatches;
-        std::transform(matches.begin(), matches.end(), std::back_inserter(stringMatches), [](auto &m) { return m.name; });
-        PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, fmt::join(stringMatches, ", "));
-      }
-      PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Expected attributes are {}.", _fullName, name, fmt::join(_attributes, ", "));
+  // Check for unexpected attributes and hints
+  for (const auto &element : aAttributes) {
+    const auto &name = element.first;
+    if (hasAttribute(name)) {
+      continue;
     }
+
+    // check existing hints
+    if (auto pos = _attributeHints.find(name);
+        pos != _attributeHints.end()) {
+      PRECICE_ERROR("The tag <{}> in the configuration contains the attribute \"{}\". {}", _fullName, name, pos->second);
+    }
+
+    auto expected = getAttributeNames();
+    auto matches  = utils::computeMatches(name, expected);
+    if (!matches.empty() && matches.front().distance < 3) {
+      matches.erase(std::remove_if(matches.begin(), matches.end(), [](auto &m) { return m.distance > 2; }), matches.end());
+      std::vector<std::string> stringMatches;
+      std::transform(matches.begin(), matches.end(), std::back_inserter(stringMatches), [](auto &m) { return m.name; });
+      PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Did you mean \"{}\"?", _fullName, name, fmt::join(stringMatches, ", "));
+    }
+    PRECICE_ERROR("The tag <{}> in the configuration contains an unknown attribute \"{}\". Expected attributes are {}.", _fullName, name, fmt::join(expected, ", "));
   }
 
-  for (auto &pair : _doubleAttributes) {
-    pair.second.readValue(aAttributes);
-  }
-
-  for (auto &pair : _intAttributes) {
-    pair.second.readValue(aAttributes);
-  }
-
-  for (auto &pair : _stringAttributes) {
-    pair.second.readValue(aAttributes);
-  }
-
-  for (auto &pair : _booleanAttributes) {
-    pair.second.readValue(aAttributes);
-  }
-
-  for (auto &pair : _eigenVectorXdAttributes) {
-    pair.second.readValue(aAttributes);
+  // Read all attributes
+  for (auto &attribute : _attributes) {
+    std::visit(
+        [&aAttributes](auto &attribute) { attribute.readValue(aAttributes); },
+        attribute);
   }
 }
 
-/*void XMLTag:: readAttributes
-(
-  XMLReader* xmlReader )
+std::vector<std::string> XMLTag::getAttributeNames() const
 {
-  PRECICE_TRACE();
-//  using utils::contained;
-//  std::set<std::string> readNames;
-  for (int i=0; i < xmlReader->getAttributeCount(); i++){
-    std::string name = xmlReader->getAttributeName(i);
-    if (not utils::contained(name, _attributes)){
-      std::string error = "Wrong attribute \"" + name + "\"";
-      throw std::runtime_error{error};
-    }
-//    else if (contained(name, _doubleAttributes)){
-//      XMLAttribute<double>& attr = _doubleAttributes[name];
-//      attr.readValue(xmlReader);
-//    }
-//    else if (contained(name, _intAttributes)){
-//      XMLAttribute<int>& attr = _intAttributes[name];
-//      attr.readValue(xmlReader);
-//    }
-//    else if (contained(name, _stringAttributes)){
-//      XMLAttribute<std::string>& attr = _stringAttributes[name];
-//      attr.readValue(xmlReader);
-//    }
-//    else if (contained(name, _booleanAttributes)){
-//      XMLAttribute<bool>& attr = _booleanAttributes[name];
-//      attr.readValue(xmlReader);
-//    }
-//    else if (contained(name, _vector2DAttributes)){
-//      XMLAttribute<Vector2D>& attr = _vector2DAttributes[name];
-//      attr.readValue(xmlReader);
-//    }
-//    else if (contained(name, _vector3DAttributes)){
-//      XMLAttribute<Vector3D>& attr = _vector3DAttributes[name];
-//      attr.readValue(xmlReader);
-//    }
-//    else if (contained(name, _dynVectorAttributes)){
-//      XMLAttribute<DynVector>& attr = _dynVectorAttributes[name];
-//      attr.readValue(xmlReader);
-//    }
-//    else {
-//      throw std::runtime_error{"Internal error in readAttributes"};
-//    }
-//    readNames.insert(name);
+  std::vector<std::string> names;
+  for (const auto &attribute : _attributes) {
+    names.push_back(xml::getName(attribute));
   }
-
-//  // Check if all attributes are read
-//  for (const std::string& name : _attributes){
-//    if (not contained(name, readNames)){
-//
-//      std::ostringstream stream;
-//      stream << "Attribute \"" << name << "\" is not defined";
-//      throw std::runtime_error{stream.str()};
-//    }
-//  }
-
-  for (auto & pair : _doubleAttributes){
-     pair.second.readValue(xmlReader);
-  }
-
-  for ( auto & pair : _intAttributes){
-    pair.second.readValue(xmlReader);
-  }
-
-  for ( auto & pair : _stringAttributes ){
-    pair.second.readValue(xmlReader);
-  }
-
-  for ( auto & pair : _booleanAttributes ){
-    pair.second.readValue(xmlReader);
-  }
-
-  for ( auto & pair : _eigenVectorXdAttributes ){
-    pair.second.readValue(xmlReader);
-  }
-}*/
+  return names;
+}
 
 void XMLTag::areAllSubtagsConfigured() const
 {
@@ -344,47 +257,21 @@ void XMLTag::resetAttributes()
   for (auto &pair : _configuredNamespaces) {
     pair.second = false;
   }
-
-  for (auto &pair : _doubleAttributes) {
-    pair.second.setRead(false);
+  for (auto &attribute : _attributes) {
+    std::visit(
+        [](auto &attribute) { attribute.setRead(false); },
+        attribute);
   }
-
-  for (auto &pair : _intAttributes) {
-    pair.second.setRead(false);
-  }
-
-  for (auto &pair : _stringAttributes) {
-    pair.second.setRead(false);
-  }
-
-  for (auto &pair : _booleanAttributes) {
-    pair.second.setRead(false);
-  }
-
-  for (auto &pair : _eigenVectorXdAttributes) {
-    pair.second.setRead(false);
-  }
-
   for (auto &tag : _subtags) {
     tag->_configured = false;
     tag->resetAttributes();
   }
 }
 
-void XMLTag::clear()
+std::string getName(const XMLTag::Attribute &attribute)
 {
-  _doubleAttributes.clear();
-  _intAttributes.clear();
-  _stringAttributes.clear();
-  _booleanAttributes.clear();
-  _subtags.clear();
+  return std::visit([](auto &attribute) { return attribute.getName(); }, attribute);
 }
-
-//NoPListener& getNoPListener()
-//{
-//  static NoPListener listener;
-//  return listener;
-//}
 
 XMLTag getRootTag()
 {
@@ -422,12 +309,3 @@ std::string_view XMLTag::getOccurrenceString(XMLTag::Occurrence occurrence)
   return "";
 }
 } // namespace precice::xml
-
-//std::ostream& operator<<
-//(
-//  std::ostream&                 os,
-//  const precice::xml::XMLTag& tag )
-//{
-//  os << tag.printDocumentation(80, 0);
-//  return os;
-//}

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -4,8 +4,8 @@
 #include <map>
 #include <memory>
 #include <optional>
-#include <set>
 #include <string>
+#include <variant>
 #include <vector>
 #include "logging/Logger.hpp"
 #include "xml/ConfigParser.hpp"
@@ -17,8 +17,7 @@ class ConfigParser;
 }
 } // namespace precice
 
-namespace precice {
-namespace xml {
+namespace precice::xml {
 
 /// Tightly coupled to the parameters of Participant()
 struct ConfigurationContext {
@@ -36,15 +35,21 @@ public:
 
   using Subtags = typename std::vector<std::shared_ptr<XMLTag>>;
 
-  template <typename T>
-  using AttributeMap = typename std::map<std::string, XMLAttribute<T>>;
+  using Attribute = std::variant<
+      XMLAttribute<double>,
+      XMLAttribute<int>,
+      XMLAttribute<std::string>,
+      XMLAttribute<bool>,
+      XMLAttribute<Eigen::VectorXd>>;
+
+  using Attributes = typename std::vector<Attribute>;
 
   /// Callback interface for configuration classes using XMLTag.
   struct Listener {
 
     Listener &operator=(Listener &&) = delete;
 
-    virtual ~Listener(){};
+    virtual ~Listener() = default;
     /**
      * @brief Callback at begin of XML tag.
      *
@@ -116,9 +121,6 @@ public:
     return _subtags;
   };
 
-  /// Removes the XML subtag with given name
-  //XMLTag& removeSubtag ( const std::string& tagName );
-
   /// Adds a XML attribute by making a copy of the given attribute.
   XMLTag &addAttribute(const XMLAttribute<double> &attribute);
 
@@ -137,7 +139,7 @@ public:
   /// Adds a hint for missing attributes, which will be displayed along the error message.
   void addAttributeHint(std::string name, std::string message);
 
-  bool hasAttribute(const std::string &attributeName);
+  bool hasAttribute(const std::string &attributeName) const;
 
   template <typename Container>
   void addSubtags(const Container &subtags)
@@ -180,48 +182,14 @@ public:
 
   bool getBooleanAttributeValue(const std::string &name, std::optional<bool> default_value = std::nullopt) const;
 
-  std::vector<std::string> getAttributes() const
+  Eigen::VectorXd getEigenVectorXdAttributeValue(const std::string &name) const;
+
+  std::vector<std::string> getAttributeNames() const;
+
+  const Attributes &getAttributes() const
   {
     return _attributes;
-  }
-
-  const AttributeMap<double> &getDoubleAttributes() const
-  {
-    return _doubleAttributes;
   };
-
-  const AttributeMap<int> &getIntAttributes() const
-  {
-    return _intAttributes;
-  };
-
-  const AttributeMap<std::string> &getStringAttributes() const
-  {
-    return _stringAttributes;
-  };
-
-  const AttributeMap<bool> &getBooleanAttributes() const
-  {
-    return _booleanAttributes;
-  };
-
-  const AttributeMap<Eigen::VectorXd> &getEigenVectorXdAttributes() const
-  {
-    return _eigenVectorXdAttributes;
-  };
-
-  /**
-   * @brief Returns Eigen vector attribute value with given dimensions.
-   *
-   * If the parsed vector has less dimensions then required, an error message
-   * is thrown.
-   *
-   * @param[in] name Name of attribute.
-   * @param[in] dimensions Dimensions of the vector to be returned.
-   */
-  Eigen::VectorXd getEigenVectorXdAttributeValue(
-      const std::string &name,
-      int                dimensions) const;
 
   bool isConfigured() const
   {
@@ -232,9 +200,6 @@ public:
   {
     return _occurrence;
   }
-
-  /// Removes all attributes and subtags
-  void clear();
 
   /// reads all attributes of this tag
   void readAttributes(const std::map<std::string, std::string> &aAttributes);
@@ -265,17 +230,7 @@ private:
 
   std::map<std::string, bool> _configuredNamespaces;
 
-  std::vector<std::string> _attributes;
-
-  AttributeMap<double> _doubleAttributes;
-
-  AttributeMap<int> _intAttributes;
-
-  AttributeMap<std::string> _stringAttributes;
-
-  AttributeMap<bool> _booleanAttributes;
-
-  AttributeMap<Eigen::VectorXd> _eigenVectorXdAttributes;
+  Attributes _attributes;
 
   std::map<std::string, std::string> _attributeHints;
 
@@ -284,6 +239,9 @@ private:
   void resetAttributes();
 };
 
+/// Returns the name of an Attribute
+std::string getName(const XMLTag::Attribute &attribute);
+
 // ------------------------------------------------------ HEADER IMPLEMENTATION
 
 /// No operation listener for tests.
@@ -291,13 +249,6 @@ struct NoPListener : public XMLTag::Listener {
   void xmlTagCallback(ConfigurationContext const &context, XMLTag &callingTag) override {}
   void xmlEndTagCallback(ConfigurationContext const &context, XMLTag &callingTag) override {}
 };
-
-/**
- * @brief Returns an XMLTag::Listener that does nothing on callbacks.
- *
- * This is useful for tests, when the root tag to be specified in
- */
-//NoPListener& getNoPListener();
 
 /**
  * @brief Returns an empty root tag with name "configuration".
@@ -312,12 +263,4 @@ void configure(
     const precice::xml::ConfigurationContext &context,
     std::string_view                          configurationFilename);
 
-} // namespace xml
-} // namespace precice
-
-/**
- * @brief Adds documentation of tag to output stream os.
- */
-//std::ostream& operator<< (
-//  std::ostream&                 os,
-//  const precice::xml::XMLTag& tag );
+} // namespace precice::xml

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -16,7 +16,9 @@ using precice::testing::getPathToSources;
 BOOST_AUTO_TEST_SUITE(XML)
 
 struct CallbackHostAttr : public XMLTag::Listener {
-  Eigen::VectorXd eigenValue;
+  Eigen::VectorXd eigenValue1;
+  Eigen::VectorXd eigenValue2;
+  Eigen::VectorXd eigenValue3;
   double          doubleValue;
   int             intValue;
   bool            boolValue;
@@ -28,8 +30,16 @@ struct CallbackHostAttr : public XMLTag::Listener {
       doubleValue = callingTag.getDoubleAttributeValue("attribute");
     }
 
-    if (callingTag.getName() == "test-eigen") {
-      eigenValue = callingTag.getEigenVectorXdAttributeValue("attribute", 3);
+    if (callingTag.getName() == "test-eigen-1") {
+      eigenValue1 = callingTag.getEigenVectorXdAttributeValue("attribute");
+    }
+
+    if (callingTag.getName() == "test-eigen-2") {
+      eigenValue2 = callingTag.getEigenVectorXdAttributeValue("attribute");
+    }
+
+    if (callingTag.getName() == "test-eigen-3") {
+      eigenValue3 = callingTag.getEigenVectorXdAttributeValue("attribute");
     }
 
     if (callingTag.getName() == "test-int") {
@@ -61,7 +71,9 @@ BOOST_AUTO_TEST_CASE(AttributeTypeTest)
   XMLTag           testcaseTag(cb, "test-config", XMLTag::OCCUR_ONCE);
 
   XMLTag doubleTag(cb, "test-double", XMLTag::OCCUR_ONCE_OR_MORE);
-  XMLTag eigenTag(cb, "test-eigen", XMLTag::OCCUR_ONCE_OR_MORE);
+  XMLTag eigen1Tag(cb, "test-eigen-1", XMLTag::OCCUR_ONCE_OR_MORE);
+  XMLTag eigen2Tag(cb, "test-eigen-2", XMLTag::OCCUR_ONCE_OR_MORE);
+  XMLTag eigen3Tag(cb, "test-eigen-3", XMLTag::OCCUR_ONCE_OR_MORE);
   XMLTag intTag(cb, "test-int", XMLTag::OCCUR_ONCE_OR_MORE);
   XMLTag stringTag(cb, "test-string", XMLTag::OCCUR_ONCE_OR_MORE);
   XMLTag boolTag(cb, "test-bool", XMLTag::OCCUR_ONCE_OR_MORE);
@@ -73,13 +85,17 @@ BOOST_AUTO_TEST_CASE(AttributeTypeTest)
   XMLAttribute<std::string>     stringAttr("text");
 
   doubleTag.addAttribute(doubleAttr);
-  eigenTag.addAttribute(eigenAttr);
+  eigen1Tag.addAttribute(eigenAttr);
+  eigen2Tag.addAttribute(eigenAttr);
+  eigen3Tag.addAttribute(eigenAttr);
   intTag.addAttribute(intAttr);
   boolTag.addAttribute(boolAttr);
   stringTag.addAttribute(stringAttr);
 
   testcaseTag.addSubtag(doubleTag);
-  testcaseTag.addSubtag(eigenTag);
+  testcaseTag.addSubtag(eigen1Tag);
+  testcaseTag.addSubtag(eigen2Tag);
+  testcaseTag.addSubtag(eigen3Tag);
   testcaseTag.addSubtag(intTag);
   testcaseTag.addSubtag(boolTag);
   testcaseTag.addSubtag(stringTag);
@@ -93,9 +109,17 @@ BOOST_AUTO_TEST_CASE(AttributeTypeTest)
   BOOST_TEST(cb.intValue == 4);
   BOOST_TEST(cb.stringValue == "Hello World");
 
-  BOOST_TEST(cb.eigenValue(0) == 3.0);
-  BOOST_TEST(cb.eigenValue(1) == 2.0);
-  BOOST_TEST(cb.eigenValue(2) == 1.0);
+  BOOST_TEST(cb.eigenValue1.size() == 1);
+  BOOST_TEST(cb.eigenValue1(0) == 3.0);
+
+  BOOST_TEST(cb.eigenValue2.size() == 2);
+  BOOST_TEST(cb.eigenValue2(0) == 3.0);
+  BOOST_TEST(cb.eigenValue2(1) == 2.0);
+
+  BOOST_TEST(cb.eigenValue3.size() == 3);
+  BOOST_TEST(cb.eigenValue3(0) == 3.0);
+  BOOST_TEST(cb.eigenValue3(1) == 2.0);
+  BOOST_TEST(cb.eigenValue3(2) == 1.0);
 }
 
 BOOST_AUTO_TEST_CASE(OccurenceTest)

--- a/src/xml/tests/XMLTest.cpp
+++ b/src/xml/tests/XMLTest.cpp
@@ -20,7 +20,7 @@ struct CallbackHost : public XMLTag::Listener {
   void xmlTagCallback(const ConfigurationContext &context, XMLTag &callingTag) override
   {
     if (callingTag.getName() == "test-eigen-vectorxd-attributes") {
-      eigenVectorXd = callingTag.getEigenVectorXdAttributeValue("value", 3);
+      eigenVectorXd = callingTag.getEigenVectorXdAttributeValue("value");
     }
   }
 
@@ -63,6 +63,7 @@ BOOST_AUTO_TEST_CASE(VectorAttributes)
   rootTag.addSubtag(testTagEigenXd);
 
   configure(rootTag, ConfigurationContext{}, filename);
+  BOOST_TEST(cb.eigenVectorXd.size() == 3);
   BOOST_TEST(cb.eigenVectorXd(0) == 3.0);
   BOOST_TEST(cb.eigenVectorXd(1) == 2.0);
   BOOST_TEST(cb.eigenVectorXd(2) == 1.0);

--- a/src/xml/tests/xmlparser_test.xml
+++ b/src/xml/tests/xmlparser_test.xml
@@ -8,6 +8,8 @@
     <test-bool attribute="No" />
     <test-bool attribute="Yes" />
     <test-bool attribute="1" />
-    <test-eigen attribute="3.0; 2.0; 1.0" />
+    <test-eigen-1 attribute="3.0" />
+    <test-eigen-2 attribute="3.0; 2.0" />
+    <test-eigen-3 attribute="3.0; 2.0; 1.0" />
   </test-config>
 </configuration>


### PR DESCRIPTION
## Main changes of this PR

This PR cleans up the XML attribute handling by storing `XMLAttribute`s in order of definition as a variant.
This keeps the order in the documentation consistent with the order of definition.
Furthermore, reading an Eigen vector, which is only needed for the `WatchPoint`, now doesn't check the dimension any longer. This was moved to the participant config, which allows for a better error message and for #1669 to work out of the box. I added tests for 1D and 2D Eigen attributes.
I also removed a bunch of dead and unneeded code.

## Motivation and additional information

Easier to write comprehensive documentation and less code to worry about.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
