### PR TITLE
Set default restart method for IMVJ

### DIFF
--- a/docs/changelog/2136.md
+++ b/docs/changelog/2136.md
@@ -1,0 +1,1 @@
+- Changed the default mode for IMVJ from no-restart to SVD-restart.

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -200,7 +200,7 @@ void AccelerationConfiguration::xmlTagCallback(
     _config.preconditionerType                 = callingTag.getStringAttributeValue(ATTR_TYPE);
     _config.precond_nbNonConstTWindows         = callingTag.getIntAttributeValue(ATTR_PRECOND_NONCONST_TIME_WINDOWS);
   } else if (callingTag.getName() == TAG_IMVJRESTART) {
-
+    _userDefinitions.defineRestartType = true;
 #ifndef PRECICE_NO_MPI
     _config.imvjChunkSize = callingTag.getIntAttributeValue(ATTR_IMVJCHUNKSIZE);
     const auto &f         = callingTag.getStringAttributeValue(ATTR_TYPE);
@@ -288,7 +288,11 @@ void AccelerationConfiguration::xmlEndTagCallback(
       _config.timeWindowsReused = (_userDefinitions.definedTimeWindowsReused) ? _config.timeWindowsReused : _defaultValuesIQNIMVJ.timeWindowsReused;
       _config.filter            = (_userDefinitions.definedFilter) ? _config.filter : _defaultValuesIQNILS.filter;
       _config.singularityLimit  = (_userDefinitions.definedFilter) ? _config.singularityLimit : _defaultValuesIQNILS.singularityLimit;
-      _acceleration             = PtrAcceleration(
+      if (!_config.alwaysBuildJacobian) {
+        _config.imvjRestartType = (_userDefinitions.defineRestartType) ? _config.imvjRestartType : _defaultValuesIQNIMVJ.imvjRestartType;
+        _config.imvjChunkSize   = (_userDefinitions.defineRestartType) ? _config.imvjChunkSize : _defaultValuesIQNIMVJ.imvjChunkSize;
+      }
+      _acceleration = PtrAcceleration(
           new IQNIMVJAcceleration(
               _config.relaxationFactor,
               _config.forceInitialRelaxation,
@@ -486,11 +490,11 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     tagIMVJRESTART.addAttribute(attrRestartName);
     tagIMVJRESTART.setDocumentation("Type of IMVJ restart mode that is used:\n"
                                     "- `no-restart`: IMVJ runs in normal mode with explicit representation of Jacobian\n"
-                                    "- `RS-ZERO`:    IMVJ runs in restart mode. After M time windows all Jacobain information is dropped, restart with no information\n"
+                                    "- `RS-0`:    IMVJ runs in restart mode. After M time windows all Jacobain information is dropped, restart with no information\n"
                                     "- `RS-LS`:      IMVJ runs in restart mode. After M time windows a IQN-LS like approximation for the initial guess of the Jacobian is computed.\n"
                                     "- `RS-SVD`:     IMVJ runs in restart mode. After M time windows a truncated SVD of the Jacobian is updated.\n"
                                     "- `RS-SLIDE`:   IMVJ runs in sliding window restart mode.\n"
-                                    "If this tag is not provided, IMVJ runs in normal mode with explicit representation of Jacobian.");
+                                    "If this tag is not provided, IMVJ runs in restart mode with SVD-method.");
     auto attrChunkSize = makeXMLAttribute(ATTR_IMVJCHUNKSIZE, 8)
                              .setDocumentation("Specifies the number of time windows M after which the IMVJ restarts, if run in restart-mode. Default value is M=8.");
     auto attrReusedTimeWindowsAtRestart = makeXMLAttribute(ATTR_RSLS_REUSED_TIME_WINDOWS, 8)

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -136,6 +136,8 @@ private:
     double      singularityLimit           = 1e-2;
     std::string preconditionerType         = "residual-sum";
     int         precond_nbNonConstTWindows = -1;
+    int         imvjRestartType            = 3;
+    int         imvjChunkSize              = 8;
   } _defaultValuesIQNIMVJ;
 
   const double _defaultAitkenRelaxationFactor = 0.5;
@@ -146,6 +148,7 @@ private:
     bool definedTimeWindowsReused  = false;
     bool definedFilter             = false;
     bool definedPreconditionerType = false;
+    bool defineRestartType         = false;
   } _userDefinitions;
 
   void addTypeSpecificSubtags(xml::XMLTag &tag);


### PR DESCRIPTION
## Main changes of this PR
Set default restart method for IMVJ, when no explicit request for building Jacobian or explicit restart mode is given.

## Motivation and additional information
Close #1064.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.-> manually checked
~~* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).~~
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
