### PR TITLE
Automatically register tests in CTest

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -82,7 +82,7 @@ jobs:
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
       working-directory: build
-      run: ctest
+      run: ctest -j
     - uses: actions/upload-artifact@v4
       if: failure()
       with:

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -81,6 +81,8 @@ jobs:
     - name: Tests
       env:
         CTEST_OUTPUT_ON_FAILURE: 1
+        OMPI_MCA_btl: self,vader
+        OMPI_MCA_pml: ob1
       working-directory: build
       run: ctest -j
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -152,7 +152,9 @@ jobs:
         env:
           CTEST_OUTPUT_ON_FAILURE: 1
           BOOST_TEST_LOG_LEVEL: all
-          OMPI_MCA_btl_tcp_if_include: lo # required for arch
+          OMPI_MCA_btl: self,vader
+          OMPI_MCA_pml: ob1
+          FI_PROVIDER: ${{ matrix.IMAGE == 'Intel' && 'tcp' || 'sockets' }} # use sockets on fedora and tcp on intel
           PSM3_HAL: loopback # required for fedora
         working-directory: build
         run: su -c ". ../venv/bin/activate && ctest -j" $PRECICE_USER

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -155,7 +155,7 @@ jobs:
           OMPI_MCA_btl_tcp_if_include: lo # required for arch
           PSM3_HAL: loopback # required for fedora
         working-directory: build
-        run: su -c ". ../venv/bin/activate && ctest" $PRECICE_USER
+        run: su -c ". ../venv/bin/activate && ctest -j" $PRECICE_USER
       - name: Coverage Report
         working-directory: build
         if: ${{ matrix.COVFLAGS }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,9 @@ if (PRECICE_FEATURE_MPI_COMMUNICATION)
   set(MPI_DETERMINE_LIBRARY_VERSION ON) # Try to detect the library vendor
 
   find_package(MPI REQUIRED)
-  message(STATUS "MPI Version: ${MPI_CXX_LIBRARY_VERSION_STRING}")
+
+  string(REGEX MATCH "^[^\n]*" PRECICE_MPI_VERSION "${MPI_CXX_LIBRARY_VERSION_STRING}")
+  message(STATUS "MPI Version: ${PRECICE_MPI_VERSION}")
 endif()
 
 # Option: PETSC

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -25,61 +25,6 @@ else()
 endif()
 mark_as_advanced(PRECICE_TEST_WRAPPER_SCRIPT)
 
-
-function(add_precice_test)
-  cmake_parse_arguments(PARSE_ARGV 0 PAT "PETSC;MPIPORTS;GINKGO;GINKGO_OMP;GINKGO_CUDA;GINKGO_HIP" "NAME;ARGUMENTS;TIMEOUT;LABELS" "")
-  # Check arguments
-  if(NOT PAT_NAME)
-    message(FATAL_ERROR "Argument NAME not passed")
-  endif()
-
-  # We always prefix our tests
-  set(PAT_FULL_NAME "precice.${PAT_NAME}")
-
-  # Are direct dependencies fulfilled?
-  if( (NOT PRECICE_FEATURE_MPI_COMMUNICATION) OR (PAT_PETSC AND NOT PRECICE_FEATURE_PETSC_MAPPING)
-       OR (PAT_GINKGO AND NOT PRECICE_FEATURE_GINKGO_MAPPING)
-       OR (PAT_GINKGO_OMP AND NOT PRECICE_WITH_OPENMP)
-       OR (PAT_GINKGO_CUDA AND NOT PRECICE_WITH_CUDA)
-       OR (PAT_GINKGO_HIP AND NOT PRECICE_WITH_HIP))
-    message(STATUS "Test ${PAT_FULL_NAME} - skipped")
-    return()
-  endif()
-
-  # We need to disable the MPIPorts tests in case we detect Open MPI or Intel MPI
-  if(PAT_MPIPORTS AND (MPI_CXX_LIBRARY_VERSION_STRING MATCHES "Open MPI|Intel"))
-    message(STATUS "Test ${PAT_FULL_NAME} - skipped (unsupported for this MPI)")
-    return()
-  endif()
-  message(STATUS "Test ${PAT_FULL_NAME}")
-
-  # Assemble the command
-  # --map-by=:OVERSUBSCRIBE works for OpenMPI(4+5) and MPICH, but not for Intel which doesn't need a flag
-  set(_precice_oversubscribe "--map-by;:OVERSUBSCRIBE")
-  if(MPI_CXX_LIBRARY_VERSION_STRING MATCHES "Intel")
-     set(_precice_oversubscribe "")
-  endif()
-  add_test(NAME ${PAT_FULL_NAME}
-    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 ${_precice_oversubscribe}  ${PRECICE_CTEST_MPI_FLAGS} ${MPIEXEC_PREFLAGS} $<TARGET_FILE:testprecice> ${MPIEXEC_POSTFLAGS} ${PAT_ARGUMENTS}
-    )
-  unset(_precice_oversubscribe)
-
-  # Generate working directory
-  set(PAT_WDIR "${PRECICE_TEST_DIR}/${PAT_NAME}")
-  file(MAKE_DIRECTORY "${PAT_WDIR}")
-  # Setting properties
-  set_tests_properties(${PAT_FULL_NAME}
-    PROPERTIES
-    WORKING_DIRECTORY "${PAT_WDIR}"
-    ENVIRONMENT "OMP_NUM_THREADS=2"
-    )
-  if(PAT_TIMEOUT)
-    set_tests_properties(${PAT_FULL_NAME} PROPERTIES TIMEOUT ${PAT_TIMEOUT} )
-  endif()
-  set(_labels ${PAT_LABELS})
-  set_tests_properties(${PAT_FULL_NAME} PROPERTIES LABELS "${_labels}")
-endfunction(add_precice_test)
-
 function(add_precice_test_build_solverdummy PAT_LANG)
   # Turn language to lowercase
   string(TOLOWER ${PAT_LANG} PAT_LANG)
@@ -124,7 +69,7 @@ function(add_precice_test_build_solverdummy PAT_LANG)
     PROPERTIES
     WORKING_DIRECTORY "${PAT_BIN_DIR}"
     FIXTURES_SETUP "${PAT_LANG}-solverdummy"
-    LABELS "Solverdummy"
+    LABELS "solverdummy"
     TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
     )
 endfunction(add_precice_test_build_solverdummy)
