### PR TITLE
Simplify Acceleration class by removing unnecessary functions

### DIFF
--- a/docs/changelog/2107.md
+++ b/docs/changelog/2107.md
@@ -1,1 +1,0 @@
-- Remove columns "QNColumns", "DeletedQNColumns", and "DroppedQNColumns" from `*-iterations.log` for non-quasi-Newton acceleration schemes.

--- a/docs/changelog/2107.md
+++ b/docs/changelog/2107.md
@@ -1,0 +1,1 @@
+- Remove columns "QNColumns", "DeletedQNColumns", and "DroppedQNColumns" from `*-iterations.log` for non-quasi-Newton acceleration schemes.

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -42,24 +42,6 @@ public:
 
   virtual void importState(io::TXTReader &reader) {}
 
-  /// Gives the number of QN columns that where filtered out (i.e. deleted) in this time window
-  virtual int getDeletedColumns() const
-  {
-    return 0;
-  }
-
-  /// Gives the number of QN columns that went out of scope in this time window
-  virtual int getDroppedColumns() const
-  {
-    return 0;
-  }
-
-  /// Gives the number of current QN columns (LS = least squares)
-  virtual int getLSSystemCols() const
-  {
-    return 0;
-  }
-
 protected:
   /// Checks if all dataIDs are contained in cplData
   void checkDataIDs(const DataMap &cplData) const;

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -632,7 +632,7 @@ int BaseQNAcceleration::getLSSystemCols() const
   return cols;
 }
 
