### PR TITLE
Add export data tests

### DIFF
--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -24,6 +24,47 @@ using namespace precice;
 BOOST_AUTO_TEST_SUITE(CSVExport)
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalar)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
+
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportVector)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
+
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportMissing)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  // no sample
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {
   PRECICE_TEST();

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -19,6 +19,47 @@ BOOST_AUTO_TEST_SUITE(VTKExport)
 
 using namespace precice;
 
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalar)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
+
+  io::ExportVTK exportCSV{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportCSV.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportVector)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
+
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTK.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportMissing)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  // no sample
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTK.doExport(0, 0.0);
+}
+
 PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
 {

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -23,7 +23,48 @@ using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(VTPExport)
 
-PRECICE_TEST_SETUP(1_rank)
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
+BOOST_AUTO_TEST_CASE(ExportScalar)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
+
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
+BOOST_AUTO_TEST_CASE(ExportVector)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
+
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
+BOOST_AUTO_TEST_CASE(ExportMissing)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  // no sample
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTP.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 {
   PRECICE_TEST();

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -23,7 +23,48 @@ using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(VTUExport)
 
-PRECICE_TEST_SETUP(1_rank)
+  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalar)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
+
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
+}
+
+  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportVector)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
+
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
+}
+
+  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportMissing)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh.createVertex(Eigen::Vector2d::Zero());
+  mesh.createVertex(Eigen::Vector2d::Constant(1));
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  // no sample
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  exportVTU.doExport(0, 0.0);
+}
+
+  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 {
   PRECICE_TEST();

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -23,7 +23,7 @@ using namespace precice;
 
 BOOST_AUTO_TEST_SUITE(VTUExport)
 
-  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalar)
 {
   PRECICE_TEST();
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
   exportVTU.doExport(0, 0.0);
 }
 
-  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportVector)
 {
   PRECICE_TEST();
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(ExportVector)
   exportVTU.doExport(0, 0.0);
 }
 
-  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportMissing)
 {
   PRECICE_TEST();
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   exportVTU.doExport(0, 0.0);
 }
 
-  PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
+PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 {
   PRECICE_TEST();


### PR DESCRIPTION
## Main changes of this PR

This PR adds simple exporter tests for scalar, vectorial and missing data.

## Motivation and additional information

This would have prevented #2131

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
