### PR TITLE
Print nested events with indentation

### DIFF
--- a/docs/changelog/2117.md
+++ b/docs/changelog/2117.md
@@ -1,1 +1,1 @@
-- Changed output of `precice-profiling analyze` to show nested output using indentation
+- Changed output of `precice-profiling analyze` to show nested events using indentation

--- a/docs/changelog/2117.md
+++ b/docs/changelog/2117.md
@@ -1,0 +1,1 @@
+- Changed output of `precice-profiling analyze` to show nested output using indentation

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -73,6 +73,23 @@ def printWide(df):
 
     import polars as pl
 
+    def makeLabel(eventName):
+        if "_GLOBAL" in eventName:
+            return "total"
+
+        indentation = "  "
+
+        if "/" not in eventName:
+            return indentation + eventName
+        parts = eventName.split("/")
+        return indentation * len(parts) + parts[-1]
+
+    df = (
+        df.sort("eid")
+        .with_columns(pl.col("eid").map_elements(makeLabel, return_dtype=pl.String))
+        .rename({"eid": "name"})
+    )
+
     mincolwidth = 8
 
     def formattedLength(s):
@@ -85,19 +102,31 @@ def printWide(df):
         .row(0)
     )
     assert len(headerWidths) == len(bodyWidths)
-    colwidths = map(max, zip(headerWidths, bodyWidths, repeat(mincolwidth)))
+    colwidths = list(map(max, zip(headerWidths, bodyWidths, repeat(mincolwidth))))
+    colaligns = ["<"] + [">"] * (len(df.columns) - 1)
 
-    colfmts = ["{:>" + str(w) + "}" for w in colwidths]
+    colfmts = ["{:" + a + str(w) + "}" for w, a in zip(colwidths, colaligns)]
 
     rowfmt = colfmts[0]
+
     # Measurements always come in batches of 5
-    from itertools import islice
+    def batched(iterable):
+        from itertools import islice
+
+        iterator = iter(iterable)
+        while batch := tuple(islice(iterator, 5)):
+            yield batch
 
     fmts = iter(colfmts[1:])
-    while batch := list(islice(fmts, 5)):
+    for batch in batched(fmts):
         rowfmt += " | " + " ".join(batch)
 
+    hline = "-" * colwidths[0]
+    for b in batched(colwidths[1:]):
+        hline += "-+-" + "-" * (sum(b) + len(b) - 1)
+
     print(rowfmt.format(*(df.columns)))
+    print(hline)
     for row in df.iter_rows():
         print(rowfmt.format(*map(lambda e: "" if e is None else e, row)))
 

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -549,9 +549,12 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
     run = Run(profilingfile)
     df = run.toDataFrame()
 
-    assert df.select(
-        pl.col("participant").is_in([participant]).any()
-    ).item(), f"Given participant {participant} doesn't exist."
+    participants = set(df.get_column("participant").unique())
+    assert (
+        participant in participants
+    ), f"Given participant {participant} doesn't exist. Known: " + ", ".join(
+        participants
+    )
 
     print(f"Output timing are in {unit}.")
 

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -119,11 +119,11 @@ def printWide(df):
 
     fmts = iter(colfmts[1:])
     for batch in batched(fmts):
-        rowfmt += " | " + " ".join(batch)
+        rowfmt += " │ " + " ".join(batch)
 
-    hline = "-" * colwidths[0]
+    hline = "─" * colwidths[0]
     for b in batched(colwidths[1:]):
-        hline += "-+-" + "-" * (sum(b) + len(b) - 1)
+        hline += "─┼─" + "─" * (sum(b) + len(b) - 1)
 
     print(rowfmt.format(*(df.columns)))
     print(hline)


### PR DESCRIPTION
## Main changes of this PR

This PR changes the `precice-profiling analyze` output to print nested events using indentation.

This makes the `eid` column (renamed to name) more impact and makes the output more digestible.
Note that this only changes the console output, the csv output using `-o` still contains the full event name as the eid column.

### Serial example

