### PR TITLE
Refactor test setup into separate class

### DIFF
--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -31,9 +31,57 @@ namespace precice::testing {
 
 using Par = utils::Parallel;
 
+// TestSetup
+
+void TestSetup::handleOption(testing::Require requirement)
+{
+  using testing::Require;
+  switch (requirement) {
+  case Require::PETSc:
+    petsc  = true;
+    events = true;
+    break;
+  case Require::Events:
+    events = true;
+    break;
+  case Require::Ginkgo:
+    ginkgo = true;
+    events = true;
+    break;
+  default:
+    std::terminate();
+  }
+}
+
+void TestSetup::handleOption(ParticipantState participant)
+{
+  participants.emplace_back(participant);
+}
+
+void TestSetup::handleOption(Ranks ranks)
+{
+  participants.emplace_back("Unnamed"_on(ranks));
+}
+
+int TestSetup::totalRanks() const
+{
+  return std::accumulate(participants.begin(), participants.end(), 0, [](int i, const ParticipantState &ps) { return i + ps.size; });
+}
+
+// TestContext
+
+TestContext::TestContext(TestSetup setup)
+    : _setup(setup)
+{
+  for (const auto &p : setup.participants) {
+    _names.emplace(p.name);
+  }
+  initialize(setup.participants);
+}
+
 TestContext::~TestContext() noexcept
 {
-  if (!invalid && _petsc) {
+  if (!invalid && _setup.petsc) {
     precice::utils::Petsc::finalize();
   }
   if (!invalid) {
@@ -70,7 +118,7 @@ bool TestContext::hasSize(int size) const
 
 bool TestContext::isNamed(const std::string &name) const
 {
-  if (std::find(_names.begin(), _names.end(), name) == _names.end()) {
+  if (_names.count(name) == 0) {
     throw std::runtime_error("The requested name \"" + name + "\" does not exist!");
   }
   return this->name == name;
@@ -87,36 +135,6 @@ bool TestContext::isRank(Rank rank) const
 bool TestContext::isPrimary() const
 {
   return isRank(0);
-}
-
-void TestContext::handleOption(Participants &, testing::Require requirement)
-{
-  using testing::Require;
-  switch (requirement) {
-  case Require::PETSc:
-    _petsc  = true;
-    _events = true;
-    break;
-  case Require::Events:
-    _events = true;
-    break;
-  case Require::Ginkgo:
-    _ginkgo = true;
-    _events = true;
-    break;
-  default:
-    std::terminate();
-  }
-}
-
-void TestContext::handleOption(Participants &participants, ParticipantState participant)
-{
-  if (_simple) {
-    std::terminate();
-  }
-  // @TODO add check if name already registered
-  _names.push_back(participant.name);
-  participants.emplace_back(std::move(participant));
 }
 
 void TestContext::setContextFrom(const ParticipantState &p)
@@ -203,7 +221,7 @@ void TestContext::initializeEvents()
   // Always initialize the events
   auto &er = precice::profiling::EventRegistry::instance();
   er.initialize(name, rank, size);
-  if (_events) { // Enable them if they are requested
+  if (_setup.events) { // Enable them if they are requested
     er.setMode(precice::profiling::Mode::All);
     er.setDirectory("./precice-profiling");
   } else {
@@ -214,14 +232,14 @@ void TestContext::initializeEvents()
 
 void TestContext::initializePetsc()
 {
-  if (!invalid && _petsc) {
+  if (!invalid && _setup.petsc) {
     precice::utils::Petsc::initialize(_contextComm->comm);
   }
 }
 
 void TestContext::initializeGinkgo()
 {
-  if (!invalid && _ginkgo) {
+  if (!invalid && _setup.ginkgo) {
     int    argc = 0;
     char **argv;
 #ifndef PRECICE_NO_GINKGO
@@ -247,11 +265,11 @@ m2n::PtrM2N TestContext::connectPrimaryRanks(const std::string &acceptor, const 
   };
   auto m2n = m2n::PtrM2N(new m2n::M2N(participantCom, distrFactory, options.useOnlyPrimaryCom, options.useTwoLevelInit));
 
-  if (std::find(_names.begin(), _names.end(), acceptor) == _names.end()) {
+  if (_names.count(acceptor) == 0) {
     throw std::runtime_error{
         "Acceptor \"" + acceptor + "\" not defined in this context."};
   }
-  if (std::find(_names.begin(), _names.end(), requestor) == _names.end()) {
+  if (_names.count(requestor) == 0) {
     throw std::runtime_error{
         "Requestor \"" + requestor + "\" not defined in this context."};
   }
@@ -280,13 +298,13 @@ std::string TestContext::describe() const
   }
   os << " and runs on rank " << rank << " out of " << size << '.';
 
-  if (_initIntraComm || _events || _petsc) {
+  if (_initIntraComm || _setup.events || _setup.petsc) {
     os << " Initialized: {";
     if (_initIntraComm)
       os << " IntraComm Communication ";
-    if (_events)
+    if (_setup.events)
       os << " Events";
-    if (_petsc)
+    if (_setup.petsc)
       os << " PETSc";
     os << '}';
   }

--- a/src/testing/TestContext.hpp
+++ b/src/testing/TestContext.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -45,7 +46,7 @@ inline constexpr Ranks operator""_rank(unsigned long long value)
 /// Represents a ParticipantState in a test
 struct ParticipantState {
   /// the name of the participant
-  std::string name;
+  std::string_view name;
 
   /// the amount of ranks this participant runs on
   int size = 1;
@@ -54,7 +55,7 @@ struct ParticipantState {
   bool initIntraComm = false;
 
   /// Constructs a serial participant with a given name
-  explicit ParticipantState(std::string n)
+  constexpr explicit ParticipantState(std::string_view n)
       : name(std::move(n)){};
 
   /** Injects the amount of ranks this participant should run on.
@@ -65,7 +66,7 @@ struct ParticipantState {
    *
    * @returns A reference to the ParticipantState allowing for chaining.
    */
-  ParticipantState &operator()(Ranks rsize)
+  constexpr ParticipantState &operator()(Ranks rsize)
   {
     size = rsize.value;
     return *this;
@@ -75,7 +76,7 @@ struct ParticipantState {
    *
    * @returns A reference to the ParticipantState allowing for chaining.
    */
-  ParticipantState &setupIntraComm()
+  constexpr ParticipantState &setupIntraComm()
   {
     initIntraComm = true;
     return *this;
@@ -83,7 +84,7 @@ struct ParticipantState {
 };
 
 /// User-defined literal allowing to create a serial ParticipantState from a given string.
-inline ParticipantState operator""_on(const char *name, std::size_t)
+inline constexpr ParticipantState operator""_on(const char *name, std::size_t)
 {
   return ParticipantState{name};
 }
@@ -103,6 +104,47 @@ enum class Require {
   Events,
   /// Ginkgo initialization
   Ginkgo,
+};
+
+/// Contains the setup description of a test including participants and requirements
+struct TestSetup {
+
+  /** Create a context representing an unnamed Participant running on a given count of Ranks and some requirements
+   *
+   * @note You need to construct a Participant if you require initializing
+   * an intra-participant connection `"Serial"_on(3_ranks).setupIntraComm()`
+   *
+   * @attention This call synchronizes all ranks
+   *
+   * @see Require
+   */
+  template <class... T>
+  TestSetup(T... args)
+  {
+    (handleOption(args), ...);
+  }
+
+  /// @{
+  /// @name Option Handling
+  void handleOption(ParticipantState participants);
+  void handleOption(Ranks ranks);
+  void handleOption(testing::Require requirement);
+  /// @}
+
+  /// total amount of ranks required by this setup
+  int totalRanks() const;
+
+  /// whether to initialize PETSc
+  bool petsc = false;
+
+  /// whether to initialize events
+  bool events = false;
+
+  /// whether to initialize Ginkgo (the device)
+  bool ginkgo = false;
+
+  /// All known participants
+  std::vector<ParticipantState> participants;
 };
 
 /** A type of distributed connection
@@ -167,61 +209,8 @@ public:
   /// whether this context is valid or not
   bool invalid = false;
 
-  /// @{
-  /// @name Construction
-
   /// Create a context representing an unnamed serial Participant
-  TestContext() = default;
-
-  /** Create a context representing an unnamed Participant running on a given count of Ranks
-   *
-   * @note You need to construct a Participant if you require initializing
-   * an intra-participant connection `"Serial"_on(3_ranks).setupIntraComm()`
-   *
-   * @attention This call synchronizes all ranks
-   *
-   */
-  template <class... T>
-  TestContext(Ranks ranks)
-      : _simple(true)
-  {
-    Participants participants{"Serial"_on(ranks)};
-    initialize(participants);
-  }
-
-  /** Create a context representing an unnamed Participant running on a given count of Ranks and some requirements
-   *
-   * @note You need to construct a Participant if you require initializing
-   * an intra-participant connection `"Serial"_on(3_ranks).setupIntraComm()`
-   *
-   * @attention This call synchronizes all ranks
-   *
-   * @see Require
-   */
-  template <class... T>
-  TestContext(Ranks ranks, T... args)
-      : _simple(true)
-  {
-    Participants participants{"Serial"_on(ranks)};
-    handleOptions(participants, args...);
-    initialize(participants);
-  }
-
-  /** Create a context representing one or more participants
-   *
-   * @attention This call synchronizes all ranks
-   *
-   * @see Require
-   */
-  template <class... T>
-  TestContext(T... args)
-  {
-    Participants participants;
-    handleOptions(participants, args...);
-    initialize(participants);
-  }
-
-  /// @}
+  TestContext(TestSetup setup);
 
   /** Cleans-up all initialized parts and synchronizes all ranks
    * @attention This call synchronizes all ranks
@@ -281,45 +270,16 @@ public:
   std::string describe() const;
 
 private:
-  /// whether to initialize PETSc
-  bool _petsc = false;
+  TestSetup _setup;
 
-  /// whether to initialize events
-  bool _events = false;
-
-  /// whether to initialize Ginkgo (the device)
-  bool _ginkgo = false;
-
-  /// whether this Context was created with a Ranks constructor
-  bool _simple = false;
-
-  /// whether to initialize an intra-participant connection
+  /// whether this context needs to initialize the intracomm
   bool _initIntraComm = false;
 
   /// the MPI communicator of the context
   utils::Parallel::CommStatePtr _contextComm;
 
   /// contains the name of every known Participant
-  std::vector<std::string> _names;
-
-  /// @{
-  /// @name Option Handling
-  void handleOption(Participants &participants, ParticipantState participant);
-  void handleOption(Participants &participants, testing::Require requirement);
-
-  template <class LastOption>
-  void handleOptions(Participants &participants, LastOption &last)
-  {
-    handleOption(participants, last);
-  }
-
-  template <class NextOption, class... Rest>
-  void handleOptions(Participants &participants, NextOption &next, Rest &... rest)
-  {
-    handleOption(participants, next);
-    handleOptions(participants, rest...);
-  }
-  /// @}
+  std::set<std::string> _names;
 
   /** set the context from a Participants and the current com
    * Both uniquely identify a context.

--- a/src/testing/TestContext.hpp
+++ b/src/testing/TestContext.hpp
@@ -114,8 +114,6 @@ struct TestSetup {
    * @note You need to construct a Participant if you require initializing
    * an intra-participant connection `"Serial"_on(3_ranks).setupIntraComm()`
    *
-   * @attention This call synchronizes all ranks
-   *
    * @see Require
    */
   template <class... T>
@@ -209,7 +207,15 @@ public:
   /// whether this context is valid or not
   bool invalid = false;
 
-  /// Create a context representing an unnamed serial Participant
+  /** Creates a context for a rank in the given TestSetup
+   *
+   * Unneeded ranks are marked as invalid.
+   * Provides a TestContext named `context` which can be used in the test.
+   *
+   * @attention This call synchronizes all ranks
+   *
+   * @see @ref PRECICE_TEST()
+   */
   TestContext(TestSetup setup);
 
   /** Cleans-up all initialized parts and synchronizes all ranks

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -24,13 +24,13 @@ using precice::testing::operator""_on;
 using precice::testing::operator""_dataID;
 } // namespace inject
 
-#define PRECICE_TEST(...)                             \
-  using namespace precice::testing::inject;           \
-  precice::testing::TestContext context{__VA_ARGS__}; \
-  if (context.invalid) {                              \
-    return;                                           \
-  }                                                   \
-  BOOST_TEST_MESSAGE(context.describe());             \
+#define PRECICE_TEST(...)                                                          \
+  using namespace precice::testing::inject;                                        \
+  precice::testing::TestContext context{precice::testing::TestSetup{__VA_ARGS__}}; \
+  if (context.invalid) {                                                           \
+    return;                                                                        \
+  }                                                                                \
+  BOOST_TEST_MESSAGE(context.describe());                                          \
   boost::unit_test::framework::add_context(BOOST_TEST_LAZY_MSG(context.describe()), true);
 
 /// struct giving access to the impl of a befriended class or struct


### PR DESCRIPTION
## Main changes of this PR

This PR refactors the test setup into a separate class.

## Motivation and additional information

This is a preparation step for moving the TestSetup into a decorator to make it accessible outside of tests.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
