### PR TITLE
Migrate Watchpoint/integral to samples

### DIFF
--- a/src/precice/impl/WatchIntegral.cpp
+++ b/src/precice/impl/WatchIntegral.cpp
@@ -108,7 +108,7 @@ void WatchIntegral::exportIntegralData(
 Eigen::VectorXd WatchIntegral::calculateIntegral(const mesh::PtrData &data) const
 {
   int                    dim    = data->getDimensions();
-  const Eigen::VectorXd &values = data->values();
+  const Eigen::VectorXd &values = data->timeStepsStorage().last().sample.values;
   Eigen::VectorXd        sum    = Eigen::VectorXd::Zero(dim);
 
   if (_mesh->edges().empty() || (not _isScalingOn)) {
@@ -120,7 +120,7 @@ Eigen::VectorXd WatchIntegral::calculateIntegral(const mesh::PtrData &data) cons
     }
     return sum;
   } else { // Connectivity information is given
-    return mesh::integrateSurface(_mesh, data->values());
+    return mesh::integrateSurface(_mesh, data->timeStepsStorage().last().sample.values);
   }
 }
 

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -131,7 +131,7 @@ void WatchPoint::getValue(
 {
   int                    dim = _mesh->getDimensions();
   Eigen::VectorXd        temp(dim);
-  const Eigen::VectorXd &values = data->values();
+  const Eigen::VectorXd &values = data->timeStepsStorage().last().sample.values;
   for (const auto &elem : _interpolation->getWeightedElements()) {
     int offset = elem.vertexID * dim;
     for (int i = 0; i < dim; i++) {
@@ -146,7 +146,7 @@ void WatchPoint::getValue(
     double &       value,
     mesh::PtrData &data)
 {
-  const Eigen::VectorXd &values = data->values();
+  const Eigen::VectorXd &values = data->timeStepsStorage().last().sample.values;
   for (const auto &elem : _interpolation->getWeightedElements()) {
     value += elem.weight * values[elem.vertexID];
   }

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -52,15 +52,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-noConnectivity.log");
 
@@ -72,10 +65,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -115,19 +105,8 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
-  doubleValues(4) = 5.0;
-  doubleValues(5) = 6.0;
-  doubleValues(6) = 7.0;
-  doubleValues(7) = 8.0;
+  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity.log");
 
@@ -139,14 +118,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
-    doubleValues(4) = 6.0;
-    doubleValues(5) = 7.0;
-    doubleValues(6) = 8.0;
-    doubleValues(7) = 9.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -188,14 +160,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity.log");
 
@@ -207,9 +173,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -251,14 +215,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-noScale.log");
 
@@ -270,9 +228,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -314,17 +270,8 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
-  doubleValues(4) = 5.0;
-  doubleValues(5) = 6.0;
+  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity.log");
 
@@ -336,12 +283,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
-    doubleValues(4) = 6.0;
-    doubleValues(5) = 7.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -385,17 +327,8 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
-  doubleValues(4) = 5.0;
-  doubleValues(5) = 6.0;
+  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-noScale.log");
 
@@ -407,12 +340,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
-    doubleValues(4) = 6.0;
-    doubleValues(5) = 7.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -463,15 +391,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity.log");
 
@@ -483,10 +404,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -535,15 +453,8 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity-noScale.log");
 
@@ -555,10 +466,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -607,19 +515,8 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
-  doubleValues(4) = 5.0;
-  doubleValues(5) = 6.0;
-  doubleValues(6) = 7.0;
-  doubleValues(7) = 8.0;
+  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity.log");
 
@@ -631,14 +528,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
-    doubleValues(4) = 6.0;
-    doubleValues(5) = 7.0;
-    doubleValues(6) = 8.0;
-    doubleValues(7) = 9.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -687,19 +577,8 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
-  doubleValues(4) = 5.0;
-  doubleValues(5) = 6.0;
-  doubleValues(6) = 7.0;
-  doubleValues(7) = 8.0;
+  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity-noScale.log");
 
@@ -711,14 +590,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleValues(0) = 2.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
-    doubleValues(3) = 5.0;
-    doubleValues(4) = 6.0;
-    doubleValues(5) = 7.0;
-    doubleValues(6) = 8.0;
-    doubleValues(7) = 9.0;
+    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -767,15 +639,8 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
-
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-meshChange-faceConnectivity.log");
 
@@ -821,8 +686,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
   std::string name("rectangle");
   int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
-  PtrData     doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &      doubleValues = doubleData->values();
+  PtrData     doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
     mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -838,20 +702,14 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
     mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
   }
 
-  mesh->allocateDataValues();
-
   if (utils::IntraComm::isPrimary()) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0}}));
   } else if (context.isRank(1)) {
-    doubleValues(0) = 3.0;
-    doubleValues(1) = 4.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{3.0, 4.0}}));
   } else if (context.isRank(2)) {
-    doubleValues(0) = 5.0;
-    doubleValues(1) = 6.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0}}));
   } else if (context.isRank(3)) {
-    doubleValues(0) = 7.0;
-    doubleValues(1) = 8.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{7.0, 8.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-noConnectivity-parallel.log");
@@ -865,17 +723,13 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0}}));
     } else if (context.isRank(1)) {
-      doubleValues(0) = 4.0;
-      doubleValues(1) = 5.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{4.0, 5.0}}));
     } else if (context.isRank(2)) {
-      doubleValues(0) = 6.0;
-      doubleValues(1) = 7.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0}}));
     } else if (context.isRank(3)) {
-      doubleValues(0) = 8.0;
-      doubleValues(1) = 9.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{8.0, 9.0}}));
     }
 
     // Write output again
