### PR TITLE
Fix exporter crash on non-existant data

### DIFF
--- a/src/io/ExportCSV.cpp
+++ b/src/io/ExportCSV.cpp
@@ -96,6 +96,14 @@ void ExportCSV::doExport(int index, double time)
   // Prepare writing data
   std::vector<StridedAccess> dataColumns;
   for (const auto &data : _mesh->data()) {
+    if (data->timeStepsStorage().empty()) {
+      if (data->hasGradient()) {
+        data->timeStepsStorage().setSampleAtTime(0, time::Sample(data->getDimensions(), _mesh->nVertices(), _mesh->getDimensions()).setZero());
+      } else {
+        data->timeStepsStorage().setSampleAtTime(0, time::Sample(data->getDimensions(), _mesh->nVertices()).setZero());
+      }
+    }
+
     auto          dim    = data->getDimensions();
     double const *values = data->timeStepsStorage().last().sample.values.data();
     for (int i = 0; i < dim; ++i) {

--- a/src/io/ExportXML.cpp
+++ b/src/io/ExportXML.cpp
@@ -246,6 +246,13 @@ void ExportXML::exportData(
   outFile << "\n            </DataArray>\n";
 
   for (const mesh::PtrData &data : mesh.data()) { // Plot vertex data
+    if (data->timeStepsStorage().empty()) {
+      if (data->hasGradient()) {
+        data->timeStepsStorage().setSampleAtTime(0, time::Sample(data->getDimensions(), mesh.nVertices(), mesh.getDimensions()).setZero());
+      } else {
+        data->timeStepsStorage().setSampleAtTime(0, time::Sample(data->getDimensions(), mesh.nVertices()).setZero());
+      }
+    }
     const Eigen::VectorXd &values         = data->timeStepsStorage().last().sample.values;
     int                    dataDimensions = data->getDimensions();
     std::string            dataName(data->getName());

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -27,7 +27,7 @@ PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalar)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
@@ -35,13 +35,14 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportVector)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
@@ -49,26 +50,28 @@ BOOST_AUTO_TEST_CASE(ExportVector)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportMissing)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalarParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -77,15 +80,16 @@ BOOST_AUTO_TEST_CASE(ExportScalarParallel)
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
   data->setSampleAtTime(0, time::Sample{1, 1}.setZero());
 
-  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportVectorParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -94,15 +98,16 @@ BOOST_AUTO_TEST_CASE(ExportVectorParallel)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
 
-  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportMissingParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -111,15 +116,16 @@ BOOST_AUTO_TEST_CASE(ExportMissingParallel)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   BOOST_TEST_REQUIRE(data->timeStepsStorage().empty());
   // no sample
-  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -130,8 +136,9 @@ BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
   mesh::PtrData data = mesh.createData("data", 2, 1_dataID);
   data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
   // no sample
-  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -139,7 +146,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {
   PRECICE_TEST();
   int           dim = 2;
-  mesh::Mesh    mesh("ExportPolygonalMeshSerial", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -150,6 +157,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -157,7 +165,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST();
   int        dim = 2;
-  mesh::Mesh mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
@@ -184,6 +192,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv", "Mesh-io-CSVExport.2_init.csv", "Mesh-io-CSVExport.3_init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -191,7 +200,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST();
   int        dim = 3;
-  mesh::Mesh mesh("ExportTriangulatedMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
@@ -221,6 +230,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv", "Mesh-io-CSVExport.2_init.csv", "Mesh-io-CSVExport.3_init.csv");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -228,7 +238,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 {
   PRECICE_TEST();
   int        dim = 3;
-  mesh::Mesh mesh("ExportSplitSquare", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
@@ -281,6 +291,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv", "Mesh-io-CSVExport.2_init.csv", "Mesh-io-CSVExport.3_init.csv");
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(ExportScalarParallel)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
-  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
+  testing::expectFiles(fmt::format("Mesh-io-CSVExport.{}_init.csv", context.rank));
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(ExportVectorParallel)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
-  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
+  testing::expectFiles(fmt::format("Mesh-io-CSVExport.{}_init.csv", context.rank));
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(ExportMissingParallel)
   // no sample
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
-  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
+  testing::expectFiles(fmt::format("Mesh-io-CSVExport.{}_init.csv", context.rank));
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -138,7 +138,7 @@ BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
   // no sample
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
-  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv");
+  testing::expectFiles(fmt::format("Mesh-io-CSVExport.{}_init.csv", context.rank));
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -192,7 +192,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
-  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv", "Mesh-io-CSVExport.2_init.csv", "Mesh-io-CSVExport.3_init.csv");
+  testing::expectFiles(fmt::format("Mesh-io-CSVExport.{}_init.csv", context.rank));
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
-  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv", "Mesh-io-CSVExport.2_init.csv", "Mesh-io-CSVExport.3_init.csv");
+  testing::expectFiles(fmt::format("Mesh-io-CSVExport.{}_init.csv", context.rank));
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 
   io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
-  testing::expectFiles("Mesh-io-CSVExport.0_init.csv", "Mesh-io-CSVExport.1_init.csv", "Mesh-io-CSVExport.2_init.csv", "Mesh-io-CSVExport.3_init.csv");
+  testing::expectFiles(fmt::format("Mesh-io-CSVExport.{}_init.csv", context.rank));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
   data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
 
-  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(ExportVector)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
 
-  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
-  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportCSV exportCSV{"io-CSVExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 

--- a/src/io/tests/ExportCSVTest.cpp
+++ b/src/io/tests/ExportCSVTest.cpp
@@ -64,6 +64,76 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   exportCSV.doExport(0, 0.0);
 }
 
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalarParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{1, 1}.setZero());
+
+  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportCSV.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportVectorParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
+
+  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportCSV.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportMissingParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  BOOST_TEST_REQUIRE(data->timeStepsStorage().empty());
+  // no sample
+  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportCSV.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  auto missing = mesh.createData("missing", 2, 0_dataID);
+  BOOST_TEST_REQUIRE(missing->timeStepsStorage().empty());
+  mesh::PtrData data = mesh.createData("data", 2, 1_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
+  // no sample
+  io::ExportCSV exportCSV{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportCSV.doExport(0, 0.0);
+}
+
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -1,5 +1,6 @@
 #include <Eigen/Core>
 #include <algorithm>
+#include <filesystem>
 #include <string>
 #include "io/Export.hpp"
 #include "io/ExportVTK.hpp"
@@ -23,7 +24,7 @@ PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalar)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
@@ -31,13 +32,14 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
 
   io::ExportVTK exportCSV{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTKExport.init.vtk");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportVector)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
@@ -45,19 +47,21 @@ BOOST_AUTO_TEST_CASE(ExportVector)
 
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTKExport.init.vtk");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportMissing)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTKExport.init.vtk");
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -66,7 +70,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   PRECICE_TEST();
   int dimensions = 2;
   // Create mesh to map from
-  mesh::Mesh    mesh("ExportDataWithGradient", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", 2, 1_dataID);
   dataScalar->requireDataGradient();
@@ -87,6 +91,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTKExport.init.vtk", "Mesh-io-VTKExport.dt1.vtk");
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -94,7 +99,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST();
   int           dim = 2;
-  mesh::Mesh    mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Constant(0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1.0));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -106,6 +111,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTKExport.init.vtk", "Mesh-io-VTKExport.dt1.vtk");
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -113,7 +119,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST();
   int           dim = 3;
-  mesh::Mesh    mesh("ExportTriangulatedMesh", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d::Constant(1.0));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
@@ -126,6 +132,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTKExport.init.vtk", "Mesh-io-VTKExport.dt1.vtk");
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -133,7 +140,7 @@ BOOST_AUTO_TEST_CASE(ExportTetrahedron)
 {
   PRECICE_TEST();
   int           dim = 3;
-  mesh::Mesh    mesh("ExportTetrahedron", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Constant(0.0));
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector3d{0.0, 1.0, 0.0});
@@ -144,6 +151,7 @@ BOOST_AUTO_TEST_CASE(ExportTetrahedron)
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTKExport.init.vtk", "Mesh-io-VTKExport.dt1.vtk");
 }
 
 BOOST_AUTO_TEST_SUITE_END() // ExportVTK

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
   data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
 
-  io::ExportVTK exportCSV{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTK exportCSV{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportCSV.doExport(0, 0.0);
 }
 
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(ExportVector)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
 
-  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
 }
 
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
-  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
 }
 
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   vectorial.gradients.setOnes();
   dataScalar->setSampleAtTime(0, vectorial);
 
-  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
 }
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
 }
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   mesh::Edge &e3 = mesh.createEdge(v3, v1);
   mesh.createTriangle(e1, e2, e3);
 
