### PR TITLE
Remove exchange-dir from remeshing tests

### DIFF
--- a/tests/remeshing/ResetAfterSubcycling.xml
+++ b/tests/remeshing/ResetAfterSubcycling.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/ResetWhileIterating.xml
+++ b/tests/remeshing/ResetWhileIterating.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/SubcylingAfterReset.xml
+++ b/tests/remeshing/SubcylingAfterReset.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-explicit/two-meshes/LocalMapping.xml
+++ b/tests/remeshing/parallel-explicit/two-meshes/LocalMapping.xml
@@ -41,7 +41,7 @@
     <read-data name="DA2" mesh="MB" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-explicit/two-meshes/RemoteMapping.xml
+++ b/tests/remeshing/parallel-explicit/two-meshes/RemoteMapping.xml
@@ -42,7 +42,7 @@
     <mapping:nearest-neighbor direction="read" from="MA2" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-explicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshBothSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshFirstSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-ILS/RemeshSecondSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshBothSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshFirstSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/IQN-IMVJ/RemeshSecondSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshBothSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshFirstSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/aitken/RemeshSecondSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshBothSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshFirstSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/acceleration/constant/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/acceleration/constant/RemeshSecondSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBoth2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshBothSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirst2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshFirstSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecond2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/changed-mapping/RemeshSecondSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/OverlapBoth2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterFirst2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/ScatterSecond2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapFirst.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapFirst.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapFirst2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapSecond.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapSecond.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/changed-partition/SwapSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/changed-partition/SwapSecond2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/convergence/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshBothSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/convergence/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshFirstSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/convergence/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/convergence/RemeshSecondSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshBoth.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBoth.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshBoth2LI.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBoth2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshBothSerial.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshBothSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirst.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirst.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirst2LI.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirst2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshFirstSerial.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshFirstSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="A" second="B" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecond.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecond.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecond2LI.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecond2LI.xml
@@ -29,11 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets
-    use-two-level-initialization="yes"
-    acceptor="B"
-    connector="A"
-    exchange-directory=".." />
+  <m2n:sockets use-two-level-initialization="yes" acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />

--- a/tests/remeshing/parallel-implicit/noop/RemeshSecondSerial.xml
+++ b/tests/remeshing/parallel-implicit/noop/RemeshSecondSerial.xml
@@ -29,7 +29,7 @@
     <mapping:nearest-neighbor direction="read" from="MA" to="MB" constraint="consistent" />
   </participant>
 
-  <m2n:sockets acceptor="B" connector="A" exchange-directory=".." />
+  <m2n:sockets acceptor="B" connector="A" />
 
   <coupling-scheme:parallel-implicit>
     <participants first="B" second="A" />


### PR DESCRIPTION
## Main changes of this PR

Removes the exchange dirs from the remeshing tests which lead to test conflicts when running tests in parallel.

## Motivation and additional information

Caused by using a real configuration case to setup the test. Tests use the CWD as the default exchange dir.

Part of #2118 


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
