### PR TITLE
Fix list_units not showing data tests

### DIFF
--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -40,7 +40,7 @@ private:
     if (ts.p_type_name == "suite") {
       prefix.push_back(ts.p_name);
     }
-    return test_tree_visitor::visit((boost::unit_test::test_unit const &) ts);
+    return true;
   }
 
   void test_suite_finish(boost::unit_test::test_suite const &ts) override
@@ -63,6 +63,12 @@ void printTestList()
 {
   using namespace boost::unit_test;
   test_case_printer tcp;
+  // We need to manually initialize boost test
+  // Internally it always accesses the first argument
+  char  arg0[] = "./testprecice";
+  char *argv[] = {arg0};
+  framework::init(&init_unit_test, 1, argv);
+  framework::finalize_setup_phase();
   traverse_test_tree(framework::master_test_suite(), tcp, true);
 }
 


### PR DESCRIPTION
## Main changes of this PR

This PR fixes `./testprecice --list_units` to show data tests. Before, data tests like the QN tests weren't displayed correctly.

## Motivation and additional information

This impacts #2118

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