-  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
 }
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(ExportTetrahedron)
 
   mesh.createTetrahedron(v1, v2, v3, v4);
 
-  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);
   exportVTK.doExport(1, 1.0);
 }

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
   data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
 }
 
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(ExportVector)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
 }
 
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
 }
 
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   vectorial.gradients.setOnes();
   dataScalar->setSampleAtTime(0, vectorial);
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
 }
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   vectorial.gradients.setOnes();
   dataScalar->setSampleAtTime(0, vectorial);
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
 }
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
 }

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -27,7 +27,7 @@ PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
 BOOST_AUTO_TEST_CASE(ExportScalar)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
@@ -35,13 +35,14 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTPExport.init.vtp");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
 BOOST_AUTO_TEST_CASE(ExportVector)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
@@ -49,26 +50,28 @@ BOOST_AUTO_TEST_CASE(ExportVector)
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTPExport.init.vtp");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
 BOOST_AUTO_TEST_CASE(ExportMissing)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTPExport.init.vtp");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalarParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -77,15 +80,19 @@ BOOST_AUTO_TEST_CASE(ExportScalarParallel)
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
   data->setSampleAtTime(0, time::Sample{1, 1}.setZero());
 
-  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTPExport.init_0.vtp",
+      "Mesh-io-VTPExport.init_1.vtp",
+      "Mesh-io-VTPExport.init.pvtp");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportVectorParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -94,15 +101,19 @@ BOOST_AUTO_TEST_CASE(ExportVectorParallel)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
 
