### PR TITLE
Cleanup logging includes

### DIFF
--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -1,25 +1,26 @@
-#include "LogConfiguration.hpp"
+#include "logging/LogConfiguration.hpp"
+#include "utils/assertion.hpp"
+
 #include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <string>
+#include <utility>
+
 #include <boost/core/null_deleter.hpp>
 #include <boost/log/attributes/mutable_constant.hpp>
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/sinks/sink.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_ostream_backend.hpp>
 #include <boost/log/support/date_time.hpp>
 #include <boost/log/trivial.hpp>
-#include <boost/log/utility/setup/console.hpp>
+#include <boost/log/utility/setup/filter_parser.hpp>
+#include <boost/log/utility/setup/formatter_parser.hpp>
 #include <boost/program_options.hpp>
-#include <deque>
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include <iterator>
-#include <map>
-#include <sstream>
-#include <string>
-#include <utility>
-#include "utils/String.hpp"
-#include "utils/assertion.hpp"
 
 namespace precice::logging {
 

--- a/src/logging/LogConfiguration.hpp
+++ b/src/logging/LogConfiguration.hpp
@@ -3,8 +3,7 @@
 #include <string>
 #include <vector>
 
-namespace precice {
-namespace logging {
+namespace precice::logging {
 
 /// Holds the configuration for one logging backend (sink) and takes care of default values.
 struct BackendConfiguration {
@@ -63,5 +62,4 @@ struct GlobalLoggingConfig {
 /// Returns the global logging configuration
 GlobalLoggingConfig &getGlobalLoggingConfig();
 
-} // namespace logging
-} // namespace precice
+} // namespace precice::logging

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -1,15 +1,15 @@
+#include <boost/log/attributes/clock.hpp>
 #include <boost/log/attributes/constant.hpp>
 #include <boost/log/attributes/function.hpp>
 #include <boost/log/attributes/named_scope.hpp>
 #include <boost/log/attributes/timer.hpp>
 #include <boost/log/sources/severity_feature.hpp>
 #include <boost/log/trivial.hpp>
-#include <boost/log/utility/setup/common_attributes.hpp>
 #include <utility>
-#include <utils/assertion.hpp>
 
 #include "logging/LogConfiguration.hpp"
 #include "logging/Logger.hpp"
+#include "utils/assertion.hpp"
 
 namespace precice::logging {
 

--- a/src/logging/Tracer.cpp
+++ b/src/logging/Tracer.cpp
@@ -1,7 +1,7 @@
-#include "Tracer.hpp"
 #include <string>
 #include <utility>
-#include "logging/Logger.hpp"
+
+#include "logging/Tracer.hpp"
 
 namespace precice::logging {
 

--- a/src/logging/Tracer.hpp
+++ b/src/logging/Tracer.hpp
@@ -1,8 +1,9 @@
 #pragma once
-#include "Logger.hpp"
 
-namespace precice {
-namespace logging {
+#include "logging/Logger.hpp"
+
+namespace precice::logging {
+
 class Logger;
 struct LogLocation;
 
@@ -17,5 +18,4 @@ private:
   LogLocation _loc;
 };
 
-} // namespace logging
-} // namespace precice
+} // namespace precice::logging

--- a/src/logging/config/LogConfiguration.cpp
+++ b/src/logging/config/LogConfiguration.cpp
@@ -1,4 +1,4 @@
-#include "LogConfiguration.hpp"
+#include "logging/LogConfiguration.hpp"
 #include "logging/LogMacros.hpp"
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLAttribute.hpp"

--- a/src/logging/config/LogConfiguration.cpp
+++ b/src/logging/config/LogConfiguration.cpp
@@ -1,9 +1,9 @@
-#include "logging/LogConfiguration.hpp"
+#include "logging/config/LogConfiguration.hpp"
 #include "logging/LogMacros.hpp"
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLAttribute.hpp"
 
-namespace precice::config {
+namespace precice::logging {
 
 LogConfiguration::LogConfiguration(
     xml::XMLTag &parent)
@@ -81,4 +81,4 @@ void LogConfiguration::xmlEndTagCallback(
     precice::logging::setupLogging(_logconfig, tag.getBooleanAttributeValue("enabled"));
 }
 
-} // namespace precice::config
+} // namespace precice::logging

--- a/src/logging/config/LogConfiguration.hpp
+++ b/src/logging/config/LogConfiguration.hpp
@@ -1,12 +1,10 @@
 #pragma once
 
-#include <string>
 #include "logging/LogConfiguration.hpp"
 #include "logging/Logger.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace config {
+namespace precice::logging {
 
 /// Configures the log config file to use
 class LogConfiguration : public xml::XMLTag::Listener {
@@ -23,5 +21,4 @@ private:
   precice::logging::LoggingConfiguration _logconfig;
 };
 
-} // namespace config
-} // namespace precice
+} // namespace precice::logging

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -130,7 +130,7 @@ private:
   xml::XMLTag _tag;
 
   // The log configuration must be constructed first to prevent log clutter
-  LogConfiguration _logConfig;
+  logging::LogConfiguration _logConfig;
 
   // Handle other configuration afterwards
   precice::profiling::ProfilingConfiguration _profilingConfig;


### PR DESCRIPTION
## Main changes of this PR

This PR cleans up the includes in the logging part of preCICE.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