```
Reading events file profiling.json
Output timing are in us.
name                                          │       sum    count      mean       min       max
──────────────────────────────────────────────┼─────────────────────────────────────────────────
total                                         │ 1520885.0        1 1520885.0 1520885.0 1520885.0
  advance                                     │  183083.0        1  183083.0  183083.0  183083.0
    m2n.receiveData                           │    1362.0        1    1362.0    1362.0    1362.0
    map.bbm.mapData.FromA-MeshToB-Mesh        │      86.0        1      86.0      86.0      86.0
    map.vci.computeMapping.FromA-MeshToB-Mesh │  181377.0        1  181377.0  181377.0  181377.0
    query.index.getTetraIndexTree.A-Mesh      │  172770.0        1  172770.0  172770.0  172770.0
  configure                                   │      71.0        1      71.0      71.0      71.0
  finalize                                    │     704.0        1     704.0     704.0     704.0
  initialize                                  │ 1333426.0        1 1333426.0 1333426.0 1333426.0
    m2n.acceptPrimaryRankConnection.A         │  810972.0        1  810972.0  810972.0  810972.0
    m2n.acceptSecondaryRanksConnection        │   47853.0        1   47853.0   47853.0   47853.0
    m2n.broadcastVertexDistributions          │       1.0        1       1.0       1.0       1.0
    m2n.buildCommunicationMap                 │    5491.0        1    5491.0    5491.0    5491.0
    m2n.createCommunications                  │     426.0        1     426.0     426.0     426.0
    m2n.exchangeVertexDistribution            │   41864.0        1   41864.0   41864.0   41864.0
    partition.prepareMesh.B-Mesh              │      36.0        1      36.0      36.0      36.0
    partition.receiveGlobalMesh.A-Mesh        │  468944.0        1  468944.0  468944.0  468944.0
    preprocess.B-Mesh                         │      26.0        1      26.0      26.0      26.0
  solver.advance                              │    2278.0        1    2278.0    2278.0    2278.0
  solver.initialize.postinit                  │     178.0        1     178.0     178.0     178.0
  solver.initialize.preinit                   │     925.0        1     925.0     925.0     925.0
```

### Parallel example

