### PR TITLE
Add test for subcycling in  Aitken accleration

### DIFF
--- a/docs/changelog/2163.md
+++ b/docs/changelog/2163.md
@@ -1,0 +1,1 @@
+- Added support for waveform iterations in Aitken acceleration

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -38,10 +38,6 @@ AitkenAcceleration::AitkenAcceleration(double                  initialRelaxation
 void AitkenAcceleration::initialize(const DataMap &cplData)
 {
   checkDataIDs(cplData);
-  for (const auto &data : cplData | boost::adaptors::map_values) {
-    PRECICE_CHECK(!data->exchangeSubsteps(),
-                  "Aitken acceleration does not yet support using data from all substeps. Please set substeps=\"false\" in the exchange tag of data \"{}\".", data->getDataName());
-  }
 
   // Accumulate number of entries
   // Size for each subvector needed for preconditioner

--- a/tests/serial/aitken/WithSubsteps.cpp
+++ b/tests/serial/aitken/WithSubsteps.cpp
@@ -1,0 +1,126 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Aitken)
+PRECICE_TEST_SETUP("A"_on(1_rank), "B"_on(1_rank))
+BOOST_AUTO_TEST_CASE(WithSubsteps)
+{
+  PRECICE_TEST();
+
+  using Eigen::Vector2d;
+
+  std::string meshName, writeDataName, readDataName;
+
+  if (context.isNamed("A")) {
+    meshName      = "A-Mesh";
+    writeDataName = "Data";
+    readDataName  = "Data2";
+  } else {
+    BOOST_REQUIRE(context.isNamed("B"));
+    meshName      = "B-Mesh";
+    writeDataName = "Data2";
+    readDataName  = "Data";
+  }
+
+  precice::Participant interface(context.name, context.config(), context.rank, context.size);
+  VertexID             vertexIDs[2];
+
+  // meshes for rank 0 and rank 1, we use matching meshes for both participants
+  double positions0[4] = {1.0, 0.0, 1.0, 0.5};
+  double positions1[4] = {2.0, 0.0, 2.0, 1.0};
+
+  if (context.isNamed("A")) {
+    if (context.isPrimary()) {
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
+    } else {
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
+    }
+  } else {
+    BOOST_REQUIRE(context.isNamed("B"));
+    if (not context.isPrimary()) {
+      interface.setMeshVertices(meshName, positions0, vertexIDs);
+    } else {
+      interface.setMeshVertices(meshName, positions1, vertexIDs);
+    }
+  }
+
+  int             nSubsteps = 5;             // perform subcycling on solvers. 5 steps happen in each window.
+  Eigen::MatrixXd savedValues(nSubsteps, 2); // save the solution to check for correctness after it has converged
+
+  interface.initialize();
+  double maxDt         = interface.getMaxTimeStepSize();
+  double inValues[2]   = {0.0, 0.0};
+  double outValues[2]  = {0.0, 0.0};
+  double dt            = maxDt / nSubsteps; //Do 5 substeps to check if QN and Waveform iterations work together
+  int    nSubStepsDone = 0;                 // Counts the number of substeps that are done
+  double t             = 0;
+  int    iterations    = 0;
+  double timeCheckpoint;
+  while (interface.isCouplingOngoing()) {
+
+    if (interface.requiresWritingCheckpoint()) {
+      timeCheckpoint = t;
+      iterations     = 0;
+      nSubStepsDone  = 0;
+    }
+
+    interface.readData(meshName, readDataName, {vertexIDs, 2}, dt, {inValues, 2});
+
+    /*
+      Solves the following linear system
+      2*x1 + x2 = t**2
+      -x1 + x2 = t
+      Analytical solutions are x1 = 1/3*(t**2 - t) and x2 = 1/3*(t**2 + 2*t).
+    */
+
+    if (context.isNamed("A")) {
+      for (int i = 0; i < 2; i++) {
+        outValues[i] = inValues[i]; //only pushes solution through
+      }
+    } else {
+      outValues[0] = (-inValues[0] - inValues[1] + t * t);
+      outValues[1] = inValues[0] + t;
+    }
+
+    // save the outValues in savedValues to check for correctness later
+    savedValues(nSubStepsDone, 0) = outValues[0];
+    savedValues(nSubStepsDone, 1) = outValues[1];
+
+    interface.writeData(meshName, writeDataName, {vertexIDs, 2}, {outValues, 2});
+
+    nSubStepsDone += 1;
+    t += dt;
+
+    interface.advance(dt);
+    maxDt = interface.getMaxTimeStepSize();
+    dt    = dt > maxDt ? maxDt : dt;
+
+    if (interface.requiresReadingCheckpoint()) {
+      nSubStepsDone = 0;
+      t             = timeCheckpoint;
+      iterations++;
+    }
+  }
+  interface.finalize();
+
+  // Check that the last time window has converged to the analytical solution
+  auto analyticalSolution = [](double localTime) { return std::vector<double>{(localTime * localTime - localTime) / 3, (localTime * localTime + 2 * localTime) / 3}; };
+  for (int i = 0; i < nSubsteps; i++) {
+    // scaling with the time window length which is equal to 1
+    double localTime = (1.0 * i) / nSubStepsDone + timeCheckpoint;
+    BOOST_TEST(math::equals(savedValues(i, 0), analyticalSolution(localTime)[0], 1e-10));
+    BOOST_TEST(math::equals(savedValues(i, 1), analyticalSolution(localTime)[1], 1e-10));
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Aitken
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/aitken/WithSubsteps.xml
+++ b/tests/serial/aitken/WithSubsteps.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data" waveform-degree="2" />
+  <data:scalar name="Data2" waveform-degree="2" />
+
+  <mesh name="A-Mesh" dimensions="2">
+    <use-data name="Data" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="B-Mesh" dimensions="2">
+    <use-data name="Data" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="A">
+    <provide-mesh name="A-Mesh" />
+    <receive-mesh name="B-Mesh" from="B" />
+    <read-data name="Data2" mesh="A-Mesh" />
+    <write-data name="Data" mesh="A-Mesh" />
+    <mapping:nearest-neighbor direction="write" from="A-Mesh" to="B-Mesh" constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="B-Mesh"
+      to="A-Mesh"
+      constraint="conservative" />
+  </participant>
+
+  <participant name="B">
+    <provide-mesh name="B-Mesh" />
+    <read-data name="Data" mesh="B-Mesh" />
+    <write-data name="Data2" mesh="B-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="B" connector="A" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="B" second="A" />
+    <max-time value="1.0" />
+    <time-window-size value="1.0" />
+    <exchange data="Data" mesh="B-Mesh" from="A" to="B" substeps="true" />
+    <exchange data="Data2" mesh="B-Mesh" from="B" to="A" substeps="true" />
+    <max-iterations value="100" />
+    <relative-convergence-measure limit="1.0e-10" data="Data" mesh="B-Mesh" />
+    <acceleration:aitken>
+      <data mesh="B-Mesh" name="Data" />
+      <initial-relaxation value="0.1" />
+    </acceleration:aitken>
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -188,6 +188,7 @@ target_sources(testprecice
     tests/serial/action-timings/ActionTimingsSerialImplicit.cpp
     tests/serial/aitken/DefaultInitialRelaxation.cpp
     tests/serial/aitken/DefinedInitialRelaxation.cpp
+    tests/serial/aitken/WithSubsteps.cpp
     tests/serial/circular/Explicit.cpp
     tests/serial/circular/helper.hpp
     tests/serial/compositional/OneActivatedMuscle.cpp


### PR DESCRIPTION
## Main changes of this PR
Allow subcycling and waveform iteration in Aitken acceleration.

## Motivation and additional information
Closes part of #1825 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