@@ -912,8 +766,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   std::string name("rectangle");
   int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
-  PtrData     doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &      doubleValues = doubleData->values();
+  PtrData     doubleData = mesh->createData("DoubleData", 2, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
     mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -929,28 +782,14 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
     mesh->createVertex(Eigen::Vector2d(0.0, 1.0));
   }
 
-  mesh->allocateDataValues();
-
   if (utils::IntraComm::isPrimary()) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
-    doubleValues(2) = 3.0;
-    doubleValues(3) = 4.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
   } else if (context.isRank(1)) {
-    doubleValues(0) = 5.0;
-    doubleValues(1) = 6.0;
-    doubleValues(2) = 7.0;
-    doubleValues(3) = 8.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
   } else if (context.isRank(2)) {
-    doubleValues(0) = 9.0;
-    doubleValues(1) = 10.0;
-    doubleValues(2) = 11.0;
-    doubleValues(3) = 12.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
   } else if (context.isRank(3)) {
-    doubleValues(0) = 13.0;
-    doubleValues(1) = 14.0;
-    doubleValues(2) = 15.0;
-    doubleValues(3) = 16.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity-parallel.log");
@@ -964,25 +803,13 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
-      doubleValues(2) = 4.0;
-      doubleValues(3) = 5.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
     } else if (context.isRank(1)) {
-      doubleValues(0) = 6.0;
-      doubleValues(1) = 7.0;
-      doubleValues(2) = 8.0;
-      doubleValues(3) = 9.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
     } else if (context.isRank(2)) {
-      doubleValues(0) = 10.0;
-      doubleValues(1) = 11.0;
-      doubleValues(2) = 12.0;
-      doubleValues(3) = 13.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
     } else if (context.isRank(3)) {
-      doubleValues(0) = 14.0;
-      doubleValues(1) = 15.0;
-      doubleValues(2) = 16.0;
-      doubleValues(3) = 17.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
     }
 
     // Write output again
