### PR TITLE
Add additional fundamental events

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -120,7 +120,7 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
   PRECICE_ASSERT(m2n.get() != nullptr);
   PRECICE_ASSERT(m2n->isConnected());
 
-  profiling::Event e("sendData", profiling::Fundamental);
+  profiling::Event e("waitAndSendData", profiling::Fundamental);
 
   for (const auto &data : sendData | boost::adaptors::map_values) {
     const auto &stamples = data->stamples();
@@ -180,7 +180,7 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
   PRECICE_TRACE();
   PRECICE_ASSERT(m2n.get());
   PRECICE_ASSERT(m2n->isConnected());
-  profiling::Event e("receiveData", profiling::Fundamental);
+  profiling::Event e("waitAndReceiveData", profiling::Fundamental);
   for (const auto &data : receiveData | boost::adaptors::map_values) {
 
     if (data->exchangeSubsteps()) {

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -216,7 +216,8 @@ void M2N::send(
     PRECICE_ASSERT(_distComs[meshID].get() != nullptr);
 
     if (precice::syncMode && not utils::IntraComm::isSecondary()) {
-      bool ack = true;
+      Event es("mn2.sendData.interSync");
+      bool  ack = true;
       _interComm->send(ack, 0);
       _interComm->receive(ack, 0);
       _interComm->send(ack, 0);
@@ -302,14 +303,12 @@ void M2N::receive(precice::span<double> itemsToReceive,
     PRECICE_ASSERT(_distComs.find(meshID) != _distComs.end());
     PRECICE_ASSERT(_distComs[meshID].get() != nullptr);
 
-    if (precice::syncMode) {
-      if (not utils::IntraComm::isSecondary()) {
-        bool ack;
-
-        _interComm->receive(ack, 0);
-        _interComm->send(ack, 0);
-        _interComm->receive(ack, 0);
-      }
+    if (precice::syncMode && not utils::IntraComm::isSecondary()) {
+      Event es("m2n.receiveData.interSync");
+      bool  ack;
+      _interComm->receive(ack, 0);
+      _interComm->send(ack, 0);
+      _interComm->receive(ack, 0);
     }
 
     Event e("m2n.receiveData", profiling::Synchronize);

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1451,6 +1451,10 @@ void ParticipantImpl::computeMappings(std::vector<MappingContext> &contexts, con
 void ParticipantImpl::mapInitialWrittenData()
 {
   PRECICE_TRACE();
+  if (!_accessor->hasWriteMappings()) {
+    return;
+  }
+
   computeMappings(_accessor->writeMappingContexts(), "write");
   for (auto &context : _accessor->writeDataContexts()) {
     if (context.hasMapping()) {
@@ -1463,6 +1467,10 @@ void ParticipantImpl::mapInitialWrittenData()
 void ParticipantImpl::mapWrittenData(std::optional<double> after)
 {
   PRECICE_TRACE();
+  if (!_accessor->hasWriteMappings()) {
+    return;
+  }
+
   computeMappings(_accessor->writeMappingContexts(), "write");
   for (auto &context : _accessor->writeDataContexts()) {
     if (context.hasMapping()) {
@@ -1492,6 +1500,10 @@ void ParticipantImpl::trimReadMappedData(double startOfTimeWindow, bool isTimeWi
 void ParticipantImpl::mapInitialReadData()
 {
   PRECICE_TRACE();
+  if (!_accessor->hasReadMappings()) {
+    return;
+  }
+
   computeMappings(_accessor->readMappingContexts(), "read");
   for (auto &context : _accessor->readDataContexts()) {
     if (context.hasMapping()) {
@@ -1505,6 +1517,10 @@ void ParticipantImpl::mapInitialReadData()
 void ParticipantImpl::mapReadData()
 {
   PRECICE_TRACE();
+  if (!_accessor->hasReadMappings()) {
+    return;
+  }
+
   computeMappings(_accessor->readMappingContexts(), "read");
   for (auto &context : _accessor->readDataContexts()) {
     if (context.hasMapping()) {

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -289,6 +289,16 @@ bool ParticipantState::isDirectAccessAllowed(std::string_view mesh) const
 
 // Other queries
 
+bool ParticipantState::hasReadMappings() const
+{
+  return !_readMappingContexts.empty();
+}
+
+bool ParticipantState::hasWriteMappings() const
+{
+  return !_writeMappingContexts.empty();
+}
+
 std::vector<MappingContext> &ParticipantState::readMappingContexts()
 {
   return _readMappingContexts;

--- a/src/precice/impl/ParticipantState.hpp
+++ b/src/precice/impl/ParticipantState.hpp
@@ -282,6 +282,12 @@ public:
   /// Returns true, if the participant uses a primary tag.
   bool useIntraComm() const;
 
+  /// Returns true, if the participant has at least one read mapping
+  bool hasReadMappings() const;
+
+  /// Returns true, if the participant has at least one write mapping
+  bool hasWriteMappings() const;
+
   /// Provided access to all read \ref MappingContext
   std::vector<MappingContext> &readMappingContexts();
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds additional fundamental events which segment initialize, construction, and advance into comprehensible subsections.

## Example elastic-tube-1d

Total size of `precice-profiling` directories for 864 time steps is 6.5MB 
[Example profiling.json](https://github.com/user-attachments/files/17559414/profiling.json)


sunburst plots #2116 of fundamentals:

![newplot(6)](https://github.com/user-attachments/assets/d8fb3699-491c-4ada-b73e-3bb0361896ee)

![newplot(5)](https://github.com/user-attachments/assets/e104f2bd-300b-439c-9c21-ac89159b6b77)

All profiling events with #2117 
```
Reading events file profiling.json
Output timing are in us.
name                                                               │        sum    count               mean        min        max
───────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────
total                                                              │ 11701207.0        1         11701207.0 11701207.0 11701207.0
  advance                                                          │ 10101600.0      864 11691.666666666666     1796.0    17383.0
    advanceCoupling                                                │  9913933.0      864  11474.45949074074     1602.0    17165.0
      accelerate                                                   │  8529308.0      864   9871.88425925926       74.0    15346.0
        cpl.computeQuasiNewtonUpdate                               │  8374178.0      764 10960.965968586388       53.0    15324.0
          ApplyFilter                                              │  7199436.0      763  9435.695937090433       78.0    13358.0
      receiveData                                                  │  1158721.0      863 1342.6662804171494      933.0     3415.0
        m2n.receiveData                                            │  1146755.0      863  1328.800695249131      916.0     3389.0
      sendConvergence                                              │    24252.0      864 28.069444444444443       24.0       53.0
      sendData                                                     │    40447.0      864 46.813657407407405       33.0      151.0
        m2n.sendData                                               │    31846.0      864   36.8587962962963       29.0       87.0
    mapReadData                                                    │    75939.0      864  87.89236111111111       32.0      142.0
      map.nn.mapData.FromFluid-Nodes-MeshToSolid-Nodes-Mesh        │    20291.0      863 23.512166859791424       20.0       38.0
    mapWriteData                                                   │     5738.0      864  6.641203703703703        5.0       16.0
  construction                                                     │  1288560.0        1          1288560.0  1288560.0  1288560.0
    com.initializeMPI                                              │  1276755.0        1          1276755.0  1276755.0  1276755.0
    configure                                                      │    11466.0        1            11466.0    11466.0    11466.0
    startProfilingBackend                                          │      313.0        1              313.0      313.0      313.0
  finalize                                                         │      618.0        1              618.0      618.0      618.0
  initialize                                                       │   187911.0        1           187911.0   187911.0   187911.0
    connectPrimaries                                               │     3187.0        1             3187.0     3187.0     3187.0
      m2n.acceptPrimaryRankConnection.Fluid                        │     3109.0        1             3109.0     3109.0     3109.0
    connectSecondaries                                             │   131019.0        1           131019.0   131019.0   131019.0
      m2n.acceptSecondaryRanksConnection                           │   130844.0        1           130844.0   130844.0   130844.0
        m2n.broadcastVertexDistributions                           │        0.0        2                0.0        0.0        0.0
        m2n.buildCommunicationMap                                  │       31.0        2               15.5       14.0       17.0
        m2n.createCommunications                                   │     2318.0        2             1159.0     1126.0     1192.0
        m2n.exchangeVertexDistribution                             │   128339.0        2            64169.5    41751.0    86588.0
    initalizeCouplingScheme                                        │     8671.0        1             8671.0     8671.0     8671.0
      receiveData                                                  │     8442.0        1             8442.0     8442.0     8442.0
        m2n.receiveData                                            │     8425.0        1             8425.0     8425.0     8425.0
      sendData                                                     │       54.0        1               54.0       54.0       54.0
        m2n.sendData                                               │       48.0        1               48.0       48.0       48.0
    mapInitialReadData                                             │     2088.0        1             2088.0     2088.0     2088.0
      map.nn.computeMapping.FromFluid-Nodes-MeshToSolid-Nodes-Mesh │     1948.0        1             1948.0     1948.0     1948.0
        query.index.getVertexIndexTree.Fluid-Nodes-Mesh            │      104.0        1              104.0      104.0      104.0
      map.nn.mapData.FromFluid-Nodes-MeshToSolid-Nodes-Mesh        │       20.0        1               20.0       20.0       20.0
    mapInitialWriteData                                            │        6.0        1                6.0        6.0        6.0
    preprocess.Solid-Nodes-Mesh                                    │       17.0        1               17.0       17.0       17.0
    repartitioning                                                 │    42807.0        1            42807.0    42807.0    42807.0
      partition.gatherMesh.Solid-Nodes-Mesh                        │      161.0        1              161.0      161.0      161.0
      partition.prepareMesh.Solid-Nodes-Mesh                       │       34.0        1               34.0       34.0       34.0
      partition.receiveGlobalMesh.Fluid-Nodes-Mesh                 │    42100.0        1            42100.0    42100.0    42100.0
      partition.sendGlobalMesh.Solid-Nodes-Mesh                    │       94.0        1               94.0       94.0       94.0
  solver.advance                                                   │   116159.0      865  134.2878612716763       48.0      233.0
  solver.initialize                                                │      169.0        1              169.0      169.0      169.0

```

## Motivation and additional information

It is now possible to determine weather the mapping, acceleration or communication is the bottleneck.

Closes #2114

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
