### PR TITLE
Remove preinstalled pkg-config and cmake from mac

### DIFF
--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install pip packages
       run: pip3 install numpy polars
     - name: Install preCICE dependencies
-      run: brew install cmake eigen libxml2 boost petsc openmpi pkg-config ninja
+      run: brew install --overwrite cmake eigen libxml2 boost petsc openmpi pkg-config ninja
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install pip packages
       run: pip3 install numpy polars
     - name: Install preCICE dependencies
-      run: brew install cmake eigen libxml2 boost petsc openmpi pkg-config ninja
+      run: brew install eigen libxml2 boost petsc openmpi ninja
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure

--- a/.github/workflows/build-and-test-mac.yml
+++ b/.github/workflows/build-and-test-mac.yml
@@ -46,7 +46,7 @@ jobs:
     - name: Install pip packages
       run: pip3 install numpy polars
     - name: Install preCICE dependencies
-      run: brew install eigen libxml2 boost petsc openmpi ninja
+      run: brew install cmake eigen libxml2 boost petsc openmpi pkg-config ninja
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure


### PR DESCRIPTION
## Main changes of this PR

Removes the preinstalled packages from the brew dependency installation step.

## Motivation and additional information

There now seems to be a conflict with the newest macos runner image.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
