### PR TITLE
Add relative times to profiling analyse

### DIFF
--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -619,14 +619,18 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
         minSecRank = rankAdvance.select(pl.first("rank")).item()
         maxSecRank = rankAdvance.select(pl.last("rank")).item()
 
-        ranksToPrint = (
-            (0, minSecRank) if minSecRank == maxSecRank else (0, minSecRank, maxSecRank)
-        )
-        if len(ranksToPrint) == 2:
+        if minSecRank is None or maxSecRank is None:
+            ranksToPrint = (0,)
+            print(
+                "Selection only contains the primary rank 0 as event isn't available on secondary ranks."
+            )
+        elif minSecRank == maxSecRank:
+            ranksToPrint = (0, minSecRank)
             print(
                 f"Selection contains the primary rank 0 and secondary rank {minSecRank}."
             )
         else:
+            ranksToPrint = (0, minSecRank, maxSecRank)
             print(
                 f"Selection contains the primary rank 0, the cheapest secondary rank {minSecRank}, and the most expensive secondary rank {maxSecRank}."
             )

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -84,51 +84,73 @@ def printWide(df):
         parts = eventName.split("/")
         return indentation * len(parts) + parts[-1]
 
-    df = (
+    df: pl.DataFrame = (
         df.sort("eid")
         .with_columns(pl.col("eid").map_elements(makeLabel, return_dtype=pl.String))
         .rename({"eid": "name"})
     )
 
-    mincolwidth = 8
+    blocksize = 6
+    assert len(df.columns) % blocksize == 1
 
-    def formattedLength(s):
-        return len("{:}".format(s))
+    headerFmts = []
+    bodyFmts = []
+    colWidths = []
+    for col in df.iter_columns():
+        headerWidth = len(col.name.encode())
 
-    headerWidths = tuple(map(formattedLength, df.columns))
-    bodyWidths = tuple(
-        df.select(pl.all().map_elements(formattedLength, return_dtype=pl.Int64))
-        .max()
-        .row(0)
-    )
-    assert len(headerWidths) == len(bodyWidths)
-    colwidths = list(map(max, zip(headerWidths, bodyWidths, repeat(mincolwidth))))
-    colaligns = ["<"] + [">"] * (len(df.columns) - 1)
+        def fmt(d):
+            if col.dtype == pl.Float32 or col.dtype == pl.Float64:
+                return len(f"{d:.2f}")
+            else:
+                return len(f"{d}")
 
-    colfmts = ["{:" + a + str(w) + "}" for w, a in zip(colwidths, colaligns)]
+        width = col.map_elements(fmt, return_dtype=pl.Int64).max()
+        width = max(width, headerWidth)
+        colWidths.append(width)
+        sw = str(width)
 
-    rowfmt = colfmts[0]
+        headerFmts.append("{:<" + sw + "}")
 
-    # Measurements always come in batches of 5
-    def batched(iterable):
-        from itertools import islice
+        if col.dtype == pl.Float32 or col.dtype == pl.Float64:
+            bodyFmts.append("{:>" + sw + ".2f}")
+        elif col.dtype == pl.String:
+            bodyFmts.append("{:<" + sw + "}")
+        else:
+            bodyFmts.append("{:>" + sw + "}")
 
-        iterator = iter(iterable)
-        while batch := tuple(islice(iterator, 6)):
-            yield batch
+    headerFmt = ""
+    hline = ""
+    bodyFmt = ""
 
-    fmts = iter(colfmts[1:])
-    for batch in batched(fmts):
-        rowfmt += " │ " + " ".join(batch)
+    for col, (h, b, w) in enumerate(zip(headerFmts, bodyFmts, colWidths)):
+        if col % blocksize == 1:
+            headerFmt += " │ "
+        else:
+            headerFmt += " "
+        headerFmt += h
 
-    hline = "─" * colwidths[0]
-    for b in batched(colwidths[1:]):
-        hline += "─┼─" + "─" * (sum(b) + len(b) - 1)
+        if col % blocksize == 1:
+            hline += "─┼─"
+        else:
+            hline += " "
 
-    print(rowfmt.format(*(df.columns)))
+        hline += "─" * w
+
+        if col % blocksize == 1:
+            bodyFmt += " │ "
+        else:
+            bodyFmt += " "
+        bodyFmt += b
+
+    print(headerFmt.format(*(df.columns)))
     print(hline)
     for row in df.iter_rows():
-        print(rowfmt.format(*map(lambda e: "" if e is None else e, row)))
+        print(
+            bodyFmt.format(
+                *map(lambda e: float("nan") if e is None else e, row)
+            ).replace("nan", "   ")
+        )
 
 
 @functools.lru_cache

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -114,7 +114,7 @@ def printWide(df):
         from itertools import islice
 
         iterator = iter(iterable)
-        while batch := tuple(islice(iterator, 5)):
+        while batch := tuple(islice(iterator, 6)):
             yield batch
 
     fmts = iter(colfmts[1:])
@@ -564,7 +564,10 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
     df = (
         df.filter(pl.col("participant") == participant)
         .drop("participant")
-        .with_columns(pl.col("dur") * dur_factor)
+        .with_columns(
+            (pl.col("dur") * dur_factor),
+            (pl.col("dur") / pl.col("dur").max().over(["rank"]) * 100).alias("rel"),
+        )
     )
 
     ranks = df.select("rank").unique()
@@ -574,6 +577,7 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
             df.group_by("eid")
             .agg(
                 pl.sum("dur").alias("sum"),
+                pl.sum("rel").alias("%"),
                 pl.count("dur").alias("count"),
                 pl.mean("dur").alias("mean"),
                 pl.min("dur").alias("min"),
@@ -614,6 +618,7 @@ def analyzeCommand(profilingfile, participant, event, outfile=None, unit="us"):
                         .group_by("eid")
                         .agg(
                             pl.sum("dur").alias(f"R{rank}:sum"),
+                            pl.sum("rel").alias(f"R{rank}:%"),
                             pl.count("dur").alias(f"R{rank}:count"),
                             pl.mean("dur").alias(f"R{rank}:mean"),
                             pl.min("dur").alias(f"R{rank}:min"),


### PR DESCRIPTION
## Main changes of this PR

This PR adds relative times to the output of `precice-profiling analyze` and limits the output format to 2 decimal places.

Parallel participants use per-rank total times as reference.

## Motivation and additional information

Closes #1988 
Closes #2048

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
