### PR TITLE
Add multi coupling initialize test

### DIFF
--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers10.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers10.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include <fstream>
+#include <string>
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MultiCoupling)
+BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers10)
+{
+  PRECICE_TEST("SolverA"_on(1_rank), "SolverB"_on(1_rank), "SolverC"_on(1_rank));
+  const std::string configFile = context.config();
+  multiCouplingThreeSolvers(configFile, context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers10.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers10.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataAB" />
+  <data:scalar name="DataBA" />
+  <data:scalar name="DataBC" />
+  <data:scalar name="DataCB" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+    <use-data name="DataCB" />
+    <use-data name="DataBC" />
+  </mesh>
+
+  <mesh name="MeshB1" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+  </mesh>
+
+  <mesh name="MeshB2" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <participant name="SolverA">
+    <provide-mesh name="MeshA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <write-data name="DataAB" mesh="MeshA" />
+    <read-data name="DataBA" mesh="MeshA" />
+  </participant>
+
+  <participant name="SolverB">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <provide-mesh name="MeshB1" />
+    <provide-mesh name="MeshB2" />
+    <write-data name="DataBA" mesh="MeshB1" />
+    <write-data name="DataBC" mesh="MeshB2" />
+    <read-data name="DataAB" mesh="MeshB1" />
+    <read-data name="DataCB" mesh="MeshB2" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB1" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB1" to="MeshA" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshB2" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB2" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <participant name="SolverC">
+    <provide-mesh name="MeshC" />
+    <write-data name="DataCB" mesh="MeshC" />
+    <read-data name="DataBC" mesh="MeshC" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
+
+  <coupling-scheme:multi>
+    <participant name="SolverA" control="yes" />
+    <participant name="SolverB" />
+    <participant name="SolverC" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <max-iterations value="2" />
+    <!-- Check that we can initialize data to different participants -->
+    <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" initialize="yes" />
+    <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverB" initialize="no" />
+    <exchange data="DataBC" mesh="MeshC" from="SolverB" to="SolverC" initialize="yes" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" initialize="no" />
+    <relative-convergence-measure data="DataCB" mesh="MeshC" limit="1e-4" />
+    <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers7.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers7.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include <fstream>
+#include <string>
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MultiCoupling)
+BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers7)
+{
+  PRECICE_TEST("SolverA"_on(1_rank), "SolverB"_on(1_rank), "SolverC"_on(1_rank));
+  const std::string configFile = context.config();
+  multiCouplingThreeSolvers(configFile, context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers7.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers7.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataAB" />
+  <data:scalar name="DataBA" />
+  <data:scalar name="DataBC" />
+  <data:scalar name="DataCB" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+    <use-data name="DataCB" />
+    <use-data name="DataBC" />
+  </mesh>
+
+  <mesh name="MeshB1" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+  </mesh>
+
+  <mesh name="MeshB2" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <participant name="SolverA">
+    <provide-mesh name="MeshA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <write-data name="DataAB" mesh="MeshA" />
+    <read-data name="DataBA" mesh="MeshA" />
+  </participant>
+
+  <participant name="SolverB">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <provide-mesh name="MeshB1" />
+    <provide-mesh name="MeshB2" />
+    <write-data name="DataBA" mesh="MeshB1" />
+    <write-data name="DataBC" mesh="MeshB2" />
+    <read-data name="DataAB" mesh="MeshB1" />
+    <read-data name="DataCB" mesh="MeshB2" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB1" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB1" to="MeshA" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshB2" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB2" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <participant name="SolverC">
+    <provide-mesh name="MeshC" />
+    <write-data name="DataCB" mesh="MeshC" />
+    <read-data name="DataBC" mesh="MeshC" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
+
+  <coupling-scheme:multi>
+    <participant name="SolverA" control="yes" />
+    <participant name="SolverB" />
+    <participant name="SolverC" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <max-iterations value="2" />
+    <!-- Check that we can initialize all data received by the controller -->
+    <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" initialize="yes" />
+    <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverB" initialize="yes" />
+    <exchange data="DataBC" mesh="MeshC" from="SolverB" to="SolverC" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" initialize="yes" />
+    <relative-convergence-measure data="DataCB" mesh="MeshC" limit="1e-4" />
+    <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers8.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers8.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include <fstream>
+#include <string>
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MultiCoupling)
+BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers8)
+{
+  PRECICE_TEST("SolverA"_on(1_rank), "SolverB"_on(1_rank), "SolverC"_on(1_rank));
+  const std::string configFile = context.config();
+  multiCouplingThreeSolvers(configFile, context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers8.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers8.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataAB" />
+  <data:scalar name="DataBA" />
+  <data:scalar name="DataBC" />
+  <data:scalar name="DataCB" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+    <use-data name="DataCB" />
+    <use-data name="DataBC" />
+  </mesh>
+
+  <mesh name="MeshB1" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+  </mesh>
+
+  <mesh name="MeshB2" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <participant name="SolverA">
+    <provide-mesh name="MeshA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <write-data name="DataAB" mesh="MeshA" />
+    <read-data name="DataBA" mesh="MeshA" />
+  </participant>
+
+  <participant name="SolverB">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <provide-mesh name="MeshB1" />
+    <provide-mesh name="MeshB2" />
+    <write-data name="DataBA" mesh="MeshB1" />
+    <write-data name="DataBC" mesh="MeshB2" />
+    <read-data name="DataAB" mesh="MeshB1" />
+    <read-data name="DataCB" mesh="MeshB2" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB1" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB1" to="MeshA" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshB2" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB2" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <participant name="SolverC">
+    <provide-mesh name="MeshC" />
+    <write-data name="DataCB" mesh="MeshC" />
+    <read-data name="DataBC" mesh="MeshC" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
+
+  <coupling-scheme:multi>
+    <participant name="SolverA" control="yes" />
+    <participant name="SolverB" />
+    <participant name="SolverC" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <max-iterations value="2" />
+    <!-- Check that we can initialize only data received by the controller -->
+    <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" initialize="yes" />
+    <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverB" initialize="no" />
+    <exchange data="DataBC" mesh="MeshC" from="SolverB" to="SolverC" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" initialize="no" />
+    <relative-convergence-measure data="DataCB" mesh="MeshC" limit="1e-4" />
+    <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers9.cpp
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers9.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include <fstream>
+#include <string>
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(MultiCoupling)
+BOOST_AUTO_TEST_CASE(MultiCouplingThreeSolvers9)
+{
+  PRECICE_TEST("SolverA"_on(1_rank), "SolverB"_on(1_rank), "SolverC"_on(1_rank));
+  const std::string configFile = context.config();
+  multiCouplingThreeSolvers(configFile, context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // MultiCoupling
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers9.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers9.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataAB" />
+  <data:scalar name="DataBA" />
+  <data:scalar name="DataBC" />
+  <data:scalar name="DataCB" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+    <use-data name="DataCB" />
+    <use-data name="DataBC" />
+  </mesh>
+
+  <mesh name="MeshB1" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+  </mesh>
+
+  <mesh name="MeshB2" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataBC" />
+    <use-data name="DataCB" />
+  </mesh>
+
+  <participant name="SolverA">
+    <provide-mesh name="MeshA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <write-data name="DataAB" mesh="MeshA" />
+    <read-data name="DataBA" mesh="MeshA" />
+  </participant>
+
+  <participant name="SolverB">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <receive-mesh name="MeshC" from="SolverC" />
+    <provide-mesh name="MeshB1" />
+    <provide-mesh name="MeshB2" />
+    <write-data name="DataBA" mesh="MeshB1" />
+    <write-data name="DataBC" mesh="MeshB2" />
+    <read-data name="DataAB" mesh="MeshB1" />
+    <read-data name="DataCB" mesh="MeshB2" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB1" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB1" to="MeshA" constraint="consistent" />
+    <mapping:nearest-neighbor direction="read" from="MeshC" to="MeshB2" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB2" to="MeshC" constraint="consistent" />
+  </participant>
+
+  <participant name="SolverC">
+    <provide-mesh name="MeshC" />
+    <write-data name="DataCB" mesh="MeshC" />
+    <read-data name="DataBC" mesh="MeshC" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverC" connector="SolverA" />
+  <m2n:sockets acceptor="SolverB" connector="SolverC" />
+
+  <coupling-scheme:multi>
+    <participant name="SolverA" control="yes" />
+    <participant name="SolverB" />
+    <participant name="SolverC" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <max-iterations value="2" />
+    <!-- Check that we can initialize data send by C -->
+    <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" initialize="no" />
+    <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverB" initialize="yes" />
+    <exchange data="DataBC" mesh="MeshC" from="SolverB" to="SolverC" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" initialize="yes" />
+    <relative-convergence-measure data="DataCB" mesh="MeshC" limit="1e-4" />
+    <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -325,11 +325,15 @@ target_sources(testprecice
     tests/serial/multi-coupling/MultiCouplingFourSolvers1.cpp
     tests/serial/multi-coupling/MultiCouplingFourSolvers2.cpp
     tests/serial/multi-coupling/MultiCouplingThreeSolvers1.cpp
+    tests/serial/multi-coupling/MultiCouplingThreeSolvers10.cpp
     tests/serial/multi-coupling/MultiCouplingThreeSolvers2.cpp
     tests/serial/multi-coupling/MultiCouplingThreeSolvers3.cpp
     tests/serial/multi-coupling/MultiCouplingThreeSolvers4.cpp
     tests/serial/multi-coupling/MultiCouplingThreeSolvers5.cpp
     tests/serial/multi-coupling/MultiCouplingThreeSolvers6.cpp
+    tests/serial/multi-coupling/MultiCouplingThreeSolvers7.cpp
+    tests/serial/multi-coupling/MultiCouplingThreeSolvers8.cpp
+    tests/serial/multi-coupling/MultiCouplingThreeSolvers9.cpp
     tests/serial/multi-coupling/MultiCouplingTwoSolvers1.cpp
     tests/serial/multi-coupling/MultiCouplingTwoSolvers2.cpp
     tests/serial/multi-coupling/helpers.cpp


### PR DESCRIPTION
## Main changes of this PR


## Motivation and additional information
This PR provides a test for this [issue](https://github.com/precice/precice/issues/1512) and is the follow up of  https://github.com/precice/precice/pull/2133. The test does not pass: when having 3 participants in a multi-coupling scheme  we are not able to initialize only data send to the controller!  

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
