### PR TITLE
Configure preconditioner for IMVJ separately

### DIFF
--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -305,7 +305,7 @@ void AccelerationConfiguration::xmlEndTagCallback(
       // create preconditioner
       // if imvj restart-mode is of type RS-SVD, max number of non-const preconditioned time windows is limited by the chunksize
       // it is separated from the other acceleration methods, since SVD-restart might be chosen as default here
-      if (_config.imvjRestartType == 3)
+      if (_config.imvjRestartType == IQNIMVJAcceleration::RS_SVD)
         if (_config.precond_nbNonConstTWindows > _config.imvjChunkSize)
           _config.precond_nbNonConstTWindows = _config.imvjChunkSize;
       if (_config.preconditionerType == VALUE_CONSTANT_PRECONDITIONER) {

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -249,12 +249,7 @@ void AccelerationConfiguration::xmlEndTagCallback(
   if (callingTag.getNamespace() == TAG) {
 
     //create preconditioner
-    if (callingTag.getName() == VALUE_IQNILS || callingTag.getName() == VALUE_IQNIMVJ || callingTag.getName() == VALUE_AITKEN) {
-
-      // if imvj restart-mode is of type RS-SVD, max number of non-const preconditioned time windows is limited by the chunksize
-      if (callingTag.getName() == VALUE_IQNIMVJ && _config.imvjRestartType > 0)
-        if (_config.precond_nbNonConstTWindows > _config.imvjChunkSize)
-          _config.precond_nbNonConstTWindows = _config.imvjChunkSize;
+    if (callingTag.getName() == VALUE_IQNILS || callingTag.getName() == VALUE_AITKEN) {
       if (_config.preconditionerType == VALUE_CONSTANT_PRECONDITIONER) {
         _preconditioner = PtrPreconditioner(new ConstantPreconditioner(_config.scalingFactorsInOrder()));
       } else if (_config.preconditionerType == VALUE_VALUE_PRECONDITIONER) {
@@ -306,6 +301,26 @@ void AccelerationConfiguration::xmlEndTagCallback(
         _config.imvjRestartType = (_userDefinitions.defineRestartType) ? _config.imvjRestartType : _defaultValuesIQNIMVJ.imvjRestartType;
         _config.imvjChunkSize   = (_userDefinitions.defineRestartType) ? _config.imvjChunkSize : _defaultValuesIQNIMVJ.imvjChunkSize;
       }
+
+      // create preconditioner
+      // if imvj restart-mode is of type RS-SVD, max number of non-const preconditioned time windows is limited by the chunksize
+      // it is separated from the other acceleration methods, since SVD-restart might be chosen as default here
+      if (_config.imvjRestartType == 3)
+        if (_config.precond_nbNonConstTWindows > _config.imvjChunkSize)
+          _config.precond_nbNonConstTWindows = _config.imvjChunkSize;
+      if (_config.preconditionerType == VALUE_CONSTANT_PRECONDITIONER) {
+        _preconditioner = PtrPreconditioner(new ConstantPreconditioner(_config.scalingFactorsInOrder()));
+      } else if (_config.preconditionerType == VALUE_VALUE_PRECONDITIONER) {
+        _preconditioner = PtrPreconditioner(new ValuePreconditioner(_config.precond_nbNonConstTWindows));
+      } else if (_config.preconditionerType == VALUE_RESIDUAL_PRECONDITIONER) {
+        _preconditioner = PtrPreconditioner(new ResidualPreconditioner(_config.precond_nbNonConstTWindows));
+      } else if (_config.preconditionerType == VALUE_RESIDUAL_SUM_PRECONDITIONER) {
+        _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_config.precond_nbNonConstTWindows));
+      } else {
+        // no preconditioner defined
+        _preconditioner = PtrPreconditioner(new ResidualSumPreconditioner(_defaultValuesIQNILS.precond_nbNonConstTWindows));
+      }
+
       _acceleration = PtrAcceleration(
           new IQNIMVJAcceleration(
               _config.relaxationFactor,


### PR DESCRIPTION
## Main changes of this PR
Separate the preconditioner creation after (possibly) applying the default restart method

## Motivation and additional information
After setting the SVD-restart to default in IMVJ (#2136), we might only know that SVD-mode is chosen after the check for SVD (for preconditioner configuration) is done. This is not complete. 
So we could move the check for this restart method after we have applied the default values, if necessary, in IMVJ.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
