### PR TITLE
Fix initial data in multi-coupling schemes

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -253,7 +253,7 @@ PtrCouplingData BaseCouplingScheme::addCouplingData(const mesh::PtrData &data, m
   PRECICE_CHECK(direction == CouplingData::Direction::Send,
                 "Data \"{0}\" cannot be received from multiple sources. Please remove either <exchange data=\"{0}\" ... /> tag", data->getName());
   PRECICE_CHECK(existing->exchangeSubsteps() == communicateSubsteps,
-                "Data \"{0}\" is configured with substeps enabled and disabled at the same time. Please make the configuration consistent in the <exchange data=\"{0}\" ... /> tags", data->getName());
+                "Data \"{0}\" is configured with substeps enabled and disabled at the same time. Please make the configuration consistent in the <exchange data=\"{0}\" ... substeps=\"True/False\" ... /> tags", data->getName());
   PRECICE_CHECK(existing->requiresInitialization == requiresInitialization,
                 "Data \"{0}\" is configured with data initialization enabled and disabled at the same time. Please make the configuration consistent in the <exchange data=\"{0}\" ... /> tags", data->getName());
 

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -237,16 +237,28 @@ void BaseCouplingScheme::initializeWithZeroInitialData(const DataMap &receiveDat
 
 PtrCouplingData BaseCouplingScheme::addCouplingData(const mesh::PtrData &data, mesh::PtrMesh mesh, bool requiresInitialization, bool communicateSubsteps, CouplingData::Direction direction)
 {
-  int             id = data->getID();
-  PtrCouplingData ptrCplData;
-  if (!utils::contained(id, _allData)) { // data is not used by this coupling scheme yet, create new CouplingData
-    ptrCplData = std::make_shared<CouplingData>(data, std::move(mesh), requiresInitialization, communicateSubsteps, direction);
-    _allData.emplace(id, ptrCplData);
-  } else { // data is already used by another exchange of this coupling scheme, use existing CouplingData
-    ptrCplData = _allData[id];
-    PRECICE_CHECK(ptrCplData->getDirection() == direction, "Data \"{0}\" cannot be added for sending and for receiving. Please remove either <exchange data=\"{0}\" ... /> tag", data->getName());
+  const DataID id = data->getID();
+
+  // new data
+  if (_allData.count(id) == 0) {
+    auto ptr = std::make_shared<CouplingData>(data, std::move(mesh), requiresInitialization, communicateSubsteps, direction);
+    _allData.emplace(id, ptr);
+    return ptr;
   }
-  return ptrCplData;
+
+  // data is already used by another exchange of this coupling scheme, use existing CouplingData
+  auto &existing = _allData[id];
+  PRECICE_CHECK(existing->getDirection() == direction,
+                "Data \"{0}\" cannot be added for sending and for receiving. Please remove either <exchange data=\"{0}\" ... /> tag", data->getName());
+  PRECICE_CHECK(direction == CouplingData::Direction::Send,
+                "Data \"{0}\" cannot be received from multiple sources. Please remove either <exchange data=\"{0}\" ... /> tag", data->getName());
+
+  PRECICE_CHECK(existing->exchangeSubsteps() == communicateSubsteps,
+                "Data \"{0}\" is configured with substeps enabled and disabled at the same time. Please make the configuration consistent in the <exchange data=\"{0}\" ... /> tags", data->getName());
+  PRECICE_CHECK(existing->requiresInitialization == requiresInitialization,
+                "Data \"{0}\" is configured with data initialization enabled and disabled at the same time. Please make the configuration consistent in the <exchange data=\"{0}\" ... /> tags", data->getName());
+
+  return existing;
 }
 
 bool BaseCouplingScheme::isExplicitCouplingScheme() const

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -252,7 +252,6 @@ PtrCouplingData BaseCouplingScheme::addCouplingData(const mesh::PtrData &data, m
                 "Data \"{0}\" cannot be added for sending and for receiving. Please remove either <exchange data=\"{0}\" ... /> tag", data->getName());
   PRECICE_CHECK(direction == CouplingData::Direction::Send,
                 "Data \"{0}\" cannot be received from multiple sources. Please remove either <exchange data=\"{0}\" ... /> tag", data->getName());
-
   PRECICE_CHECK(existing->exchangeSubsteps() == communicateSubsteps,
                 "Data \"{0}\" is configured with substeps enabled and disabled at the same time. Please make the configuration consistent in the <exchange data=\"{0}\" ... /> tags", data->getName());
   PRECICE_CHECK(existing->requiresInitialization == requiresInitialization,

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -82,39 +82,45 @@ void MultiCouplingScheme::exchangeInitialData()
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
 
   if (_isController) {
-    if (receivesInitializedData()) {
-      for (auto &receiveExchange : _receiveDataVector) {
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
-      }
-      notifyDataHasBeenReceived();
-    } else {
-      for (auto &receiveExchange : _receiveDataVector) {
-        initializeWithZeroInitialData(receiveExchange.second);
+    for (auto &[from, data] : _receiveDataVector) {
+      if (receivesInitializedDataFrom(from)) {
+        receiveData(_m2ns.at(from), data);
+      } else {
+        initializeWithZeroInitialData(data);
       }
     }
-    if (sendsInitializedData()) {
-      for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second);
+    notifyDataHasBeenReceived();
+    for (auto &[to, data] : _sendDataVector) {
+      if (sendsInitializedDataTo(to)) {
+        sendData(_m2ns.at(to), data);
       }
     }
   } else {
-    if (sendsInitializedData()) {
-      for (auto &sendExchange : _sendDataVector) {
-        sendData(_m2ns[sendExchange.first], sendExchange.second);
+    for (auto &[to, data] : _sendDataVector) {
+      if (sendsInitializedDataTo(to)) {
+        sendData(_m2ns.at(to), data);
       }
     }
-    if (receivesInitializedData()) {
-      for (auto &receiveExchange : _receiveDataVector) {
-        receiveData(_m2ns[receiveExchange.first], receiveExchange.second);
-      }
-      notifyDataHasBeenReceived();
-    } else {
-      for (auto &receiveExchange : _receiveDataVector) {
-        initializeWithZeroInitialData(receiveExchange.second);
+    for (auto &[from, data] : _receiveDataVector) {
+      if (receivesInitializedDataFrom(from)) {
+        receiveData(_m2ns.at(from), data);
+      } else {
+        initializeWithZeroInitialData(data);
       }
     }
+    notifyDataHasBeenReceived();
   }
   PRECICE_DEBUG("Initial data is exchanged in MultiCouplingScheme");
+}
+
+bool MultiCouplingScheme::sendsInitializedDataTo(const std::string &to) const
+{
+  return _sendInitialTo.count(to) > 0;
+}
+
+bool MultiCouplingScheme::receivesInitializedDataFrom(const std::string &from) const
+{
+  return _receiveInitialFrom.count(from) > 0;
 }
 
 void MultiCouplingScheme::exchangeFirstData()
@@ -174,6 +180,9 @@ void MultiCouplingScheme::addDataToSend(
   PtrCouplingData ptrCplData = addCouplingData(data, std::move(mesh), requiresInitialization, exchangeSubsteps, CouplingData::Direction::Send);
   PRECICE_DEBUG("Configuring send data to {}", to);
   _sendDataVector[to].emplace(data->getID(), ptrCplData);
+  if (requiresInitialization) {
+    _sendInitialTo.emplace(to);
+  }
 }
 
 void MultiCouplingScheme::addDataToReceive(
@@ -186,6 +195,9 @@ void MultiCouplingScheme::addDataToReceive(
   PtrCouplingData ptrCplData = addCouplingData(data, std::move(mesh), requiresInitialization, exchangeSubsteps, CouplingData::Direction::Receive);
   PRECICE_DEBUG("Configuring receive data from {}", from);
   _receiveDataVector[from].emplace(data->getID(), ptrCplData);
+  if (requiresInitialization) {
+    _receiveInitialFrom.emplace(from);
+  }
 }
 
 } // namespace precice::cplscheme

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -83,11 +83,21 @@ private:
    */
   std::map<std::string, DataMap> _sendDataVector;
 
+  /// Coupling partners to receive initial data from
+  std::set<std::string> _receiveInitialFrom;
+
+  /// Coupling partners to send initial data to
+  std::set<std::string> _sendInitialTo;
+
   logging::Logger _log{"cplscheme::MultiCouplingScheme"};
 
   void exchangeFirstData() override final;
 
   void exchangeSecondData() override final;
+
+  bool sendsInitializedDataTo(const std::string &to) const;
+
+  bool receivesInitializedDataFrom(const std::string &from) const;
 
   DataMap &getAccelerationData() override final;
 

--- a/tests/serial/multi-coupling/MultiCouplingThreeSolvers5.xml
+++ b/tests/serial/multi-coupling/MultiCouplingThreeSolvers5.xml
@@ -66,12 +66,12 @@
     <max-time-windows value="10" />
     <time-window-size value="1.0" />
     <max-iterations value="2" />
-    <!-- Check that we can initialize only data that is exchanged without involving the controller -->
+    <!-- Check that we can initialize data that is exchanged between non-controller -->
     <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" initialize="no" />
     <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" initialize="no" />
     <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverB" initialize="yes" />
     <exchange data="DataBC" mesh="MeshC" from="SolverB" to="SolverC" initialize="yes" />
-    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" initialize="no" />
+    <exchange data="DataCB" mesh="MeshC" from="SolverC" to="SolverA" initialize="yes" />
     <relative-convergence-measure data="DataCB" mesh="MeshC" limit="1e-4" />
     <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
   </coupling-scheme:multi>


### PR DESCRIPTION
## Main changes of this PR

This PR fixes initial data in multi-coupling schemes and enforces that data send to multiple participant is configured identically in terms of `initialize` and `substeps`.
The configuration limitation is something that never worked :tm:.

## Motivation and additional information

Tests are in #2134
Closes #2133

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviews

@BenjaminRodenberg can you have a general look on how this fits into your previous refactoring strategy?
@MakisH @carme-hp Can you verify that this works for your failing cases?