### PR TITLE
Speedup print of test list

### DIFF
--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -89,20 +89,17 @@ int main(int argc, char *argv[])
 {
   using namespace precice;
 
+  // Handle unit list printing first to avoid the MPI initialization overhead
+  if (argc == 2 && std::string(argv[1]) == "--list_units") {
+    printTestList();
+    return 0;
+  }
+
   precice::syncMode = false;
   utils::Parallel::initializeTestingMPI(&argc, &argv);
   const auto rank = utils::Parallel::current()->rank();
   const auto size = utils::Parallel::current()->size();
   logging::setMPIRank(rank);
-
-  // Handle custom printing
-  if (argc == 2 && std::string(argv[1]) == "--list_units") {
-    if (rank == 0) {
-      printTestList();
-    }
-    utils::Parallel::finalizeTestingMPI();
-    return 0;
-  }
 
   // Handle not enough MPI ranks
   if (size < 4 && argc < 2) {


### PR DESCRIPTION
## Main changes of this PR

This PR speeds up printing the list of tests by skipping MPI_Init when the test binary is called with `--list_units`.

## Motivation and additional information

This shaves of about a second, which is useful for tools.
Part of #2118

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