@@ -1041,26 +868,19 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
     mesh->createEdge(v7, v8);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0}}));
   }
   if (context.isRank(1)) {
-    doubleValues(0) = 3.0;
-    doubleValues(1) = 4.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{3.0, 4.0}}));
   }
   if (context.isRank(2)) {
-    doubleValues(0) = 5.0;
-    doubleValues(1) = 6.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0}}));
   }
   if (context.isRank(3)) {
-    doubleValues(0) = 7.0;
-    doubleValues(1) = 8.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{7.0, 8.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-parallel.log");
@@ -1074,20 +894,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0}}));
     }
     if (context.isRank(1)) {
-      doubleValues(0) = 4.0;
-      doubleValues(1) = 5.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{4.0, 5.0}}));
     }
     if (context.isRank(2)) {
-      doubleValues(0) = 6.0;
-      doubleValues(1) = 7.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0}}));
     }
     if (context.isRank(3)) {
-      doubleValues(0) = 8.0;
-      doubleValues(1) = 9.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{8.0, 9.0}}));
     }
 
     // Write output again
@@ -1146,34 +962,19 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
     mesh->createEdge(v7, v8);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
-    doubleValues(2) = 3.0;
-    doubleValues(3) = 4.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
   }
   if (context.isRank(1)) {
-    doubleValues(0) = 5.0;
-    doubleValues(1) = 6.0;
-    doubleValues(2) = 7.0;
-    doubleValues(3) = 8.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
   }
   if (context.isRank(2)) {
-    doubleValues(0) = 9.0;
-    doubleValues(1) = 10.0;
-    doubleValues(2) = 11.0;
-    doubleValues(3) = 12.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
   }
   if (context.isRank(3)) {
-    doubleValues(0) = 13.0;
-    doubleValues(1) = 14.0;
-    doubleValues(2) = 15.0;
-    doubleValues(3) = 16.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-parallel.log");
@@ -1187,28 +988,16 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
-      doubleValues(2) = 4.0;
-      doubleValues(3) = 5.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
     }
     if (context.isRank(1)) {
-      doubleValues(0) = 6.0;
-      doubleValues(1) = 7.0;
-      doubleValues(2) = 8.0;
-      doubleValues(3) = 9.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
     }
     if (context.isRank(2)) {
-      doubleValues(0) = 10.0;
-      doubleValues(1) = 11.0;
-      doubleValues(2) = 12.0;
-      doubleValues(3) = 13.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
     }
     if (context.isRank(3)) {
-      doubleValues(0) = 14.0;
-      doubleValues(1) = 15.0;
-      doubleValues(2) = 16.0;
-      doubleValues(3) = 17.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
     }
 
     // Write output again
@@ -1269,24 +1058,19 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
     mesh->createTriangle(e3, e4, e5);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
-    doubleValues(2) = 3.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0}}));
   }
   if (context.isRank(1)) {
+    doubleData->setSampleAtTime(0, time::Sample(1));
   }
   if (context.isRank(2)) {
+    doubleData->setSampleAtTime(0, time::Sample(1));
   }
   if (context.isRank(3)) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 3.0;
-    doubleValues(2) = 4.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 3.0, 4.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity-parallel.log");
@@ -1300,18 +1084,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
-      doubleValues(2) = 4.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0}}));
     }
     if (context.isRank(1)) {
+      doubleData->setSampleAtTime(1, time::Sample(1));
     }
     if (context.isRank(2)) {
+      doubleData->setSampleAtTime(1, time::Sample(1));
     }
     if (context.isRank(3)) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 4.0;
-      doubleValues(2) = 5.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 4.0, 5.0}}));
     }
 
     // Write output again
@@ -1372,30 +1154,19 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
     mesh->createTriangle(e3, e4, e5);
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 2, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
-    doubleValues(2) = 3.0;
-    doubleValues(3) = 4.0;
-    doubleValues(4) = 5.0;
-    doubleValues(5) = 6.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}}));
   }
   if (context.isRank(1)) {
+    doubleData->setSampleAtTime(0, time::Sample(1));
   }
   if (context.isRank(2)) {
+    doubleData->setSampleAtTime(0, time::Sample(1));
   }
   if (context.isRank(3)) {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
-    doubleValues(2) = 5.0;
-    doubleValues(3) = 6.0;
-    doubleValues(4) = 7.0;
-    doubleValues(5) = 8.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 5.0, 6.0, 7.0, 8.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity-parallel.log");
@@ -1409,24 +1180,16 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
-      doubleValues(2) = 4.0;
-      doubleValues(3) = 5.0;
-      doubleValues(4) = 6.0;
-      doubleValues(5) = 7.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0, 6.0, 7.0}}));
     }
     if (context.isRank(1)) {
+      doubleData->setSampleAtTime(1, time::Sample(1));
     }
     if (context.isRank(2)) {
+      doubleData->setSampleAtTime(1, time::Sample(1));
     }
     if (context.isRank(3)) {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
-      doubleValues(2) = 6.0;
-      doubleValues(3) = 7.0;
-      doubleValues(4) = 8.0;
-      doubleValues(5) = 9.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 6.0, 7.0, 8.0, 9.0}}));
     }
 
     // Write output again

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -73,38 +73,20 @@ void testWatchPoint(const TestContext & context,
   }
 
   using precice::testing::operator""_dataID;
