### PR TITLE
Fix backslash at eof

### DIFF
--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -169,4 +169,4 @@ void expectFiles(Args... args)
 
 } // namespace precice::testing
 
-using namespace precice::testing::inject;\
+using namespace precice::testing::inject;


### PR DESCRIPTION
## Main changes of this PR

Fixes the backslash at the end of the testing file.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