@@ -197,7 +142,7 @@ function(add_precice_test_run_solverdummies PAT_LANG_A PAT_LANG_B)
     PROPERTIES
     WORKING_DIRECTORY "${PAT_RUN_DIR}"
     FIXTURES_REQUIRED "${PAT_LANG_A}-solverdummy;${PAT_LANG_B}-solverdummy"
-    LABELS "Solverdummy"
+    LABELS "solverdummy"
     TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
     )
 endfunction(add_precice_test_run_solverdummies)
@@ -205,163 +150,41 @@ endfunction(add_precice_test_run_solverdummies)
 
 enable_testing()
 
+# Autodiscovery of CTest
 if(NOT PRECICE_FEATURE_MPI_COMMUNICATION)
-  message("Tests require MPICommunication to be enabled.")
+  message(STATUS "Unit and integrationtests require MPI to be enabled.")
+else()
+
+  # This file is automatically loaded by CTEST and needs to exist to prevent strange errors
+  set(ctest_tests_file "${preCICE_BINARY_DIR}/ctest_tests.cmake")
+  if(NOT EXISTS "${ctest_tests_file}")
+    file(WRITE "${ctest_tests_file}" "")
+  endif()
+  set_property(DIRECTORY
+    APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_tests_file}"
+  )
+
+  # Custom command that generates the tests list after the testprecice binary is build
+  add_custom_command(
+    TARGET testprecice POST_BUILD
+    COMMAND "${CMAKE_COMMAND}"
+    -D "TEST_EXECUTABLE=$<TARGET_FILE:testprecice>"
+    -D "TEST_FILE=${ctest_tests_file}"
+    -D "TEST_DIR=${PRECICE_TEST_DIR}"
+    -D "PRECICE_MPI_VERSION=${PRECICE_MPI_VERSION}"
+    -D "MPIEXEC_EXECUTABLE=${MPIEXEC_EXECUTABLE}"
+    -D "MPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}"
+    -D "PRECICE_CTEST_MPI_FLAGS=${PRECICE_CTEST_MPI_FLAGS}"
+    -D "MPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}"
+    -D "MPIEXEC_POSTFLAGS=${MPIEXEC_POSTFLAGS}"
+    -P "${preCICE_SOURCE_DIR}/cmake/discover_tests.cmake"
+    COMMENT "Generating list of tests"
+    BYPRODUCTS "${preCICE_BINARY_DIR}/tests.txt"
+    VERBATIM)
+
 endif()
 
