### PR TITLE
Fix event name of _GLOBAL missing in integration tests

### DIFF
--- a/src/profiling/EventUtils.cpp
+++ b/src/profiling/EventUtils.cpp
@@ -65,6 +65,7 @@ void EventRegistry::initialize(std::string_view applicationName, int rank, int s
 
   _firstwrite = true;
   _writeQueue.clear();
+  _nameDict.clear();
 
   _globalId = nameToID("_GLOBAL");
   _writeQueue.emplace_back(StartEntry{_globalId.value(), _initClock});


### PR DESCRIPTION
## Main changes of this PR

Fixes the event name of GLOBAL missing in integration tests by correctly cleaning the name map on initialize.

This allows you to add `<profiling mode="all" />` to any integration tests to analyze its profiling data later on.

## Motivation and additional information

This shouldn't be triggerable under normal circumstances.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
