### PR TITLE
Migrate exporters to using samples

### DIFF
--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -84,7 +84,6 @@ void ExportCSV::doExport(int index, double time)
   for (const auto &data : _mesh->data()) {
     auto dataName = data->getName();
     auto dim      = data->getDimensions();
-    PRECICE_ASSERT(static_cast<std::size_t>(data->values().size()) == _mesh->nVertices() * dim);
     outFile << ';' << dataName;
     if (dim == 2) {
       outFile << "X;" << dataName << 'Y';
@@ -97,8 +96,8 @@ void ExportCSV::doExport(int index, double time)
   // Prepare writing data
   std::vector<StridedAccess> dataColumns;
   for (const auto &data : _mesh->data()) {
-    auto    dim    = data->getDimensions();
-    double *values = data->values().data();
+    auto          dim    = data->getDimensions();
+    double const *values = data->timeStepsStorage().last().sample.values.data();
     for (int i = 0; i < dim; ++i) {
       dataColumns.push_back({std::next(values, i), dim});
     }

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -151,7 +151,7 @@ void ExportVTK::exportData(
   outFile << "\n\n";
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
-    Eigen::VectorXd &values = data->values();
+    const Eigen::VectorXd &values = data->timeStepsStorage().last().sample.values;
     if (data->getDimensions() > 1) {
       Eigen::VectorXd viewTemp(data->getDimensions());
       outFile << "VECTORS " << data->getName() << " double\n";
@@ -186,7 +186,7 @@ void ExportVTK::exportGradient(std::ofstream &outFile, const mesh::Mesh &mesh)
   const int spaceDim = mesh.getDimensions();
   for (const mesh::PtrData &data : mesh.data()) {
     if (data->hasGradient()) { // Check whether this data has gradient
-      auto &gradients = data->gradients();
+      const auto &gradients = data->timeStepsStorage().last().sample.gradients;
       if (data->getDimensions() == 1) { // Scalar data, create a vector <dataname>_gradient
         outFile << "VECTORS " << data->getName() << "_gradient"
                 << " double\n";

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -190,7 +190,7 @@ void ExportXML::writeSubFile(int index, double time)
 
 void ExportXML::exportGradient(const mesh::PtrData data, const int spaceDim, std::ostream &outFile) const
 {
-  const auto &             gradients      = data->gradients();
+  const auto &             gradients      = data->timeStepsStorage().last().sample.gradients;
   const int                dataDimensions = data->getDimensions();
   std::vector<std::string> suffices;
   if (dataDimensions == 1) {
@@ -246,11 +246,11 @@ void ExportXML::exportData(
   outFile << "\n            </DataArray>\n";
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
-    Eigen::VectorXd &values         = data->values();
-    int              dataDimensions = data->getDimensions();
-    std::string      dataName(data->getName());
-    int              numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
-    const bool       hasGradient        = data->hasGradient();
+    const Eigen::VectorXd &values         = data->timeStepsStorage().last().sample.values;
+    int                    dataDimensions = data->getDimensions();
+    std::string            dataName(data->getName());
+    int                    numberOfComponents = (dataDimensions == 2) ? 3 : dataDimensions;
+    const bool             hasGradient        = data->hasGradient();
     outFile << "            <DataArray type=\"Float64\" Name=\"" << dataName << "\" NumberOfComponents=\"" << numberOfComponents;
     outFile << "\" format=\"ascii\">\n";
     outFile << "               ";

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -32,18 +32,15 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 
-  // Create data
-  mesh.allocateDataValues();
-  Eigen::VectorXd &valuesScalar = dataScalar->values();
-  Eigen::VectorXd &valuesVector = dataVector->values();
-  valuesScalar << 1.0, 2.0;
-  valuesVector << 1.0, 2.0, 3.0, 4.0;
+  time::Sample scalar(1, 2, dimensions);
+  scalar.values.setLinSpaced(0, 1);
+  scalar.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, scalar);
 
-  // Create corresponding gradient data (all gradients = const = 1)
-  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
-  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
-  gradientsScalar.setOnes();
-  gradientsVector.setOnes();
+  time::Sample vectorial(dimensions, 2, dimensions);
+  vectorial.values.setLinSpaced(0, 1);
+  vectorial.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, vectorial);
 
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTK.doExport(0, 0.0);

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -36,18 +36,15 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 
-  // Create data
-  mesh.allocateDataValues();
-  Eigen::VectorXd &valuesScalar = dataScalar->values();
-  Eigen::VectorXd &valuesVector = dataVector->values();
-  valuesScalar.setLinSpaced(1., 5.);
-  valuesVector.setLinSpaced(1., 5.);
+  time::Sample scalar(1, 2, dimensions);
+  scalar.values.setLinSpaced(0, 1);
+  scalar.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, scalar);
 
-  // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
-  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
-  gradientsScalar.setOnes();
-  gradientsVector.setOnes();
+  time::Sample vectorial(dimensions, 2, dimensions);
+  vectorial.values.setLinSpaced(0, 1);
+  vectorial.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, vectorial);
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTP.doExport(0, 0.0);
@@ -67,19 +64,15 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh.createVertex(Eigen::Vector3d::Constant(1.0));
 
-  // Create data
-  mesh.allocateDataValues();
-  Eigen::VectorXd &valuesScalar = dataScalar->values();
-  Eigen::VectorXd &valuesVector = dataVector->values();
+  time::Sample scalar(1, 2, dimensions);
+  scalar.values.setLinSpaced(0, 1);
+  scalar.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, scalar);
 
-  valuesScalar.setLinSpaced(1., 5.);
-  valuesVector.setLinSpaced(1., 5.);
-
-  // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
-  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
-  gradientsScalar.setOnes();
-  gradientsVector.setOnes();
+  time::Sample vectorial(dimensions, 2, dimensions);
+  vectorial.values.setLinSpaced(0, 1);
+  vectorial.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, vectorial);
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTP.doExport(0, 0.0);

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -38,18 +38,16 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh.createVertex(Eigen::Vector2d::Constant(1.0));
 
-  // Create data
-  mesh.allocateDataValues();
-  Eigen::VectorXd &valuesScalar = dataScalar->values();
-  Eigen::VectorXd &valuesVector = dataVector->values();
-  valuesScalar.setLinSpaced(1., 5.);
-  valuesVector.setLinSpaced(1., 5.);
+  time::Sample scalar(1, 2, dimensions);
+  scalar.values.setLinSpaced(0, 1);
+  scalar.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, scalar);
 
-  // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
-  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
-  gradientsScalar.setOnes();
-  gradientsVector.setOnes();
+  time::Sample vectorial(dimensions, 2, dimensions);
+  vectorial.values.setLinSpaced(0, 1);
+  vectorial.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, vectorial);
+
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
@@ -69,19 +67,16 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh.createVertex(Eigen::Vector3d::Constant(1.0));
 
-  // Create data
-  mesh.allocateDataValues();
-  Eigen::VectorXd &valuesScalar = dataScalar->values();
-  Eigen::VectorXd &valuesVector = dataVector->values();
+  time::Sample scalar(1, 2, dimensions);
+  scalar.values.setLinSpaced(0, 1);
+  scalar.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, scalar);
 
-  valuesScalar.setLinSpaced(1., 5.);
-  valuesVector.setLinSpaced(1., 5.);
+  time::Sample vectorial(dimensions, 2, dimensions);
+  vectorial.values.setLinSpaced(0, 1);
+  vectorial.gradients.setOnes();
+  dataScalar->setSampleAtTime(0, vectorial);
 
-  // Create corresponding gradient data (all gradient values = const = 1)
-  Eigen::MatrixXd &gradientsScalar = dataScalar->gradients();
-  Eigen::MatrixXd &gradientsVector = dataVector->gradients();
-  gradientsScalar.setOnes();
-  gradientsVector.setOnes();
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);

--- a/src/time/Sample.hpp
+++ b/src/time/Sample.hpp
@@ -19,6 +19,10 @@ struct Sample {
   Sample(int dims, int dataCount)
       : dataDims(dims), values(dims * dataCount) {}
 
+  /// Constructs a Sample of given data and mesh dimensionality, and size with gradients
+  Sample(int dataDims, int nVertices, int meshDims)
+      : dataDims(dataDims), values(nVertices * dataDims), gradients(nVertices, dataDims * meshDims) {}
+
   /// Constructs a Sample of given data dimensionality and data values
   Sample(int dims, Eigen::VectorXd inValues)
       : dataDims(dims), values(std::move(inValues)) {}


### PR DESCRIPTION
## Main changes of this PR

This PR ports exporters to using samples instead of `Data::values()`

## Motivation and additional information

#1645

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
