### PR TITLE
Launch tests in CTest with exact amount of ranks

### DIFF
--- a/src/com/tests/SerializedStamplesTest.cpp
+++ b/src/com/tests/SerializedStamplesTest.cpp
@@ -16,8 +16,10 @@ BOOST_AUTO_TEST_SUITE(CommunicationTests)
 
 BOOST_AUTO_TEST_SUITE(SerializedStamples)
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(SerializeValues)
 {
+  PRECICE_TEST();
   std::vector<int> vertexOffsets{4, 8, 8, 10};
 
   const int meshDimensions = 3;
@@ -55,8 +57,10 @@ BOOST_AUTO_TEST_CASE(SerializeValues)
   }
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(DeserializeValues)
 {
+  PRECICE_TEST();
   std::vector<int> vertexOffsets{4, 8, 8, 10};
 
   const int meshDimensions = 3;
@@ -107,8 +111,10 @@ BOOST_AUTO_TEST_CASE(DeserializeValues)
   }
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(SerializeValuesAndGradients)
 {
+  PRECICE_TEST();
   std::vector<int> vertexOffsets{4, 8, 8, 10};
 
   const int meshDimensions = 3;
@@ -167,8 +173,10 @@ BOOST_AUTO_TEST_CASE(SerializeValuesAndGradients)
   }
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(DeserializeValuesAndGradients)
 {
+  PRECICE_TEST();
   std::vector<int> vertexOffsets{4, 8, 8, 10};
 
   const int meshDimensions = 3;

--- a/src/mapping/tests/RadialBasisFctMappingTest.cpp
+++ b/src/mapping/tests/RadialBasisFctMappingTest.cpp
@@ -1592,8 +1592,10 @@ BOOST_AUTO_TEST_SUITE_END() // Serial
 
 BOOST_AUTO_TEST_SUITE(Helper)
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(inverseTriangularMatrix)
 {
+  PRECICE_TEST();
   // Define the size of the matrix
   const int inSize = 112;
 

--- a/src/math/tests/BSplineTest.cpp
+++ b/src/math/tests/BSplineTest.cpp
@@ -73,8 +73,10 @@ BOOST_AUTO_TEST_CASE(ThreePointsLinear)
   BOOST_TEST(equals(bspline.interpolateAt(1.5), Eigen::Vector3d(2.5, 25, 250)));
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(ThreePointsLinearNonEquidistant)
 {
+  PRECICE_TEST();
   Eigen::Vector3d ts;
   ts << 0, 1, 3;
   Eigen::MatrixXd xs(3, 3);

--- a/src/mesh/tests/UtilsTest.cpp
+++ b/src/mesh/tests/UtilsTest.cpp
@@ -5,8 +5,10 @@ BOOST_AUTO_TEST_SUITE(MeshTests)
 
 BOOST_AUTO_TEST_SUITE(UtilsTests)
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(LocateInvalidId)
 {
+  PRECICE_TEST();
   using namespace precice;
   using namespace precice::mesh;
   mesh::Mesh mesh("2D Testmesh", 2, testing::nextMeshID());

--- a/src/precice/tests/ToolingTests.cpp
+++ b/src/precice/tests/ToolingTests.cpp
@@ -6,8 +6,10 @@
 BOOST_AUTO_TEST_SUITE(PreciceTests)
 BOOST_AUTO_TEST_SUITE(Tooling)
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(MarkdownReference)
 {
+  PRECICE_TEST();
   const std::string ref = [] {
     std::ostringstream oss;
     precice::tooling::printConfigReference(oss, precice::tooling::ConfigReferenceType::MD);
@@ -20,8 +22,10 @@ BOOST_AUTO_TEST_CASE(MarkdownReference)
   }
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(XMLReference)
 {
+  PRECICE_TEST();
   const std::string ref = [] {
     std::ostringstream oss;
     precice::tooling::printConfigReference(oss, precice::tooling::ConfigReferenceType::XML);
@@ -34,8 +38,10 @@ BOOST_AUTO_TEST_CASE(XMLReference)
   }
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(DTDReference)
 {
+  PRECICE_TEST();
   const std::string ref = [] {
     std::ostringstream oss;
     precice::tooling::printConfigReference(oss, precice::tooling::ConfigReferenceType::DTD);
@@ -50,8 +56,10 @@ BOOST_AUTO_TEST_CASE(DTDReference)
 
 BOOST_AUTO_TEST_SUITE(ConfigCheck)
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(Serial)
 {
+  PRECICE_TEST();
   BOOST_REQUIRE_NO_THROW(
       precice::tooling::checkConfiguration(
           precice::testing::getPathToSources() + "/precice/tests/config-checker.xml",
@@ -59,8 +67,10 @@ BOOST_AUTO_TEST_CASE(Serial)
           1));
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(Parallel)
 {
+  PRECICE_TEST();
   BOOST_REQUIRE_NO_THROW(
       precice::tooling::checkConfiguration(
           precice::testing::getPathToSources() + "/precice/tests/config-checker.xml",

--- a/src/testing/main.cpp
+++ b/src/testing/main.cpp
@@ -56,7 +56,13 @@ private:
     for (const auto &p : prefix) {
       std::cout << p << '/';
     }
-    std::cout << tc.p_name << '\n';
+    std::cout << tc.p_name << ' ';
+
+    if (auto setup = precice::testing::getTestSetupFor(tc); setup) {
+      std::cout << setup->totalRanks() << '\n';
+    } else {
+      std::cout << "?\n";
+    }
   }
 };
 

--- a/src/utils/tests/StatisticsTest.cpp
+++ b/src/utils/tests/StatisticsTest.cpp
@@ -32,8 +32,10 @@ BOOST_AUTO_TEST_CASE(DistanceAccumulator)
   BOOST_TEST(acc.max() == 23);
 }
 
+PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(DistanceAccumulatorOnEmptyMesh)
 {
+  PRECICE_TEST();
   pu::statistics::DistanceAccumulator acc;
   BOOST_TEST(acc.empty());
   BOOST_TEST(acc.count() == 0);


### PR DESCRIPTION
## Main changes of this PR

This PR adds the amount of requested ranks per test to the output of `./testprecice --list_units` and launches the tests either without MPI (if only 1 rank is requested) or with the exact amount of required MPI ranks.

## Motivation and additional information

* This allows using any amount of ranks in tests, removing the historic maximum of 4.
* Running tests via CTest are always correctly sized and don't need to handle unused ranks, resulting in more consistent runtimes.
* Tests using one rank should be able to run for builds with MPI disabled.

Less communication and initialization leads to a more consistent test runtime.
On my local machine:

```
Benchmark develop: ctest -j
  Time (mean ± σ):     28.418 s ±  4.859 s    [User: 317.758 s, System: 213.569 s]
  Range (min … max):   25.990 s … 38.546 s    10 runs

Benchmark this PR: ctest -j
  Time (mean ± σ):     20.106 s ±  0.828 s    [User: 208.488 s, System: 122.066 s]
  Range (min … max):   18.841 s … 21.008 s    10 runs

Summary
  this PR
    1.41 ± 0.25 times faster than develop
```

Further possible improvements:
* Don't initialize MPI running when using only 1 rank. This can lead to many problems though.
* ~~Use the amount of ranks as CTest processors to prevent overloading the system. I'll look into this.~~ Too conservative. 50% slower.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