-int BaseQNAcceleration::getLSSystemRows()
+int BaseQNAcceleration::getLSSystemRows() const
 {
   if (utils::IntraComm::isParallel()) {
     return _dimOffsets.back();
@@ -640,7 +640,7 @@ int BaseQNAcceleration::getLSSystemRows()
   return _residuals.size();
 }
 
-int BaseQNAcceleration::getPrimaryLSSystemRows()
+int BaseQNAcceleration::getPrimaryLSSystemRows() const
 {
   if (utils::IntraComm::isParallel()) {
     return _dimOffsetsPrimary.back();

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -126,10 +126,10 @@ public:
   virtual void importState(io::TXTReader &reader);
 
   /// how many QN columns were deleted in this time window
-  virtual int getDeletedColumns() const;
+  int getDeletedColumns() const;
 
   /// how many QN columns were dropped (went out of scope) in this time window
-  virtual int getDroppedColumns() const;
+  int getDroppedColumns() const;
 
   /** @brief: computes number of cols in least squares system, i.e, number of cols in
    *  _matrixV, _matrixW, _qrV, etc..
@@ -138,7 +138,7 @@ public:
    *  information about the number of cols. This info is needed for
    *  intra-participant communication. Number of its =! _cols in general.
    */
-  virtual int getLSSystemCols() const;
+  int getLSSystemCols() const;
 
 protected:
   logging::Logger _log{"acceleration::BaseQNAcceleration"};
@@ -241,8 +241,8 @@ protected:
   std::ostringstream _infostringstream;
   std::fstream       _infostream;
 
-  int getLSSystemRows();
-  int getPrimaryLSSystemRows();
+  int getLSSystemRows() const;
+  int getPrimaryLSSystemRows() const;
 
   /**
    * @brief Marks a iteration sequence as converged.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -771,19 +771,12 @@ void BaseCouplingScheme::advanceTXTWriters()
     bool converged = _iterations >= _minIterations && (_maxIterations < 0 || (_iterations < _maxIterations));
     _iterationsWriter->writeData("Convergence", converged ? 1 : 0);
 
-    if (not doesFirstStep()) {
-      std::shared_ptr<precice::acceleration::BaseQNAcceleration> qnAcceleration = std::dynamic_pointer_cast<precice::acceleration::BaseQNAcceleration>(_acceleration);
-      if (qnAcceleration) {
-        // Only write values for additional columns, if using a QN-based acceleration scheme
-        _iterationsWriter->writeData("QNColumns", qnAcceleration->getLSSystemCols());
-        _iterationsWriter->writeData("DeletedQNColumns", qnAcceleration->getDeletedColumns());
-        _iterationsWriter->writeData("DroppedQNColumns", qnAcceleration->getDroppedColumns());
-      } else {
-        // non-breaking implementation uses "0" for these columns (delete columns in the future?)
-        _iterationsWriter->writeData("QNColumns", 0);
-        _iterationsWriter->writeData("DeletedQNColumns", 0);
-        _iterationsWriter->writeData("DroppedQNColumns", 0);
-      }
+    std::shared_ptr<precice::acceleration::BaseQNAcceleration> qnAcceleration = std::dynamic_pointer_cast<precice::acceleration::BaseQNAcceleration>(_acceleration);
+    if (qnAcceleration && not doesFirstStep()) {
+      // Only write values for additional columns, if using a QN-based acceleration scheme
+      _iterationsWriter->writeData("QNColumns", qnAcceleration->getLSSystemCols());
+      _iterationsWriter->writeData("DeletedQNColumns", qnAcceleration->getDeletedColumns());
+      _iterationsWriter->writeData("DroppedQNColumns", qnAcceleration->getDroppedColumns());
     }
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 
 #include "acceleration/Acceleration.hpp"
+#include "acceleration/BaseQNAcceleration.hpp"
 #include "com/SerializedStamples.hpp"
 #include "cplscheme/BaseCouplingScheme.hpp"
 #include "cplscheme/Constants.hpp"
@@ -770,10 +771,19 @@ void BaseCouplingScheme::advanceTXTWriters()
     bool converged = _iterations >= _minIterations && (_maxIterations < 0 || (_iterations < _maxIterations));
     _iterationsWriter->writeData("Convergence", converged ? 1 : 0);
 
-    if (not doesFirstStep() && _acceleration) {
-      _iterationsWriter->writeData("QNColumns", _acceleration->getLSSystemCols());
-      _iterationsWriter->writeData("DeletedQNColumns", _acceleration->getDeletedColumns());
-      _iterationsWriter->writeData("DroppedQNColumns", _acceleration->getDroppedColumns());
+    if (not doesFirstStep()) {
+      std::shared_ptr<precice::acceleration::BaseQNAcceleration> qnAcceleration = std::dynamic_pointer_cast<precice::acceleration::BaseQNAcceleration>(_acceleration);
+      if (qnAcceleration) {
+        // Only write values for additional columns, if using a QN-based acceleration scheme
+        _iterationsWriter->writeData("QNColumns", qnAcceleration->getLSSystemCols());
+        _iterationsWriter->writeData("DeletedQNColumns", qnAcceleration->getDeletedColumns());
+        _iterationsWriter->writeData("DroppedQNColumns", qnAcceleration->getDroppedColumns());
+      } else {
+        // non-breaking implementation uses "0" for these columns (delete columns in the future?)
+        _iterationsWriter->writeData("QNColumns", 0);
+        _iterationsWriter->writeData("DeletedQNColumns", 0);
+        _iterationsWriter->writeData("DroppedQNColumns", 0);
+      }
     }
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -771,12 +771,19 @@ void BaseCouplingScheme::advanceTXTWriters()
     bool converged = _iterations >= _minIterations && (_maxIterations < 0 || (_iterations < _maxIterations));
     _iterationsWriter->writeData("Convergence", converged ? 1 : 0);
 
-    std::shared_ptr<precice::acceleration::BaseQNAcceleration> qnAcceleration = std::dynamic_pointer_cast<precice::acceleration::BaseQNAcceleration>(_acceleration);
-    if (qnAcceleration && not doesFirstStep()) {
-      // Only write values for additional columns, if using a QN-based acceleration scheme
-      _iterationsWriter->writeData("QNColumns", qnAcceleration->getLSSystemCols());
-      _iterationsWriter->writeData("DeletedQNColumns", qnAcceleration->getDeletedColumns());
-      _iterationsWriter->writeData("DroppedQNColumns", qnAcceleration->getDroppedColumns());
+    if (not doesFirstStep()) {
+      std::shared_ptr<precice::acceleration::BaseQNAcceleration> qnAcceleration = std::dynamic_pointer_cast<precice::acceleration::BaseQNAcceleration>(_acceleration);
+      if (qnAcceleration) {
+        // Only write values for additional columns, if using a QN-based acceleration scheme
+        _iterationsWriter->writeData("QNColumns", qnAcceleration->getLSSystemCols());
+        _iterationsWriter->writeData("DeletedQNColumns", qnAcceleration->getDeletedColumns());
+        _iterationsWriter->writeData("DroppedQNColumns", qnAcceleration->getDroppedColumns());
+      } else {
+        // non-breaking implementation uses "0" for these columns (delete columns in the future?)
+        _iterationsWriter->writeData("QNColumns", 0);
+        _iterationsWriter->writeData("DeletedQNColumns", 0);
+        _iterationsWriter->writeData("DroppedQNColumns", 0);
+      }
     }
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -771,7 +771,7 @@ void BaseCouplingScheme::advanceTXTWriters()
     bool converged = _iterations >= _minIterations && (_maxIterations < 0 || (_iterations < _maxIterations));
     _iterationsWriter->writeData("Convergence", converged ? 1 : 0);
 
-    if (not doesFirstStep()) {
+    if (not doesFirstStep() && _acceleration) {
       std::shared_ptr<precice::acceleration::BaseQNAcceleration> qnAcceleration = std::dynamic_pointer_cast<precice::acceleration::BaseQNAcceleration>(_acceleration);
       if (qnAcceleration) {
         // Only write values for additional columns, if using a QN-based acceleration scheme


### PR DESCRIPTION
## Main changes of this PR

Simplifies the `Acceleration.hpp` class.

## Motivation and additional information

Reduce complexity of `Acceleration` class hierarchy.

Drawback: I need to update the implementation of the writer in `BaseCouplingScheme`. However, I think that the implementation before was also not great: writing `QNColumns`, `DeletedQNColumns`, and `DroppedQNColumns` for non-QN acceleration schemes does not really make sense. I still decided to keep this and hard-code the value to `0` (same behavior as before) to implement this in a non-breaking fashion.

We could, of course, also just remove the `else` branch. This would affect the file output. This would be breaking but also an improvement.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
