### PR TITLE
Compatibility with boost asio 1.86

### DIFF
--- a/docs/changelog/2158.md
+++ b/docs/changelog/2158.md
@@ -1,0 +1,1 @@
+- Updated boost asio interface for compatibility with boost 1.86.

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -27,7 +27,7 @@ SocketCommunication::SocketCommunication(unsigned short portNumber,
       _reuseAddress(reuseAddress),
       _networkName(std::move(networkName)),
       _addressDirectory(std::move(addressDirectory)),
-      _ioContext(new IOService)
+      _ioContext(new IOContext)
 {
   if (_addressDirectory.empty()) {
     _addressDirectory = ".";

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -128,10 +128,9 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
     PRECICE_ERROR("Accepting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
-  // NOTE:
-  // Keep IO service running so that it fires asynchronous handlers from another thread.
-  _work   = std::make_shared<asio::io_context::work>(*_ioContext);
-  _thread = std::thread([this] { _ioContext->run(); });
+  // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
+  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _thread    = std::thread([this] { _ioContext->run(); });
 }
 
 void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorName,
@@ -192,9 +191,9 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
     PRECICE_ERROR("Accepting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
-  // NOTE: Keep IO service running so that it fires asynchronous handlers from another thread.
-  _work   = std::make_shared<asio::io_context::work>(*_ioContext);
-  _thread = std::thread([this] { _ioContext->run(); });
+  // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
+  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _thread    = std::thread([this] { _ioContext->run(); });
 }
 
 void SocketCommunication::requestConnection(std::string const &acceptorName,
@@ -251,9 +250,9 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
     PRECICE_ERROR("Requesting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
-  // NOTE: Keep IO service running so that it fires asynchronous handlers from another thread.
-  _work   = std::make_shared<asio::io_context::work>(*_ioContext);
-  _thread = std::thread([this] { _ioContext->run(); });
+  // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
+  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _thread    = std::thread([this] { _ioContext->run(); });
 }
 
 void SocketCommunication::requestConnectionAsClient(std::string const &  acceptorName,
@@ -308,9 +307,9 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
       PRECICE_ERROR("Requesting a socket connection at {} failed with the system error: {}", address, e.what());
     }
   }
-  // NOTE: Keep IO service running so that it fires asynchronous handlers from another thread.
-  _work   = std::make_shared<asio::io_context::work>(*_ioContext);
-  _thread = std::thread([this] { _ioContext->run(); });
+  // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
+  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _thread    = std::thread([this] { _ioContext->run(); });
 }
 
 void SocketCommunication::closeConnection()
@@ -321,7 +320,7 @@ void SocketCommunication::closeConnection()
     return;
 
   if (_thread.joinable()) {
-    _work.reset();
+    _workGuard.reset();
     _ioContext->stop();
     _thread.join();
   }

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -283,11 +283,10 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
 
       while (not isConnected()) {
         tcp::resolver resolver(*_ioContext);
-        auto          results = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
+        auto          endpoints = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
 
-        auto                      endpoint_iterator = results.begin();
-        boost::system::error_code error             = asio::error::host_not_found;
-        boost::asio::connect(*socket, std::move(endpoint_iterator), error);
+        boost::system::error_code error = asio::error::host_not_found;
+        boost::asio::connect(*socket, endpoints, error);
 
         _isConnected = not error;
 

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -129,7 +129,7 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
   }
 
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
-  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
 }
 
@@ -192,7 +192,7 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
   }
 
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
-  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
 }
 
@@ -251,7 +251,7 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
   }
 
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
-  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
 }
 
@@ -308,7 +308,7 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
     }
   }
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
-  _workGuard = std::make_shared<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
 }
 

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -218,12 +218,12 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
 
     using asio::ip::tcp;
 