-add_precice_test(
-  NAME acceleration
-  ARGUMENTS "--run_test=AccelerationTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME action
-  ARGUMENTS "--run_test=ActionTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME com
-  ARGUMENTS "--run_test=CommunicationTests:\!CommunicationTests/MPIPorts:\!CommunicationTests/MPISinglePorts"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME com.mpiports
-  ARGUMENTS "--run_test=CommunicationTests/MPIPorts:CommunicationTests/MPISinglePorts"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  LABELS "mpiports"
-  MPIPORTS
-  )
-add_precice_test(
-  NAME cplscheme
-  ARGUMENTS "--run_test=CplSchemeTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-  )
-add_precice_test(
-  NAME io
-  ARGUMENTS "--run_test=IOTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME m2n
-  ARGUMENTS "--run_test=M2NTests:\!M2NTests/MPIPorts:\!M2NTets/MPISinglePorts"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME m2n.mpiports
-  ARGUMENTS "--run_test=M2NTests/MPIPorts:M2NTests/MPISinglePorts"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  LABELS "mpiports"
-  MPIPORTS
-  )
-add_precice_test(
-  NAME mapping
-  ARGUMENTS "--run_test=MappingTests:\!MappingTests/PetRadialBasisFunctionMapping:\!MappingTests/GinkgoRadialBasisFunctionSolver"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_NORMAL}
-  )
-add_precice_test(
-  NAME mapping.petrbf
-  ARGUMENTS "--run_test=MappingTests/PetRadialBasisFunctionMapping"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-  LABELS petsc
-  PETSC
-  )
-add_precice_test(
-  NAME mapping.ginkgo.reference
-  ARGUMENTS "--run_test=MappingTests/GinkgoRadialBasisFunctionSolver/Reference"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  LABELS ginkgo
-  GINKGO
-  )
-add_precice_test(
-  NAME mapping.ginkgo.openmp
-  ARGUMENTS "--run_test=MappingTests/GinkgoRadialBasisFunctionSolver/OpenMP"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-  LABELS ginkgo
-  GINKGO_OMP
-  )
-add_precice_test(
-  NAME mapping.ginkgo.cuda
-  ARGUMENTS "--run_test=MappingTests/GinkgoRadialBasisFunctionSolver/Cuda"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  LABELS ginkgo
-  GINKGO_CUDA
-  )
-add_precice_test(
-  NAME mapping.ginkgo.cuSolver
-  ARGUMENTS "--run_test=MappingTests/GinkgoRadialBasisFunctionSolver/cuSolver"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  LABELS ginkgo
-  GINKGO_CUDA
-  )
-add_precice_test(
-  NAME mapping.ginkgo.hip
-  ARGUMENTS "--run_test=MappingTests/GinkgoRadialBasisFunctionSolver/Hip"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  LABELS ginkgo
-  GINKGO_HIP
-  )
-add_precice_test(
-  NAME mapping.ginkgo.hipSolver
-  ARGUMENTS "--run_test=MappingTests/GinkgoRadialBasisFunctionSolver/hipSolver"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  LABELS ginkgo
-  GINKGO_HIP
-  )
-add_precice_test(
-  NAME math
-  ARGUMENTS "--run_test=MathTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME mesh
-  ARGUMENTS "--run_test=MeshTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME partition
-  ARGUMENTS "--run_test=PartitionTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME interface
-  ARGUMENTS "--run_test=PreciceTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME query
-  ARGUMENTS "--run_test=QueryTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME testing
-  ARGUMENTS "--run_test=TestingTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME time
-  ARGUMENTS "--run_test=TimeTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME utils
-  ARGUMENTS "--run_test=UtilsTests"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-add_precice_test(
-  NAME xml
-  ARGUMENTS "--run_test=XML"
-  TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
-  )
-
-# Register integration tests from tests/
-# These are defined in tests/tests.cmake
-foreach(testsuite IN LISTS PRECICE_TEST_SUITES)
-  add_precice_test(
-    NAME "integration.${testsuite}"
-    ARGUMENTS "--run_test=Integration/${testsuite}"
-    TIMEOUT ${PRECICE_TEST_TIMEOUT_LONG}
-    )
-endforeach()
+# Add solverdummy tests
 
 add_precice_test_build_solverdummy(cpp)
 add_precice_test_build_solverdummy(c)

--- a/cmake/discover_tests.cmake
+++ b/cmake/discover_tests.cmake
@@ -1,0 +1,134 @@
+macro(start_file)
+  set(script "")
+endmacro()
+
+function(add_command NAME TEST_NAME)
+  set(args "")
+  foreach(arg ${ARGN})
+    if(arg MATCHES "[^-./:a-zA-Z0-9_]")
+      string(APPEND args " [==[${arg}]==]")
+    else()
+      string(APPEND args " ${arg}")
+    endif()
+  endforeach()
+  string(APPEND script "${NAME}(${TEST_NAME} ${args})\n")
+  set(script "${script}" PARENT_SCOPE)
+endfunction()
+
+function(add_test NAME)
+  if(NAME MATCHES "MPIPorts|MPISinglePorts" AND (PRECICE_MPI_VERSION MATCHES "Open MPI|Intel"))
+    # Test is unsupported by this MPI implementation
+    return()
+  endif()
+
+  string(REGEX REPLACE "[/<>]" "_" test_dir "${NAME}")
+  set(test_dir "${TEST_DIR}/${test_dir}")
+
+  if (NOT EXISTS test_dir)
+    FILE(MAKE_DIRECTORY ${test_dir})
+  endif()
+
+  # Get Labels for general test grouping
+  if(NAME MATCHES "^([^/]*)/.*$")
+    string(REPLACE "Tests" "" _label "${CMAKE_MATCH_1}")
+    list(APPEND labels "${_label}")
+    unset(_label)
+  endif()
+  # Label common keywords
+  foreach(kw Ginkgo Sockets MPIPorts MPISinglePorts MPI Remeshing)
+    if(NAME MATCHES ${kw})
+      list(APPEND labels ${kw})
+    endif()
+  endforeach()
+  # Transform into digestable labels list (every test should be labeled)
+  if(labels)
+    string(TOLOWER "${labels}" labels)
+    list(JOIN labels "\;" labels)
+  endif()
+
+  # --map-by=:OVERSUBSCRIBE works for OpenMPI(4+5) and MPICH, but not for Intel which doesn't need a flag
+  set(_oversubscribe_FLAG "--map-by;:OVERSUBSCRIBE")
+  if(PRECICE_MPI_VERSION MATCHES "Intel")
+    set(_oversubscribe_FLAG "")
+  endif()
+
+  add_command(add_test
+    "[=[precice.${NAME}]=]"
+    ${MPIEXEC_EXECUTABLE}
+    ${MPIEXEC_NUMPROC_FLAG}
+    4
+    ${_oversubscribe_FLAG}
+    ${PRECICE_CTEST_MPI_FLAGS}
+    ${MPIEXEC_PREFLAGS}
+    ${_TEST_EXECUTABLE} "--run_test=${NAME}" "--log_level=message"
+    ${MPIEXEC_POSTFLAGS}
+  )
+  add_command(set_tests_properties
+    "[=[precice.${NAME}]=]"
+    PROPERTIES
+    ENVIRONMENT "OMP_NUM_THREADS=2"
+    TIMEOUT "30"
+    WORKING_DIRECTORY "${test_dir}"
+    LABELS "${labels}"
+ )
+
+ set(script "${script}" PARENT_SCOPE)
+endfunction()
+
+macro(flush_file)
+  file(WRITE "${_TEST_FILE}" "${script}")
+  set(flush_tests_MODE APPEND PARENT_SCOPE)
+  unset(script)
+endmacro()
+
+
+function(discover_tests)
+  cmake_parse_arguments(
+    PARSE_ARGV
+    0
+    ""
+    ""
+    "TEST_EXECUTABLE;TEST_DIR;TEST_FILE"
+    ""
+  )
+
+  execute_process(
+    COMMAND "${_TEST_EXECUTABLE}" --list_units
+    WORKING_DIRECTORY "${_TEST_DIR}"
+    TIMEOUT 4
+    OUTPUT_VARIABLE output
+    RESULT_VARIABLE result
+  )
+
+  if(NOT ${result} EQUAL 0)
+    string(REPLACE "\n" "\n    " output "${output}")
+    message(FATAL_ERROR
+      "Error running test executable.\n"
+      "  Path: '${_TEST_EXECUTABLE}'\n"
+      "  Working directory: '${_TEST_DIR}'\n"
+      "  Result: ${result}\n"
+      "  Output:\n"
+      "    ${output}\n"
+    )
+  endif()
+
+  # Turn into a CMake list
+  string(REPLACE "\n" ";" output "${output}")
+
+  start_file()
+  foreach(test IN LISTS output)
+    if (NOT test STREQUAL "")
+      add_test("${test}")
+    endif()
+  endforeach()
+  flush_file()
+endfunction()
+
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  discover_tests(
+    TEST_EXECUTABLE "${TEST_EXECUTABLE}"
+    TEST_DIR "${TEST_DIR}"
+    TEST_FILE "${TEST_FILE}"
+  )
+endif()

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -406,6 +406,3 @@ target_sources(testprecice
     tests/serial/whitebox/TestConfigurationPeano.cpp
     tests/serial/whitebox/TestExplicitWithDataScaling.cpp
     )
-
-# Contains the list of integration test suites
-set(PRECICE_TEST_SUITES GeometricMultiscale Parallel QuasiNewton Remeshing Serial)

--- a/tools/building/updateSourceFiles.py
+++ b/tools/building/updateSourceFiles.py
@@ -100,10 +100,6 @@ def itest_path_to_suite(path):
     return "".join(parts)
 
 
-def test_suites_from_files(itests):
-    return sorted(set(map(itest_path_to_suite, itests)))
-
-
 SOURCES_BASE = """#
 # This file lists all sources that will be compiles into the precice library
 #
@@ -136,9 +132,6 @@ target_sources(testprecice
     PRIVATE
     {}
     )
-
-# Contains the list of integration test suites
-set(PRECICE_TEST_SUITES {})
 """
 
 
@@ -151,9 +144,7 @@ def generate_unit_tests(utests):
 
 
 def generate_integration_tests(itests):
-    return ITESTS_BASE.format(
-        "\n    ".join(itests), " ".join(test_suites_from_files(itests))
-    )
+    return ITESTS_BASE.format("\n    ".join(itests))
 
 
 def main():


### PR DESCRIPTION
## Main changes of this PR

This PR adds automatic test registration to CMake and CTest.

After building `testprecice`, CMake will generate a file containing all registered tests, based on `./testprecice --list_units`.

This opens the door for running tests in parallel using `ctest -j`, rerunning failed test using `ctest --rerun-failed`, rerunning n times, filtering by label/regex and more.

## Motivation and additional information

Note that this is more expensive the bundled method before, as calling `MPI_Init` is an expensive operation.

The tests now log everything by default, which makes `--output-on-failure` finally useful.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
