### PR TITLE
Revert swapped participant and mesh name in export filenames

### DIFF
--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -57,11 +57,11 @@ void ExportCSV::doExport(int index, double time)
   // Construct filename
   std::string filename;
   if (isParallel()) {
-    // Participant-Mesh-r2.it2
-    filename = fmt::format("{}-{}.{}_{}.csv", _participantName, _mesh->getName(), _rank, formatIndex(index));
+    // Mesh-Participant.r2.it2
+    filename = fmt::format("{}-{}.{}_{}.csv", _mesh->getName(), _participantName, _rank, formatIndex(index));
   } else {
-    // Participant-Mesh.it2
-    filename = fmt::format("{}-{}.{}.csv", _participantName, _mesh->getName(), formatIndex(index));
+    // Mesh-Participant.it2
+    filename = fmt::format("{}-{}.{}.csv", _mesh->getName(), _participantName, formatIndex(index));
   }
 
   namespace fs = std::filesystem;

--- a/src/io/ExportVTK.cpp
+++ b/src/io/ExportVTK.cpp
@@ -37,7 +37,7 @@ void ExportVTK::doExport(int index, double time)
   if (!keepExport(index))
     return;
 
-  auto filename = fmt::format("{}-{}.{}.vtk", _participantName, _mesh->getName(), formatIndex(index));
+  auto filename = fmt::format("{}-{}.{}.vtk", _mesh->getName(), _participantName, formatIndex(index));
 
   namespace fs = std::filesystem;
   fs::path outfile(_location);
@@ -61,7 +61,7 @@ void ExportVTK::exportSeries() const
   if (isParallel())
     return; // there is no parallel master file
 
-  writeSeriesFile(fmt::format("{}-{}.vtk.series", _participantName, _mesh->getName()));
+  writeSeriesFile(fmt::format("{}-{}.vtk.series", _mesh->getName(), _participantName));
 }
 
 void ExportVTK::exportMesh(

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -61,7 +61,7 @@ void ExportXML::exportSeries() const
     return;
 
   auto ext = isParallel() ? getParallelExtension() : getPieceExtension();
-  writeSeriesFile(fmt::format("{}-{}.{}.series", _participantName, _mesh->getName(), ext));
+  writeSeriesFile(fmt::format("{}-{}.{}.series", _mesh->getName(), _participantName, ext));
 }
 
 void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
@@ -95,13 +95,13 @@ void ExportXML::processDataNamesAndDimensions(const mesh::Mesh &mesh)
 std::string ExportXML::parallelPieceFilenameFor(int index, int rank) const
 {
   PRECICE_ASSERT(isParallel());
-  return fmt::format("{}-{}.{}_{}.{}", _participantName, _mesh->getName(), formatIndex(index), rank, getPieceExtension());
+  return fmt::format("{}-{}.{}_{}.{}", _mesh->getName(), _participantName, formatIndex(index), rank, getPieceExtension());
 }
 
 std::string ExportXML::serialPieceFilename(int index) const
 {
   PRECICE_ASSERT(!isParallel());
-  return fmt::format("{}-{}.{}.{}", _participantName, _mesh->getName(), formatIndex(index), getPieceExtension());
+  return fmt::format("{}-{}.{}.{}", _mesh->getName(), _participantName, formatIndex(index), getPieceExtension());
 }
 
 void ExportXML::writeParallelFile(int index, double time)
@@ -109,8 +109,8 @@ void ExportXML::writeParallelFile(int index, double time)
   PRECICE_ASSERT(isParallel());
 
   // Construct filename
-  // Participant-Mesh.it_2.pvtu
-  auto filename = fmt::format("{}-{}.{}.{}", _participantName, _mesh->getName(), formatIndex(index), getParallelExtension());
+  // Mesh-Participant.it_2.pvtu
+  auto filename = fmt::format("{}-{}.{}.{}", _mesh->getName(), _participantName, formatIndex(index), getParallelExtension());
   recordExport(filename, time);
 
   namespace fs = std::filesystem;


### PR DESCRIPTION
## Main changes of this PR

This PR reverts the change of exported file names from Participant-Mesh to Mesh-Participant.

## Motivation and additional information

Breaks the systemtests https://github.com/precice/precice/pull/2052#issuecomment-2464145569

@davidscn Shouldn't this have been noticeable in ASTE too?

Another reason for #2060 

Regression introduced in #2053

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
