### PR TITLE
Fix crash in destructor after exception in communication initialization

### DIFF
--- a/docs/changelog/2141.md
+++ b/docs/changelog/2141.md
@@ -1,0 +1,1 @@
+- Fixed crash in finalize after an inter-participant communication fails to connect.


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a crash in the destructor when initialize fails to establish primary connections.

## Motivation and additional information

I noticed this in #2118 as #2140 caused parallel tests to delete each other's communication files leading to exceptions in the `ConnectionInfoPublisher`.
I cannot think a way of reliably testing this though. Ideas welcome.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
