### PR TITLE
Add error for swapped meshes in mappings

### DIFF
--- a/docs/changelog/2124.md
+++ b/docs/changelog/2124.md
@@ -1,0 +1,2 @@
+- Added descriptive error when meshes are swapped in read/write mappings.
+- Fixed a crash when meshes in a mapping neither received nor provided by a participant.

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -411,7 +411,11 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     auto toMesh   = confMapping.toMesh->getName();
 
     if (confMapping.direction == mapping::MappingConfiguration::Direction::READ) {
-      /// A read mapping maps from received to provided
+      // A read mapping maps from received to provided
+      PRECICE_CHECK(participant->isMeshReceived(fromMesh) || participant->isMeshProvided(toMesh),
+                    "A read mapping of participant \"{}\" needs to map from a received to a provided mesh, but in this case they are swapped. "
+                    "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a write mapping instead?",
+                    participant->getName(), confMapping.fromMesh->getName(), confMapping.toMesh->getName());
       PRECICE_CHECK(participant->isMeshReceived(fromMesh),
                     "Participant \"{}\" has a read mapping from mesh \"{}\", without receiving it. "
                     "Please add a receive-mesh tag with name=\"{}\"",
@@ -422,6 +426,10 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                     participant->getName(), toMesh, toMesh);
     } else {
       // A write mapping maps from provided to received
+      PRECICE_CHECK(participant->isMeshProvided(fromMesh) || participant->isMeshReceived(toMesh),
+                    "A write mapping of participant \"{}\" needs to map from a provided to a received mesh, but in this case they are swapped. "
+                    "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a read mapping instead?",
+                    participant->getName(), confMapping.fromMesh->getName(), confMapping.toMesh->getName());
       PRECICE_CHECK(participant->isMeshProvided(fromMesh),
                     "Participant \"{}\" has a write mapping from mesh \"{}\", without providing it. "
                     "Please add a provided-mesh tag with name=\"{}\"",
@@ -448,26 +456,6 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     const auto &       toMeshID        = confMapping.toMesh->getID();
     impl::MeshContext &fromMeshContext = participant->meshContext(fromMesh);
     impl::MeshContext &toMeshContext   = participant->meshContext(toMesh);
-
-    if (confMapping.direction == mapping::MappingConfiguration::READ) {
-      PRECICE_CHECK(toMeshContext.provideMesh,
-                    "A read mapping of participant \"{}\" needs to map TO a provided mesh. Mesh \"{1}\" is not provided. "
-                    "Please add the tag <provide-mesh name=\"{1}\" /> to the participant.",
-                    participant->getName(), confMapping.toMesh->getName());
-      PRECICE_CHECK(not fromMeshContext.receiveMeshFrom.empty(),
-                    "A read mapping of participant \"{}\" needs to map FROM a received mesh. Mesh \"{1}\" is not received. "
-                    "Please add the tag <receive-mesh name=\"{1}\" /> to the participant.",
-                    participant->getName(), confMapping.toMesh->getName());
-    } else {
-      PRECICE_CHECK(fromMeshContext.provideMesh,
-                    "A write mapping of participant \"{}\" needs to map FROM a provided mesh. Mesh \"{1}\" is not provided. "
-                    "Please add the tag <provide-mesh name=\"{1}\" /> to the participant.",
-                    participant->getName(), confMapping.fromMesh->getName());
-      PRECICE_CHECK(not toMeshContext.receiveMeshFrom.empty(),
-                    "A write mapping of participant \"{}\" needs to map TO a received mesh. Mesh \"{1}\" is not received. "
-                    "Please add the tag <receive-mesh name=\"{1}\" /> to the participant.",
-                    participant->getName(), confMapping.toMesh->getName());
-    }
 
     // @TODO: is this still correct?
     if (confMapping.requiresBasisFunction) {

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -415,7 +415,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
       PRECICE_CHECK(participant->isMeshReceived(fromMesh) || participant->isMeshProvided(toMesh),
                     "A read mapping of participant \"{}\" needs to map from a received to a provided mesh, but in this case they are swapped. "
                     "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a write mapping instead?",
-                    participant->getName(), confMapping.fromMesh->getName(), confMapping.toMesh->getName());
+                    participant->getName(), confMapping.toMesh->getName(), confMapping.fromMesh->getName());
       PRECICE_CHECK(participant->isMeshReceived(fromMesh),
                     "Participant \"{}\" has a read mapping from mesh \"{}\", without receiving it. "
                     "Please add a receive-mesh tag with name=\"{}\"",
@@ -429,7 +429,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
       PRECICE_CHECK(participant->isMeshProvided(fromMesh) || participant->isMeshReceived(toMesh),
                     "A write mapping of participant \"{}\" needs to map from a provided to a received mesh, but in this case they are swapped. "
                     "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a read mapping instead?",
-                    participant->getName(), confMapping.fromMesh->getName(), confMapping.toMesh->getName());
+                    participant->getName(), confMapping.toMesh->getName(), confMapping.fromMesh->getName());
       PRECICE_CHECK(participant->isMeshProvided(fromMesh),
                     "Participant \"{}\" has a write mapping from mesh \"{}\", without providing it. "
                     "Please add a provided-mesh tag with name=\"{}\"",

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -265,19 +265,25 @@ bool ParticipantState::isMeshUsed(std::string_view mesh) const
 
 bool ParticipantState::isMeshProvided(std::string_view mesh) const
 {
-  PRECICE_ASSERT(hasMesh(mesh));
+  if (!hasMesh(mesh)) {
+    return false;
+  }
   return usedMeshContext(mesh).provideMesh;
 }
 
 bool ParticipantState::isMeshReceived(std::string_view mesh) const
 {
-  PRECICE_ASSERT(hasMesh(mesh));
+  if (!hasMesh(mesh)) {
+    return false;
+  }
   return !usedMeshContext(mesh).provideMesh;
 }
 
 bool ParticipantState::isDirectAccessAllowed(std::string_view mesh) const
 {
-  PRECICE_ASSERT(hasMesh(mesh));
+  if (!hasMesh(mesh)) {
+    return false;
+  }
   return meshContext(mesh).allowDirectAccess;
 }
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds an error message when meshes in mappings are swapped, indicating a wrong read/write direction or swapped meshes

## Motivation and additional information

I ran into this issue a few time recently and the current error messages are confusing as they suggest receiving the provided mesh or vice versa.

Example:
```
precice-tools: ERROR: A write mapping of participant "SolverTwo" needs to map from a provided to a received mesh, but in this case they are swapped. Did you intent to map from mesh "SolverOne-Mesh" to mesh "SolverTwo-Mesh", or use a read mapping instead?
```

Closes https://github.com/precice/precice/pull/2128

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