-    tcp::resolver::query query(tcp::v4(), ipAddress, portNumber, tcp::resolver::query::numeric_host);
-
     while (not isConnected()) {
-      tcp::resolver                resolver(*_ioContext);
-      tcp::resolver::endpoint_type endpoint = *(resolver.resolve(query));
-      boost::system::error_code    error    = asio::error::host_not_found;
+      tcp::resolver resolver(*_ioContext);
+      auto          results = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
+
+      auto                      endpoint = results.begin()->endpoint();
+      boost::system::error_code error    = asio::error::host_not_found;
       socket->connect(endpoint, error);
 
       _isConnected = not error;
@@ -281,11 +281,11 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
 
       PRECICE_DEBUG("Requesting connection to {}, port {}", ipAddress, portNumber);
 
-      tcp::resolver::query query(tcp::v4(), ipAddress, portNumber, tcp::resolver::query::numeric_host);
-
       while (not isConnected()) {
-        tcp::resolver             resolver(*_ioContext);
-        tcp::resolver::iterator   endpoint_iterator = resolver.resolve(query);
+        tcp::resolver resolver(*_ioContext);
+        auto          results = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
+
+        auto                      endpoint_iterator = results.begin();
         boost::system::error_code error             = asio::error::host_not_found;
         boost::asio::connect(*socket, std::move(endpoint_iterator), error);
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -146,7 +146,7 @@ private:
   using WorkGuard = boost::asio::executor_work_guard<IOContext::executor_type>;
 
   std::shared_ptr<IOContext> _ioContext;
-  std::shared_ptr<WorkGuard> _workGuard;
+  std::unique_ptr<WorkGuard> _workGuard;
   std::thread                _thread;
 
   /// Remote rank -> socket map

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -141,11 +141,11 @@ private:
   /// Directory where IP address is exchanged by file.
   std::string _addressDirectory;
 
-  using IOService = boost::asio::io_service;
+  using IOContext = boost::asio::io_context;
   using Socket    = boost::asio::ip::tcp::socket;
-  using Work      = boost::asio::io_service::work;
+  using Work      = boost::asio::io_context::work;
 
-  std::shared_ptr<IOService> _ioService;
+  std::shared_ptr<IOContext> _ioContext;
   std::shared_ptr<Work>      _work;
   std::thread                _thread;
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -143,10 +143,10 @@ private:
 
   using IOContext = boost::asio::io_context;
   using Socket    = boost::asio::ip::tcp::socket;
-  using Work      = boost::asio::io_context::work;
+  using WorkGuard = boost::asio::executor_work_guard<IOContext::executor_type>;
 
   std::shared_ptr<IOContext> _ioContext;
-  std::shared_ptr<Work>      _work;
+  std::shared_ptr<WorkGuard> _workGuard;
   std::thread                _thread;
 
   /// Remote rank -> socket map

--- a/src/com/SocketSendQueue.cpp
+++ b/src/com/SocketSendQueue.cpp
@@ -18,9 +18,9 @@ SocketSendQueue::~SocketSendQueue()
                                      "Make sure it always outlives all the requests pushed onto it.");
 }
 
-void SocketSendQueue::dispatch(std::shared_ptr<Socket>      sock,
-                               boost::asio::const_buffers_1 data,
-                               std::function<void()>        callback)
+void SocketSendQueue::dispatch(std::shared_ptr<Socket>   sock,
+                               boost::asio::const_buffer data,
+                               std::function<void()>     callback)
 {
   std::lock_guard<std::mutex> lock(_queueMutex);
   _itemQueue.push_back({std::move(sock), std::move(data), std::move(callback)});

--- a/src/com/SocketSendQueue.hpp
+++ b/src/com/SocketSendQueue.hpp
@@ -24,7 +24,7 @@ public:
   SocketSendQueue &operator=(SocketSendQueue const &) = delete;
 
   /// Put data in the queue, start processing the queue.
-  void dispatch(std::shared_ptr<Socket> sock, boost::asio::const_buffers_1 data, std::function<void()> callback);
+  void dispatch(std::shared_ptr<Socket> sock, boost::asio::const_buffer data, std::function<void()> callback);
 
   /// Notifies the queue that the last asynchronous send operation has completed.
   void sendCompleted();
@@ -34,9 +34,9 @@ private:
   void process();
 
   struct SendItem {
-    std::shared_ptr<Socket>      sock;
-    boost::asio::const_buffers_1 data;
-    std::function<void()>        callback;
+    std::shared_ptr<Socket>   sock;
+    boost::asio::const_buffer data;
+    std::function<void()>     callback;
   };
 
   /// The queue, containing items to asynchronously send using boost.asio.


### PR DESCRIPTION
## Main changes of this PR

Compatibility with boost 1.86

## Motivation and additional information

Our macOS CI/brew installs now boost 1.86 which now seems to no longer have the deprecated buffers1

https://www.boost.org/doc/libs/1_85_0/doc/html/boost_asio/reference/const_buffers_1.html

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
