### PR TITLE
Add full test name to context

### DIFF
--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -272,7 +272,7 @@ std::string TestContext::describe() const
     return "This test context is invalid!";
 
   std::ostringstream os;
-  os << "Test context";
+  os << "Test context of " << testing::getFullTestName();
   if (name.empty()) {
     os << " is unnamed";
   } else {

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -55,6 +55,11 @@ std::string getTestName()
   return boost::unit_test::framework::get<boost::unit_test::test_suite>(parent).p_name;
 }
 
+std::string getFullTestName()
+{
+  return boost::unit_test::framework::current_test_case().full_name();
+}
+
 int nextMeshID()
 {
   static utils::ManageUniqueIDs manager;

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -108,6 +108,9 @@ std::string getPathToTests();
 /// Returns the name of the current test.
 std::string getTestName();
 
+/// Return the full name of the current test as seen in boost assertions.
+std::string getFullTestName();
+
 /// Returns the full path to the file containing the current test.
 std::string getTestPath();
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds the full name of the test unit to the test context.

## Motivation and additional information

This change makes it easier to detect a hanging test.
Part of #1861

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