-  PtrData                 doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  PtrData                 vectorData   = mesh->createData("VectorData", 2, 1_dataID);
-  auto &                  doubleValues = doubleData->values();
-  auto &                  vectorValues = vectorData->values();
-  mesh->allocateDataValues();
+  PtrData                 doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  PtrData                 vectorData = mesh->createData("VectorData", 2, 1_dataID);
 
   if (context.size > 1) {
     if (context.isPrimary()) {
-      doubleValues(0) = 1.0;
-      doubleValues(1) = 2.0;
-      vectorValues(0) = 1.0;
-      vectorValues(1) = 2.0;
-      vectorValues(2) = 3.0;
-      vectorValues(3) = 4.0;
+      doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0}}));
+      vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
     } else {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
-      vectorValues(0) = 3.0;
-      vectorValues(1) = 4.0;
-      vectorValues(2) = 5.0;
-      vectorValues(3) = 6.0;
+      doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{2.0, 3.0}}));
+      vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{3.0, 4.0, 5.0, 6.0}}));
     }
   } else {
-    doubleValues(0) = 1.0;
-    doubleValues(1) = 2.0;
-    doubleValues(2) = 3.0;
-    vectorValues(0) = 1.0;
-    vectorValues(1) = 2.0;
-    vectorValues(2) = 3.0;
-    vectorValues(3) = 4.0;
-    vectorValues(4) = 5.0;
-    vectorValues(5) = 6.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3.}}));
+    vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
   }
 
   std::string filename0("precice-WatchPointTest-timeseries-0.log");
@@ -125,30 +107,15 @@ void testWatchPoint(const TestContext & context,
     // Change data (next timestep)
     if (context.size > 1) {
       if (context.isPrimary()) {
-        doubleValues(0) = 2.0;
-        doubleValues(1) = 3.0;
-        vectorValues(0) = 2.0;
-        vectorValues(1) = 3.0;
-        vectorValues(2) = 4.0;
-        vectorValues(3) = 5.0;
+        doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3.}}));
+        vectorData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5.}}));
       } else {
-        doubleValues(0) = 3.0;
-        doubleValues(1) = 4.0;
-        vectorValues(0) = 4.0;
-        vectorValues(1) = 5.0;
-        vectorValues(2) = 6.0;
-        vectorValues(3) = 7.0;
+        doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{3., 4.}}));
+        vectorData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{4., 5., 6., 7.}}));
       }
     } else {
-      doubleValues(0) = 2.0;
-      doubleValues(1) = 3.0;
-      doubleValues(2) = 4.0;
-      vectorValues(0) = 2.0;
-      vectorValues(1) = 3.0;
-      vectorValues(2) = 4.0;
-      vectorValues(3) = 5.0;
-      vectorValues(4) = 6.0;
-      vectorValues(5) = 7.0;
+      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4.}}));
+      vectorData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
     }
 
     // Write output again
@@ -287,19 +254,13 @@ BOOST_AUTO_TEST_CASE(Reinitialize)
   mesh::Vertex &v3 = mesh->createVertex(Eigen::Vector2d(1.0, 2.0));
   mesh->createEdge(v1, v2);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  PtrData vectorData   = mesh->createData("VectorData", 2, 1_dataID);