```
Reading events file profiling.json
Output timing are in us.
Selection contains the primary rank 0, the cheapest secondary rank 7, and the most expensive secondary rank 1.
name                                             │   R0:sum R0:count  R0:mean   R0:min   R0:max │   R7:sum R7:count  R7:mean   R7:min   R7:max │   R1:sum R1:count  R1:mean   R1:min   R1:max
─────────────────────────────────────────────────┼──────────────────────────────────────────────┼──────────────────────────────────────────────┼─────────────────────────────────────────────
total                                            │ 286413.0        1 286413.0 286413.0 286413.0 │ 282758.0        1 282758.0 282758.0 282758.0 │ 282681.0        1 282681.0 282681.0 282681.0
  advance                                        │  69418.0        1  69418.0  69418.0  69418.0 │    715.0        1    715.0    715.0    715.0 │  75672.0        1  75672.0  75672.0  75672.0
    m2n.receiveData                              │     38.0        1     38.0     38.0     38.0 │      2.0        1      2.0      2.0      2.0 │   1131.0        1   1131.0   1131.0   1131.0
    map.bbm.mapData.FromA-MeshToB-Mesh           │    238.0        1    238.0    238.0    238.0 │     11.0        1     11.0     11.0     11.0 │    225.0        1    225.0    225.0    225.0
    map.np.computeMapping.FromA-MeshToB-Mesh     │  68146.0        1  68146.0  68146.0  68146.0 │     27.0        1     27.0     27.0     27.0 │  73408.0        1  73408.0  73408.0  73408.0
    query.index.getEdgeIndexTree.A-Mesh          │    416.0        1    416.0    416.0    416.0 │                                              │    487.0        1    487.0    487.0    487.0
    query.index.getTriangleIndexTree.A-Mesh      │    387.0        1    387.0    387.0    387.0 │                                              │    629.0        1    629.0    629.0    629.0
    query.index.getVertexIndexTree.A-Mesh        │     99.0        1     99.0     99.0     99.0 │                                              │    161.0        1    161.0    161.0    161.0
  com.initializeIntraCom                         │   9095.0        1   9095.0   9095.0   9095.0 │   3422.0        1   3422.0   3422.0   3422.0 │   3799.0        1   3799.0   3799.0   3799.0
  configure                                      │    131.0        1    131.0    131.0    131.0 │    188.0        1    188.0    188.0    188.0 │    198.0        1    198.0    198.0    198.0
  finalize                                       │   1377.0        1   1377.0   1377.0   1377.0 │  12877.0        1  12877.0  12877.0  12877.0 │    676.0        1    676.0    676.0    676.0
  initialize                                     │ 184117.0        1 184117.0 184117.0 184117.0 │ 181376.0        1 181376.0 181376.0 181376.0 │ 181923.0        1 181923.0 181923.0 181923.0
    m2n.acceptPrimaryRankConnection.A            │  43486.0        1  43486.0  43486.0  43486.0 │  44151.0        1  44151.0  44151.0  44151.0 │  42901.0        1  42901.0  42901.0  42901.0
    m2n.acceptSecondaryRanksConnection           │  46861.0        1  46861.0  46861.0  46861.0 │  45471.0        1  45471.0  45471.0  45471.0 │  47186.0        1  47186.0  47186.0  47186.0
    m2n.broadcastVertexDistributions             │   2582.0        1   2582.0   2582.0   2582.0 │  45198.0        1  45198.0  45198.0  45198.0 │  45233.0        1  45233.0  45233.0  45233.0
    m2n.buildCommunicationMap                    │    185.0        1    185.0    185.0    185.0 │    144.0        1    144.0    144.0    144.0 │    117.0        1    117.0    117.0    117.0
    m2n.createCommunications                     │   1408.0        1   1408.0   1408.0   1408.0 │      2.0        1      2.0      2.0      2.0 │   1757.0        1   1757.0   1757.0   1757.0
    m2n.exchangeVertexDistribution               │  42534.0        1  42534.0  42534.0  42534.0 │                                              │                                             
    map.bbm.tagMeshFirstRound.FromA-MeshToB-Mesh │  70478.0        1  70478.0  70478.0  70478.0 │    181.0        1    181.0    181.0    181.0 │  69765.0        1  69765.0  69765.0  69765.0
    map.np.computeMapping.FromA-MeshToB-Mesh     │  70130.0        1  70130.0  70130.0  70130.0 │     52.0        1     52.0     52.0     52.0 │  69461.0        1  69461.0  69461.0  69461.0
    partition.broadcastMesh.A-Mesh               │   2012.0        1   2012.0   2012.0   2012.0 │   4943.0        1   4943.0   4943.0   4943.0 │   4817.0        1   4817.0   4817.0   4817.0
    partition.createOwnerInformation.A-Mesh      │   6390.0        1   6390.0   6390.0   6390.0 │     44.0        1     44.0     44.0     44.0 │   2590.0        1   2590.0   2590.0   2590.0
    partition.feedbackMesh.A-Mesh                │    598.0        1    598.0    598.0    598.0 │     57.0        1     57.0     57.0     57.0 │     86.0        1     86.0     86.0     86.0
    partition.filterMeshBB.A-Mesh                │   1781.0        1   1781.0   1781.0   1781.0 │    313.0        1    313.0    313.0    313.0 │   2910.0        1   2910.0   2910.0   2910.0
    partition.filterMeshMappingsA-Mesh           │   1015.0        1   1015.0   1015.0   1015.0 │     58.0        1     58.0     58.0     58.0 │    932.0        1    932.0    932.0    932.0
    partition.prepareMesh.B-Mesh                 │   1333.0        1   1333.0   1333.0   1333.0 │   1349.0        1   1349.0   1349.0   1349.0 │   1438.0        1   1438.0   1438.0   1438.0
    partition.receiveGlobalMesh.A-Mesh           │   5703.0        1   5703.0   5703.0   5703.0 │      2.0        1      2.0      2.0      2.0 │      1.0        1      1.0      1.0      1.0
    preprocess.B-Mesh                            │     45.0        1     45.0     45.0     45.0 │     50.0        1     50.0     50.0     50.0 │     41.0        1     41.0     41.0     41.0
    query.index.getEdgeIndexTree.A-Mesh          │    576.0        1    576.0    576.0    576.0 │                                              │   1076.0        1   1076.0   1076.0   1076.0
    query.index.getTriangleIndexTree.A-Mesh      │    537.0        1    537.0    537.0    537.0 │                                              │    989.0        1    989.0    989.0    989.0
    query.index.getVertexIndexTree.A-Mesh        │    143.0        1    143.0    143.0    143.0 │                                              │    262.0        1    262.0    262.0    262.0
  solver.advance                                 │  19248.0        1  19248.0  19248.0  19248.0 │  82181.0        1  82181.0  82181.0  82181.0 │  16855.0        1  16855.0  16855.0  16855.0
  solver.initialize.postinit                     │    721.0        1    721.0    721.0    721.0 │    281.0        1    281.0    281.0    281.0 │    730.0        1    730.0    730.0    730.0
  solver.initialize.preinit                      │   2084.0        1   2084.0   2084.0   2084.0 │   1455.0        1   1455.0   1455.0   1455.0 │   2556.0        1   2556.0   2556.0   2556.0
```


## Motivation and additional information

Closes #2115

The output will improve with #1673 as the scoping is currently manual and incomplete.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