-  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTPExport.init_0.vtp",
+      "Mesh-io-VTPExport.init_1.vtp",
+      "Mesh-io-VTPExport.init.pvtp");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportMissingParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -111,15 +122,19 @@ BOOST_AUTO_TEST_CASE(ExportMissingParallel)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   BOOST_TEST_REQUIRE(data->timeStepsStorage().empty());
   // no sample
-  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTPExport.init_0.vtp",
+      "Mesh-io-VTPExport.init_1.vtp",
+      "Mesh-io-VTPExport.init.pvtp");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -130,8 +145,12 @@ BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
   mesh::PtrData data = mesh.createData("data", 2, 1_dataID);
   data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
   // no sample
-  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTPExport.init_0.vtp",
+      "Mesh-io-VTPExport.init_1.vtp",
+      "Mesh-io-VTPExport.init.pvtp");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
@@ -140,7 +159,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   PRECICE_TEST();
   const int dimensions = 2;
   // Create mesh to map from
-  mesh::Mesh    mesh("ExportDataWithGradient2D", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -161,6 +180,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTPExport.init.vtp", "Mesh-io-VTPExport.dt1.vtp");
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -169,7 +189,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   PRECICE_TEST();
   const int dimensions = 3;
   // Create mesh to map from
-  mesh::Mesh    mesh("ExportDataWithGradient3D", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -190,6 +210,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTPExport.init.vtp", "Mesh-io-VTPExport.dt1.vtp");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -197,7 +218,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {
   PRECICE_TEST();
   int           dim = 2;
-  mesh::Mesh    mesh("ExportPolygonalMeshSerial", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -209,6 +230,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTPExport.init.vtp", "Mesh-io-VTPExport.dt1.vtp");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -216,7 +238,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST();
   int        dim = 2;
-  mesh::Mesh mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
@@ -241,9 +263,20 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
+  testing::expectFiles(
+      "Mesh-io-VTPExport.init_0.vtp",
+      "Mesh-io-VTPExport.init_1.vtp",
+      "Mesh-io-VTPExport.init_2.vtp",
+      "Mesh-io-VTPExport.init_3.vtp",
+      "Mesh-io-VTPExport.init.pvtp",
+      "Mesh-io-VTPExport.dt1_0.vtp",
+      "Mesh-io-VTPExport.dt1_1.vtp",
+      "Mesh-io-VTPExport.dt1_2.vtp",
+      "Mesh-io-VTPExport.dt1_3.vtp",
+      "Mesh-io-VTPExport.dt1.pvtp");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -251,7 +284,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST();
   int        dim = 3;
-  mesh::Mesh mesh("TriangulatedMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
@@ -279,9 +312,20 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
+  testing::expectFiles(
+      "Mesh-io-VTPExport.init_0.vtp",
+      "Mesh-io-VTPExport.init_1.vtp",
+      "Mesh-io-VTPExport.init_2.vtp",
+      "Mesh-io-VTPExport.init_3.vtp",
+      "Mesh-io-VTPExport.init.pvtp",
+      "Mesh-io-VTPExport.dt1_0.vtp",
+      "Mesh-io-VTPExport.dt1_1.vtp",
+      "Mesh-io-VTPExport.dt1_2.vtp",
+      "Mesh-io-VTPExport.dt1_3.vtp",
+      "Mesh-io-VTPExport.dt1.pvtp");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -289,7 +333,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 {
   PRECICE_TEST();
   int        dim = 3;
-  mesh::Mesh mesh("SplitSquare", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
@@ -340,9 +384,20 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
+  testing::expectFiles(
+      "Mesh-io-VTPExport.init_0.vtp",
+      "Mesh-io-VTPExport.init_1.vtp",
+      "Mesh-io-VTPExport.init_2.vtp",
+      "Mesh-io-VTPExport.init_3.vtp",
+      "Mesh-io-VTPExport.init.pvtp",
+      "Mesh-io-VTPExport.dt1_0.vtp",
+      "Mesh-io-VTPExport.dt1_1.vtp",
+      "Mesh-io-VTPExport.dt1_2.vtp",
+      "Mesh-io-VTPExport.dt1_3.vtp",
+      "Mesh-io-VTPExport.dt1.pvtp");
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -82,10 +82,13 @@ BOOST_AUTO_TEST_CASE(ExportScalarParallel)
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTPExport.init_0.vtp",
-      "Mesh-io-VTPExport.init_1.vtp",
-      "Mesh-io-VTPExport.init.pvtp");
+  if (context.isPrimary()) {
+    testing::expectFiles(
+        "Mesh-io-VTPExport.init_0.vtp",
+        "Mesh-io-VTPExport.init.pvtp");
+  } else {
+    testing::expectFiles("Mesh-io-VTPExport.init_1.vtp");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -103,10 +106,13 @@ BOOST_AUTO_TEST_CASE(ExportVectorParallel)
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTPExport.init_0.vtp",
-      "Mesh-io-VTPExport.init_1.vtp",
-      "Mesh-io-VTPExport.init.pvtp");
+  if (context.isPrimary()) {
+    testing::expectFiles(
+        "Mesh-io-VTPExport.init_0.vtp",
+        "Mesh-io-VTPExport.init.pvtp");
+  } else {
+    testing::expectFiles("Mesh-io-VTPExport.init_1.vtp");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -124,10 +130,13 @@ BOOST_AUTO_TEST_CASE(ExportMissingParallel)
   // no sample
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTPExport.init_0.vtp",
-      "Mesh-io-VTPExport.init_1.vtp",
-      "Mesh-io-VTPExport.init.pvtp");
+  if (context.isPrimary()) {
+    testing::expectFiles(
+        "Mesh-io-VTPExport.init_0.vtp",
+        "Mesh-io-VTPExport.init.pvtp");
+  } else {
+    testing::expectFiles("Mesh-io-VTPExport.init_1.vtp");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -147,10 +156,13 @@ BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
   // no sample
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTPExport.init_0.vtp",
-      "Mesh-io-VTPExport.init_1.vtp",
-      "Mesh-io-VTPExport.init.pvtp");
+  if (context.isPrimary()) {
+    testing::expectFiles(
+        "Mesh-io-VTPExport.init_0.vtp",
+        "Mesh-io-VTPExport.init.pvtp");
+  } else {
+    testing::expectFiles("Mesh-io-VTPExport.init_1.vtp");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
@@ -266,17 +278,13 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
-  testing::expectFiles(
-      "Mesh-io-VTPExport.init_0.vtp",
-      "Mesh-io-VTPExport.init_1.vtp",
-      "Mesh-io-VTPExport.init_2.vtp",
-      "Mesh-io-VTPExport.init_3.vtp",
-      "Mesh-io-VTPExport.init.pvtp",
-      "Mesh-io-VTPExport.dt1_0.vtp",
-      "Mesh-io-VTPExport.dt1_1.vtp",
-      "Mesh-io-VTPExport.dt1_2.vtp",
-      "Mesh-io-VTPExport.dt1_3.vtp",
-      "Mesh-io-VTPExport.dt1.pvtp");
+  testing::expectFiles(fmt::format("Mesh-io-VTPExport.init_{}.vtp", context.rank),
+                       fmt::format("Mesh-io-VTPExport.dt1_{}.vtp", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles(
+        "Mesh-io-VTPExport.init.pvtp",
+        "Mesh-io-VTPExport.dt1.pvtp");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -315,17 +323,13 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
-  testing::expectFiles(
-      "Mesh-io-VTPExport.init_0.vtp",
-      "Mesh-io-VTPExport.init_1.vtp",
-      "Mesh-io-VTPExport.init_2.vtp",
-      "Mesh-io-VTPExport.init_3.vtp",
-      "Mesh-io-VTPExport.init.pvtp",
-      "Mesh-io-VTPExport.dt1_0.vtp",
-      "Mesh-io-VTPExport.dt1_1.vtp",
-      "Mesh-io-VTPExport.dt1_2.vtp",
-      "Mesh-io-VTPExport.dt1_3.vtp",
-      "Mesh-io-VTPExport.dt1.pvtp");
+  testing::expectFiles(fmt::format("Mesh-io-VTPExport.init_{}.vtp", context.rank),
+                       fmt::format("Mesh-io-VTPExport.dt1_{}.vtp", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles(
+        "Mesh-io-VTPExport.init.pvtp",
+        "Mesh-io-VTPExport.dt1.pvtp");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -387,17 +391,13 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
   exportVTP.doExport(1, 1.0);
-  testing::expectFiles(
-      "Mesh-io-VTPExport.init_0.vtp",
-      "Mesh-io-VTPExport.init_1.vtp",
-      "Mesh-io-VTPExport.init_2.vtp",
-      "Mesh-io-VTPExport.init_3.vtp",
-      "Mesh-io-VTPExport.init.pvtp",
-      "Mesh-io-VTPExport.dt1_0.vtp",
-      "Mesh-io-VTPExport.dt1_1.vtp",
-      "Mesh-io-VTPExport.dt1_2.vtp",
-      "Mesh-io-VTPExport.dt1_3.vtp",
-      "Mesh-io-VTPExport.dt1.pvtp");
+  testing::expectFiles(fmt::format("Mesh-io-VTPExport.init_{}.vtp", context.rank),
+                       fmt::format("Mesh-io-VTPExport.dt1_{}.vtp", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles(
+        "Mesh-io-VTPExport.init.pvtp",
+        "Mesh-io-VTPExport.dt1.pvtp");
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -64,6 +64,76 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   exportVTP.doExport(0, 0.0);
 }
 
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalarParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{1, 1}.setZero());
+
+  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTP.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportVectorParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
+
+  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTP.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportMissingParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  BOOST_TEST_REQUIRE(data->timeStepsStorage().empty());
+  // no sample
+  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTP.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  auto missing = mesh.createData("missing", 2, 0_dataID);
+  BOOST_TEST_REQUIRE(missing->timeStepsStorage().empty());
+  mesh::PtrData data = mesh.createData("data", 2, 1_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
+  // no sample
+  io::ExportVTP exportVTP{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTP.doExport(0, 0.0);
+}
+
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm());
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 {

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -27,7 +27,7 @@ PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalar)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
@@ -35,13 +35,14 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTUExport.init.vtu");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportVector)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
@@ -49,26 +50,28 @@ BOOST_AUTO_TEST_CASE(ExportVector)
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTUExport.init.vtu");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportMissing)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   mesh.createVertex(Eigen::Vector2d::Zero());
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  testing::expectFiles("Mesh-io-VTUExport.init.vtu");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalarParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -79,13 +82,17 @@ BOOST_AUTO_TEST_CASE(ExportScalarParallel)
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init.pvtu");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportVectorParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -96,13 +103,17 @@ BOOST_AUTO_TEST_CASE(ExportVectorParallel)
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init.pvtu");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportMissingParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -113,13 +124,17 @@ BOOST_AUTO_TEST_CASE(ExportMissingParallel)
   // no sample
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init.pvtu");
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
 {
   PRECICE_TEST();
-  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", 2, testing::nextMeshID());
   if (context.isPrimary()) {
     mesh.createVertex(Eigen::Vector2d::Zero());
   } else {
@@ -132,6 +147,10 @@ BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
   // no sample
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init.pvtu");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -141,7 +160,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 
   // Create mesh to map from
   int           dimensions = 2;
-  mesh::Mesh    mesh("ExportDatawithGradient2D", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -163,6 +182,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTUExport.init.vtu", "Mesh-io-VTUExport.dt1.vtu");
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -171,7 +191,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   PRECICE_TEST();
   int dimensions = 3;
   // Create mesh to map from
-  mesh::Mesh    mesh("ExportDatawithGradient3D", dimensions, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dimensions, testing::nextMeshID());
   mesh::PtrData dataScalar = mesh.createData("dataScalar", 1, 0_dataID);
   mesh::PtrData dataVector = mesh.createData("dataVector", dimensions, 1_dataID);
   dataScalar->requireDataGradient();
@@ -193,6 +213,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTUExport.init.vtu", "Mesh-io-VTUExport.dt1.vtu");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -200,7 +221,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
 {
   PRECICE_TEST();
   int           dim = 2;
-  mesh::Mesh    mesh("ExportPolygonalMeshSerial", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, testing::nextMeshID());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::Vertex &v3 = mesh.createVertex(Eigen::Vector2d{1.0, 0.0});
@@ -212,6 +233,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTUExport.init.vtu", "Mesh-io-VTUExport.dt1.vtu");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -219,7 +241,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
 {
   PRECICE_TEST();
   int        dim = 2;
-  mesh::Mesh mesh("ExportPolygonalMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector2d::Zero());
@@ -245,9 +267,20 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
     mesh.createVertex(Eigen::Vector2d::Constant(3.0));
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init_2.vtu",
+      "Mesh-io-VTUExport.init_3.vtu",
+      "Mesh-io-VTUExport.init.pvtu",
+      "Mesh-io-VTUExport.dt1_0.vtu",
+      "Mesh-io-VTUExport.dt1_1.vtu",
+      "Mesh-io-VTUExport.dt1_2.vtu",
+      "Mesh-io-VTUExport.dt1_3.vtu",
+      "Mesh-io-VTUExport.dt1.pvtu");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -255,7 +288,7 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
 {
   PRECICE_TEST();
   int        dim = 3;
-  mesh::Mesh mesh("ExportTriangulatedMesh", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d::Zero());
@@ -284,9 +317,20 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
     mesh.createVertex(Eigen::Vector3d::Constant(3.0));
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init_2.vtu",
+      "Mesh-io-VTUExport.init_3.vtu",
+      "Mesh-io-VTUExport.init.pvtu",
+      "Mesh-io-VTUExport.dt1_0.vtu",
+      "Mesh-io-VTUExport.dt1_1.vtu",
+      "Mesh-io-VTUExport.dt1_2.vtu",
+      "Mesh-io-VTUExport.dt1_3.vtu",
+      "Mesh-io-VTUExport.dt1.pvtu");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -294,7 +338,7 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
 {
   PRECICE_TEST();
   int        dim = 3;
-  mesh::Mesh mesh("ExportSplitSquare", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   mesh::Vertex &vm = mesh.createVertex(Eigen::Vector3d::Zero());
   if (context.isRank(0)) {
@@ -345,9 +389,20 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
     mesh.createTriangle(eo1, e12, e2o);
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init_2.vtu",
+      "Mesh-io-VTUExport.init_3.vtu",
+      "Mesh-io-VTUExport.init.pvtu",
+      "Mesh-io-VTUExport.dt1_0.vtu",
+      "Mesh-io-VTUExport.dt1_1.vtu",
+      "Mesh-io-VTUExport.dt1_2.vtu",
+      "Mesh-io-VTUExport.dt1_3.vtu",
+      "Mesh-io-VTUExport.dt1.pvtu");
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -355,7 +410,7 @@ BOOST_AUTO_TEST_CASE(ExportOneTetrahedron)
 {
   PRECICE_TEST();
   int           dim = 3;
-  mesh::Mesh    mesh("ExportOneTetrahedron", dim, testing::nextMeshID());
+  mesh::Mesh    mesh("Mesh", dim, testing::nextMeshID());
   mesh::Vertex &v0 = mesh.createVertex(Eigen::Vector3d::Zero());
   mesh::Vertex &v1 = mesh.createVertex(Eigen::Vector3d{1.0, 0.0, 0.0});
   mesh::Vertex &v2 = mesh.createVertex(Eigen::Vector3d{0.0, 1.0, 0.0});
@@ -363,9 +418,10 @@ BOOST_AUTO_TEST_CASE(ExportOneTetrahedron)
 
   mesh.createTetrahedron(v0, v1, v2, v3);
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles("Mesh-io-VTUExport.init.vtu", "Mesh-io-VTUExport.dt1.vtu");
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -375,7 +431,7 @@ BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
   // Unit cube is made of 6 tetrahedra. We have 3 ranks with 2 tetra each
   // as well as en empty rank. Empty rank is the 3rd
   int        dim = 3;
-  mesh::Mesh mesh("ExportPartitionedCube", dim, testing::nextMeshID());
+  mesh::Mesh mesh("Mesh", dim, testing::nextMeshID());
 
   if (context.isRank(0)) {
     mesh::Vertex &v000 = mesh.createVertex(Eigen::Vector3d{0.0, 0.0, 0.0});
@@ -408,9 +464,20 @@ BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
     mesh.createTetrahedron(v000, v100, v110, v111);
   }
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, context.rank, context.size};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
+  testing::expectFiles(
+      "Mesh-io-VTUExport.init_0.vtu",
+      "Mesh-io-VTUExport.init_1.vtu",
+      "Mesh-io-VTUExport.init_2.vtu",
+      "Mesh-io-VTUExport.init_3.vtu",
+      "Mesh-io-VTUExport.init.pvtu",
+      "Mesh-io-VTUExport.dt1_0.vtu",
+      "Mesh-io-VTUExport.dt1_1.vtu",
+      "Mesh-io-VTUExport.dt1_2.vtu",
+      "Mesh-io-VTUExport.dt1_3.vtu",
+      "Mesh-io-VTUExport.dt1.pvtu");
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -82,10 +82,11 @@ BOOST_AUTO_TEST_CASE(ExportScalarParallel)
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -103,10 +104,11 @@ BOOST_AUTO_TEST_CASE(ExportVectorParallel)
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -124,10 +126,11 @@ BOOST_AUTO_TEST_CASE(ExportMissingParallel)
   // no sample
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
@@ -147,10 +150,11 @@ BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
   // no sample
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -270,17 +274,11 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMesh)
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init_2.vtu",
-      "Mesh-io-VTUExport.init_3.vtu",
-      "Mesh-io-VTUExport.init.pvtu",
-      "Mesh-io-VTUExport.dt1_0.vtu",
-      "Mesh-io-VTUExport.dt1_1.vtu",
-      "Mesh-io-VTUExport.dt1_2.vtu",
-      "Mesh-io-VTUExport.dt1_3.vtu",
-      "Mesh-io-VTUExport.dt1.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank), fmt::format("Mesh-io-VTUExport.dt1_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu", "Mesh-io-VTUExport.dt1.pvtu");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -320,17 +318,11 @@ BOOST_AUTO_TEST_CASE(ExportTriangulatedMesh)
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init_2.vtu",
-      "Mesh-io-VTUExport.init_3.vtu",
-      "Mesh-io-VTUExport.init.pvtu",
-      "Mesh-io-VTUExport.dt1_0.vtu",
-      "Mesh-io-VTUExport.dt1_1.vtu",
-      "Mesh-io-VTUExport.dt1_2.vtu",
-      "Mesh-io-VTUExport.dt1_3.vtu",
-      "Mesh-io-VTUExport.dt1.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank), fmt::format("Mesh-io-VTUExport.dt1_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu", "Mesh-io-VTUExport.dt1.pvtu");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(4_ranks).setupIntraComm())
@@ -392,17 +384,11 @@ BOOST_AUTO_TEST_CASE(ExportSplitSquare)
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init_2.vtu",
-      "Mesh-io-VTUExport.init_3.vtu",
-      "Mesh-io-VTUExport.init.pvtu",
-      "Mesh-io-VTUExport.dt1_0.vtu",
-      "Mesh-io-VTUExport.dt1_1.vtu",
-      "Mesh-io-VTUExport.dt1_2.vtu",
-      "Mesh-io-VTUExport.dt1_3.vtu",
-      "Mesh-io-VTUExport.dt1.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank), fmt::format("Mesh-io-VTUExport.dt1_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu", "Mesh-io-VTUExport.dt1.pvtu");
+  }
 }
 
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
@@ -467,17 +453,11 @@ BOOST_AUTO_TEST_CASE(ExportPartitionedCube)
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
-  testing::expectFiles(
-      "Mesh-io-VTUExport.init_0.vtu",
-      "Mesh-io-VTUExport.init_1.vtu",
-      "Mesh-io-VTUExport.init_2.vtu",
-      "Mesh-io-VTUExport.init_3.vtu",
-      "Mesh-io-VTUExport.init.pvtu",
-      "Mesh-io-VTUExport.dt1_0.vtu",
-      "Mesh-io-VTUExport.dt1_1.vtu",
-      "Mesh-io-VTUExport.dt1_2.vtu",
-      "Mesh-io-VTUExport.dt1_3.vtu",
-      "Mesh-io-VTUExport.dt1.pvtu");
+
+  testing::expectFiles(fmt::format("Mesh-io-VTUExport.init_{}.vtu", context.rank), fmt::format("Mesh-io-VTUExport.dt1_{}.vtu", context.rank));
+  if (context.isPrimary()) {
+    testing::expectFiles("Mesh-io-VTUExport.init.pvtu", "Mesh-io-VTUExport.dt1.pvtu");
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -64,6 +64,76 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   exportVTU.doExport(0, 0.0);
 }
 
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalarParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportScalarMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{1, 1}.setZero());
+
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTU.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportVectorParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
+
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTU.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportMissingParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
+  BOOST_TEST_REQUIRE(data->timeStepsStorage().empty());
+  // no sample
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTU.doExport(0, 0.0);
+}
+
+PRECICE_TEST_SETUP(""_on(2_ranks).setupIntraComm())
+BOOST_AUTO_TEST_CASE(ExportScalarAndMissingParallel)
+{
+  PRECICE_TEST();
+  mesh::Mesh mesh("ExportVectorMesh", 2, testing::nextMeshID());
+  if (context.isPrimary()) {
+    mesh.createVertex(Eigen::Vector2d::Zero());
+  } else {
+    mesh.createVertex(Eigen::Vector2d::Constant(1));
+  }
+  auto missing = mesh.createData("missing", 2, 0_dataID);
+  BOOST_TEST_REQUIRE(missing->timeStepsStorage().empty());
+  mesh::PtrData data = mesh.createData("data", 2, 1_dataID);
+  data->setSampleAtTime(0, time::Sample{2, 1}.setZero());
+  // no sample
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
+  exportVTU.doExport(0, 0.0);
+}
+
 PRECICE_TEST_SETUP(""_on(1_rank).setupIntraComm())
 BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
 {

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(ExportScalar)
   mesh::PtrData data = mesh.createData("data", 1, 0_dataID);
   data->setSampleAtTime(0, time::Sample{1, 2}.setZero());
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
 }
 
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(ExportVector)
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   data->setSampleAtTime(0, time::Sample{2, 2}.setZero());
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
 }
 
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(ExportMissing)
   mesh.createVertex(Eigen::Vector2d::Constant(1));
   mesh::PtrData data = mesh.createData("data", 2, 0_dataID);
   // no sample
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
 }
 
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   vectorial.gradients.setOnes();
   dataScalar->setSampleAtTime(0, vectorial);
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
 }
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   vectorial.gradients.setOnes();
   dataScalar->setSampleAtTime(0, vectorial);
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
 }
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(ExportPolygonalMeshSerial)
   mesh.createEdge(v2, v3);
   mesh.createEdge(v3, v1);
 
-  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 0, 0, 1};
+  io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
   exportVTU.doExport(1, 1.0);
 }

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -132,4 +132,9 @@ boost::test_tools::predicate_result equals(double a, double b, double tolerance)
   return true;
 }
 
+void expectFile(std::string_view name)
+{
+  BOOST_TEST(std::filesystem::is_regular_file(name), "File " << name << " is not a regular file or doesn't exist.");
+}
+
 } // namespace precice::testing

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -159,6 +159,14 @@ std::optional<TestSetup> getTestSetupFor(const boost::unit_test::test_unit &tu);
  */
 int nextMeshID();
 
+void expectFile(std::string_view name);
+
+template <typename... Args>
+void expectFiles(Args... args)
+{
+  (expectFile(args), ...);
+}
+
 } // namespace precice::testing
 
 using namespace precice::testing::inject;\


### PR DESCRIPTION
## Main changes of this PR

This PR fixes other exporters than VTK (#2131) crashing when exporting a mesh with non-existent data.

The tests now also check for existing output files, which uncovered that most tests weren't exporting anything, making the tests useless.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