-  auto &  doubleValues = doubleData->values();
-  auto &  vectorValues = vectorData->values();
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  PtrData vectorData = mesh->createData("VectorData", 2, 1_dataID);
 
   // v1, v2 carry data 1
   // v2 and later v3 carry data 2
-  doubleValues.setConstant(1.0);
-  doubleValues(2) = 2.0;
-  vectorValues.setConstant(1.0);
-  vectorValues(4) = 2.0;
-  vectorValues(5) = 2.0;
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 1., 2.}}));
+  vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 1., 1., 1., 2., 2.}}));
 
   std::string filename0("precice-WatchPointTest-reinit-0.log");
   std::string filename1("precice-WatchPointTest-reinit-1.log");
@@ -324,15 +285,8 @@ BOOST_AUTO_TEST_CASE(Reinitialize)
     mesh::Vertex &v4 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
     mesh->createEdge(v3, v4);
     mesh->index().clear();
-    mesh->allocateDataValues();
-    doubleValues.setConstant(1.0);
-    doubleValues(2) = 2.0;
-    doubleValues(3) = 2.0;
-    vectorValues.setConstant(1.0);
-    vectorValues(4) = 2.0;
-    vectorValues(5) = 2.0;
-    vectorValues(6) = 2.0;
-    vectorValues(7) = 2.0;
+    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 1., 2., 2.}}));
+    vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 1., 1., 1., 2., 2., 2., 2.}}));
 
     // Re-Initialize
     watchpoint0.initialize();
@@ -394,18 +348,12 @@ BOOST_AUTO_TEST_CASE(VolumetricInterpolation2D)
   mesh->createEdge(v3, v1);
   mesh->createTriangle(v1, v2, v3);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  PtrData vectorData   = mesh->createData("VectorData", 2, 1_dataID);
-  auto &  doubleValues = doubleData->values();
-  auto &  vectorValues = vectorData->values();
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
+  PtrData vectorData = mesh->createData("VectorData", 2, 1_dataID);
 
   // Data is (1,1,2) for the scalar, and same for each vector component.
-  doubleValues.setConstant(1.0);
-  doubleValues(2) = 2.0;
-  vectorValues.setConstant(1.0);
-  vectorValues(4) = 2.0;
-  vectorValues(5) = 2.0;
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 1., 2., 2.}}));
+  vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 1., 1., 1., 2., 2., 2., 2.}}));
 
   std::string filename0("precice-WatchPointTest-volumetric2d-0.log");
   std::string filename1("precice-WatchPointTest-volumetric2d-1.log");
@@ -475,15 +423,10 @@ BOOST_AUTO_TEST_CASE(VolumetricInterpolation3D)
 
   mesh->createTetrahedron(v1, v2, v3, v4);
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   // Data is (1,1,2) for the scalar, and same for each vector component.
-  doubleValues(0) = 1.0;
-  doubleValues(1) = 2.0;
-  doubleValues(2) = 3.0;
-  doubleValues(3) = 4.0;
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string filename0("precice-WatchPointTest-volumetric3d-0.log");
   std::string filename1("precice-WatchPointTest-volumetric3d-1.log");
@@ -572,14 +515,10 @@ BOOST_AUTO_TEST_CASE(VolumetricParallel)
   } break;
   }
 
-  PtrData doubleData   = mesh->createData("DoubleData", 1, 0_dataID);
-  auto &  doubleValues = doubleData->values();
-  mesh->allocateDataValues();
+  PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   // Data is (1, 2, 3, 4) on the tetra, other ranks agree on their subset
-  for (int i = 0; i <= context.rank; ++i) {
-    doubleValues(i) = i + 1;
-  }
+  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd(context.rank + 1).setLinSpaced(1., context.rank + 1)));
 
   std::string filename0("precice-WatchPointTest-volumetricParallel-0.log");
   bool        isClosest;


### PR DESCRIPTION
## Main changes of this PR

This PR migrates the watchpoints and integrals implementation and tests to using samples instead of relying on `Data::values()`

## Motivation and additional information

#1645


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
