### PR TITLE
Fix unnecessary empty watchpoint and watchintegral files

### DIFF
--- a/docs/changelog/2126.md
+++ b/docs/changelog/2126.md
@@ -1,0 +1,1 @@
+- Fixed unnecessary creation of empty watchpoint and watchintegral files at non-owning participants.

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -658,38 +658,42 @@ void ParticipantConfiguration::finishParticipantConfiguration(
   _exportConfig->resetExports();
 
   // Create watch points
-  for (const WatchPointConfig &config : _watchPointConfigs) {
-    PRECICE_CHECK(participant->isMeshUsed(config.nameMesh),
-                  "Participant \"{}\" defines watchpoint \"{}\" for mesh \"{}\" which is not provided by the participant. "
-                  "Please add <provide-mesh name=\"{}\" /> to the participant.",
-                  participant->getName(), config.name, config.nameMesh, config.nameMesh);
-    const auto &meshContext = participant->usedMeshContext(config.nameMesh);
-    PRECICE_CHECK(meshContext.provideMesh,
-                  "Participant \"{}\" defines watchpoint \"{}\" for the received mesh \"{}\", which is not allowed. "
-                  "Please move the watchpoint definition to the participant providing mesh \"{}\".",
-                  participant->getName(), config.name, config.nameMesh, config.nameMesh);
-    PRECICE_CHECK(config.coordinates.size() == meshContext.mesh->getDimensions(),
-                  "Provided coordinate to watch is {}D, which does not match the dimension of the {}D mesh \"{}\".",
-                  config.coordinates.size(), meshContext.mesh->getDimensions(), meshContext.mesh->getName());
-    std::string filename = "precice-" + participant->getName() + "-watchpoint-" + config.name + ".log";
-    participant->addWatchPoint(std::make_shared<impl::WatchPoint>(config.coordinates, meshContext.mesh, std::move(filename)));
+  if (context.name == participant->getName()) {
+    for (const WatchPointConfig &config : _watchPointConfigs) {
+      PRECICE_CHECK(participant->isMeshUsed(config.nameMesh),
+                    "Participant \"{}\" defines watchpoint \"{}\" for mesh \"{}\" which is not provided by the participant. "
+                    "Please add <provide-mesh name=\"{}\" /> to the participant.",
+                    participant->getName(), config.name, config.nameMesh, config.nameMesh);
+      const auto &meshContext = participant->usedMeshContext(config.nameMesh);
+      PRECICE_CHECK(meshContext.provideMesh,
+                    "Participant \"{}\" defines watchpoint \"{}\" for the received mesh \"{}\", which is not allowed. "
+                    "Please move the watchpoint definition to the participant providing mesh \"{}\".",
+                    participant->getName(), config.name, config.nameMesh, config.nameMesh);
+      PRECICE_CHECK(config.coordinates.size() == meshContext.mesh->getDimensions(),
+                    "Provided coordinate to watch is {}D, which does not match the dimension of the {}D mesh \"{}\".",
+                    config.coordinates.size(), meshContext.mesh->getDimensions(), meshContext.mesh->getName());
+      std::string filename = "precice-" + participant->getName() + "-watchpoint-" + config.name + ".log";
+      participant->addWatchPoint(std::make_shared<impl::WatchPoint>(config.coordinates, meshContext.mesh, std::move(filename)));
+    }
   }
   _watchPointConfigs.clear();
 
   // Create watch integrals
-  for (const WatchIntegralConfig &config : _watchIntegralConfigs) {
-    PRECICE_CHECK(participant->isMeshUsed(config.nameMesh),
-                  "Participant \"{}\" defines watch integral \"{}\" for mesh \"{}\" which is not used by the participant. "
-                  "Please add a provide-mesh node with name=\"{}\".",
-                  participant->getName(), config.name, config.nameMesh, config.nameMesh);
-    const auto &meshContext = participant->usedMeshContext(config.nameMesh);
-    PRECICE_CHECK(meshContext.provideMesh,
-                  "Participant \"{}\" defines watch integral \"{}\" for the received mesh \"{}\", which is not allowed. "
-                  "Please move the watchpoint definition to the participant providing mesh \"{}\".",
-                  participant->getName(), config.name, config.nameMesh, config.nameMesh);
+  if (context.name == participant->getName()) {
+    for (const WatchIntegralConfig &config : _watchIntegralConfigs) {
+      PRECICE_CHECK(participant->isMeshUsed(config.nameMesh),
+                    "Participant \"{}\" defines watch integral \"{}\" for mesh \"{}\" which is not used by the participant. "
+                    "Please add a provide-mesh node with name=\"{}\".",
+                    participant->getName(), config.name, config.nameMesh, config.nameMesh);
+      const auto &meshContext = participant->usedMeshContext(config.nameMesh);
+      PRECICE_CHECK(meshContext.provideMesh,
+                    "Participant \"{}\" defines watch integral \"{}\" for the received mesh \"{}\", which is not allowed. "
+                    "Please move the watchpoint definition to the participant providing mesh \"{}\".",
+                    participant->getName(), config.name, config.nameMesh, config.nameMesh);
 
-    std::string filename = "precice-" + participant->getName() + "-watchintegral-" + config.name + ".log";
-    participant->addWatchIntegral(std::make_shared<impl::WatchIntegral>(meshContext.mesh, std::move(filename), config.isScalingOn));
+      std::string filename = "precice-" + participant->getName() + "-watchintegral-" + config.name + ".log";
+      participant->addWatchIntegral(std::make_shared<impl::WatchIntegral>(meshContext.mesh, std::move(filename), config.isScalingOn));
+    }
   }
   _watchIntegralConfigs.clear();
 


### PR DESCRIPTION
## Main changes of this PR

Closes #1989 

## Motivation and additional information

A simple, but not clean solution. #982 should make such things much cleaner.
I tested with the Elastic Tube 1D tutorial.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
