### PR TITLE
Add error when defining multiple accelerations

### DIFF
--- a/docs/changelog/2111.md
+++ b/docs/changelog/2111.md
@@ -1,0 +1,1 @@
+- Added error message when defining multiple acceleration schemes per coupling-scheme.

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -256,6 +256,7 @@ void AccelerationConfiguration::xmlEndTagCallback(
       }
     }
 
+    PRECICE_CHECK(!_acceleration, "You are trying to define multiple acceleration schemes, which is not allowed. Please remove one of them.");
     if (callingTag.getName() == VALUE_CONSTANT) {
       _acceleration = PtrAcceleration(
           new ConstantRelaxationAcceleration(

--- a/tests/serial/TwoAccelerations.cpp
+++ b/tests/serial/TwoAccelerations.cpp
@@ -1,0 +1,24 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_CASE(TwoAccelerations)
+{
+  PRECICE_TEST("A"_on(1_rank), "B"_on(1_rank));
+
+  using Eigen::Vector2d;
+
+  BOOST_CHECK_THROW(
+      (precice::Participant{context.name, context.config(), context.rank, context.size}),
+      ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/TwoAccelerations.xml
+++ b/tests/serial/TwoAccelerations.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" />
+  <data:scalar name="Data2" />
+
+  <mesh name="A-Mesh" dimensions="2">
+    <use-data name="Data" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="B-Mesh" dimensions="2">
+    <use-data name="Data" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="A-Mesh" />
+    <receive-mesh name="B-Mesh" from="B" />
+    <read-data name="Data2" mesh="A-Mesh" />
+    <write-data name="Data" mesh="A-Mesh" />
+    <mapping:nearest-neighbor direction="write" from="A-Mesh" to="B-Mesh" constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="B-Mesh"
+      to="A-Mesh"
+      constraint="conservative" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="B-Mesh" />
+    <read-data name="Data" mesh="B-Mesh" />
+    <write-data name="Data2" mesh="B-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="B" second="A" />
+    <max-time value="1.0" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="B-Mesh" from="A" to="B" substeps="false" />
+    <exchange data="Data2" mesh="B-Mesh" from="B" to="A" />
+    <max-iterations value="2" />
+    <relative-convergence-measure limit="1.0e-5" data="Data" mesh="B-Mesh" />
+    <acceleration:constant>
+      <relaxation value="0.5" />
+    </acceleration:constant>
+    <acceleration:aitken>
+      <data mesh="B-Mesh" name="Data" />
+      <initial-relaxation value="0.1" />
+    </acceleration:aitken>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -101,6 +101,7 @@ target_sources(testprecice
     tests/serial/TestExplicitWithSolverGeometry.cpp
     tests/serial/TestImplicit.cpp
     tests/serial/TestReadAPI.cpp
+    tests/serial/TwoAccelerations.cpp
     tests/serial/action-timings/ActionTimingsParallelExplicit.cpp
     tests/serial/action-timings/ActionTimingsParallelImplicit.cpp
     tests/serial/action-timings/ActionTimingsSerialExplicit.cpp


### PR DESCRIPTION
## Main changes of this PR

Adds an error when defining two acceleration schemes in a coupling scheme.

```
ERROR: You are trying to define multiple acceleration schemes, which is not allowed. Please remove one of them.
```

## Motivation and additional information

Closes #2109

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
