### PR TITLE
Prevent temporary allocations of Eigen Map in vertex creation

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -100,7 +100,7 @@ int Mesh::getDimensions() const
   return _dimensions;
 }
 
-Vertex &Mesh::createVertex(const Eigen::VectorXd &coords)
+Vertex &Mesh::createVertex(const Eigen::Ref<const Eigen::VectorXd> &coords)
 {
   PRECICE_ASSERT(coords.size() == _dimensions, coords.size(), _dimensions);
   auto nextID = _vertices.size();

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -131,7 +131,7 @@ public:
   int getDimensions() const;
 
   /// Creates and initializes a Vertex object.
-  Vertex &createVertex(const Eigen::VectorXd &coords);
+  Vertex &createVertex(const Eigen::Ref<const Eigen::VectorXd> &coords);
 
   /**
    * @brief Creates and initializes an Edge object.


### PR DESCRIPTION
## Main changes of this PR

Makes the vertex definition non-allocating in the vertex loop.

## Motivation and additional information

While doing some memory investigations, there was a suspicious amount of temporary allocations when creating our mesh.
Well, passing Eigen expressions to functions that expect concrete types (const Eigen::VectorXd&) forces Eigen to evaluate the expressions and creates a temporary Eigen::VectorXd to hold the result.
Using a [Ref](https://eigen.tuxfamily.org/dox/classEigen_1_1Ref.html) prevents the unnecessary allocation.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
