### PR TITLE
Release preCICE using annotated tags

### DIFF
--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -9,7 +9,7 @@ Only the release manager should update this post (even tickboxes, due to race co
 ## Pre-PR steps
 
 * [ ] Look over [PRs](https://github.com/precice/precice/pulls?q=is%3Apr+no%3Amilestone+is%3Aclosed) and [Issues](https://github.com/precice/precice/issues?q=is%3Aissue+no%3Amilestone+is%3Aclosed) without an assigned version. (all)
-* [ ] Look over entries in [`docs/changelog`](https://github.com/precice/precice/blob/develop/docs/changelog)) (all)
+* [ ] Look over entries in [`docs/changelog`](https://github.com/precice/precice/blob/develop/docs/changelog) (all)
    * Add missing entries, if necessary
    * Fix wording and tense
 * [ ] Make sure you have the latest `develop` and `main` branches locally.
@@ -51,7 +51,7 @@ Only the release manager should update this post (even tickboxes, due to race co
       * `_data/sidebars/docs_sidebar.yml`
 * [ ] Approve the PR with at least two reviews (all)
 * [ ] Merge PR to `main` ( use `git merge --no-ff release-vX.Y.Z` )
-* [ ] Tag release on `main` `vX.Y.Z` and verify by running `git describe --tags`
+* [ ] Create an annotated tag on `main` using `git tag -a vX.Y.Z -m "preCICE version vX.Y.Z"` and verify by running `git describe --tags`
 * [ ] Merge back to `develop` and verify by running `git describe --tags`
 * [ ] Triple check that you haven't messed anything up. (You can always discard local changes)
 * [ ] Push `main` and push the `vX.Y.Z` tag


### PR DESCRIPTION
Annotated tags include metadata (message, author, timestamp) that tools like [Software Heritage](https://docs.softwareheritage.org/user/faq/index.html#i-cannot-find-all-my-releases-in-a-git-repository-archived-in-software-heritage-what-should-i-do) rely on for properly displaying and recognizing "releases". Software heritage is an additional archiving platform typically encouraged to use by Darus. preCICE is already there, but the releases are currently not picked-up, so it would be advantageous to have the preCICE releases there by default.
