### PR TITLE
Expand data in profiling export

### DIFF
--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -472,8 +472,26 @@ class Run:
 
         return {"traceEvents": metaEvents + mainEvents}
 
-    def toExportList(self, unit=None):
+    def allDataFields(self):
+        return list(
+            {
+                dname
+                for rank in self.iterRanks()
+                for e in rank.events
+                if "data" in e
+                for dname in e["data"].keys()
+            }
+        )
+
+    def toExportList(self, unit, dataNames):
         factor = ns_to_unit_factor(unit) * 1e3 if unit else 1
+
+        def makeData(e):
+            if "data" not in e:
+                return tuple("" for dname in dataNames)
+
+            return tuple(e["data"].get(dname, "") for dname in dataNames)
+
         for rank in self.iterRanks():
             for e in rank.events:
                 yield (
@@ -483,8 +501,7 @@ class Run:
                     self.lookupEvent(e["eid"]),
                     e["ts"],
                     e["dur"] * factor,
-                    "" if "data" not in e else str(e["data"]),
-                )
+                ) + makeData(e)
 
     def toDataFrame(self):
         import itertools
@@ -523,6 +540,7 @@ def traceCommand(profilingfile, outfile, rankfilter, limit):
 
 def exportCommand(profilingfile, outfile, unit):
     run = Run(profilingfile)
+    dataFields = run.allDataFields()
     fieldnames = [
         "participant",
         "rank",
@@ -530,13 +548,12 @@ def exportCommand(profilingfile, outfile, unit):
         "event",
         "timestamp",
         "duration",
-        "data",
-    ]
+    ] + dataFields
     print(f"Writing to {outfile}")
     with open(outfile, "w", newline="") as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(fieldnames)
-        writer.writerows(run.toExportList(unit))
+        writer.writerows(run.toExportList(unit, dataFields))
     return 0
 
 


### PR DESCRIPTION
## Main changes of this PR

This PR changed `precice-profiling export` to expand existing data as columns.
If an event doesn't have a data, its value is empty.
In importers of pandas and polars, empty fields will be mapped to NaN, which can be filtered on.

## Motivation and additional information

Related to #2123

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
