### PR TITLE
Remove unused conv log switch

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -713,7 +713,7 @@ bool BaseCouplingScheme::measureConvergence()
     PRECICE_ASSERT(convMeasure.couplingData->previousIteration().size() == convMeasure.couplingData->values().size(), convMeasure.couplingData->previousIteration().size(), convMeasure.couplingData->values().size(), convMeasure.couplingData->getDataName());
     convMeasure.measure->measure(convMeasure.couplingData->previousIteration(), convMeasure.couplingData->values());
 
-    if (not utils::IntraComm::isSecondary() && convMeasure.doesLogging) {
+    if (not utils::IntraComm::isSecondary()) {
       _convergenceWriter->writeData(convMeasure.logHeader(), convMeasure.measure->getNormResidual());
     }
 
@@ -768,10 +768,7 @@ void BaseCouplingScheme::initializeTXTWriters()
 
     if (not doesFirstStep()) {
       for (ConvergenceMeasureContext &convMeasure : _convergenceMeasures) {
-
-        if (convMeasure.doesLogging) {
-          _convergenceWriter->addData(convMeasure.logHeader(), io::TXTTableWriter::DOUBLE);
-        }
+        _convergenceWriter->addData(convMeasure.logHeader(), io::TXTTableWriter::DOUBLE);
       }
       if (_acceleration) {
         _iterationsWriter->addData("QNColumns", io::TXTTableWriter::INT);

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -486,7 +486,6 @@ private:
     bool                        suffices;
     bool                        strict;
     impl::PtrConvergenceMeasure measure;
-    bool                        doesLogging;
 
     std::string logHeader() const
     {


### PR DESCRIPTION
## Main changes of this PR

This PR removes an unused configuration to disable the output of convergence measures.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
