### PR TITLE
Force kebab style for XML Attributes and Namespaces

### DIFF
--- a/src/utils/String.cpp
+++ b/src/utils/String.cpp
@@ -2,6 +2,7 @@
 #include <Eigen/Dense>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <memory>
+#include <regex>
 #include <vector>
 #include "boost/algorithm/string/classification.hpp"
 #include "boost/algorithm/string/split.hpp"
@@ -97,6 +98,12 @@ std::size_t editDistance(std::string_view s1, std::string_view s2)
   }
 
   return distances(len1, len2);
+}
+
+bool isKebabStyle(std::string_view sv)
+{
+  std::regex kebabCaseRegex("^[a-z0-9]+(-[a-z0-9]+)*$");
+  return sv.empty() || std::regex_match(sv.begin(), sv.end(), kebabCaseRegex);
 }
 
 } // namespace precice::utils

--- a/src/utils/String.hpp
+++ b/src/utils/String.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace precice {
@@ -103,6 +104,8 @@ std::vector<StringMatch> computeMatches(std::string_view given, const Container 
   std::sort(entries.begin(), entries.end());
   return entries;
 }
+
+bool isKebabStyle(std::string_view sv);
 
 } // namespace utils
 } // namespace precice

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 #include "logging/Logger.hpp"
+#include "utils/String.hpp"
 #include "utils/assertion.hpp"
 #include "xml/ValueParser.hpp"
 
@@ -24,10 +25,16 @@ public:
   XMLAttribute() = delete;
 
   explicit XMLAttribute(std::string name)
-      : _name(std::move(name)){};
+      : _name(std::move(name))
+  {
+    PRECICE_ASSERT(utils::isKebabStyle(_name), _name);
+  };
 
   XMLAttribute(std::string name, ATTRIBUTE_T defaultValue)
-      : _name(std::move(name)), _hasDefaultValue(true), _defaultValue(std::move(defaultValue)){};
+      : _name(std::move(name)), _hasDefaultValue(true), _defaultValue(std::move(defaultValue))
+  {
+    PRECICE_ASSERT(utils::isKebabStyle(_name), _name);
+  };
 
   XMLAttribute(const XMLAttribute<ATTRIBUTE_T> &other) = default;
 

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -2,6 +2,7 @@
 #include <Eigen/Core>
 #include <utility>
 #include "logging/LogMacros.hpp"
+#include "utils/String.hpp"
 #include "utils/assertion.hpp"
 #include "xml/ConfigParser.hpp"
 
@@ -17,6 +18,7 @@ XMLTag::XMLTag(
       _namespace(std::move(xmlNamespace)),
       _occurrence(occurrence)
 {
+  PRECICE_ASSERT(utils::isKebabStyle(_namespace), _namespace);
   if (not _namespace.empty()) {
     _fullName = _namespace + ":" + _name;
   } else {


### PR DESCRIPTION
## Main changes of this PR

This PR enforces kebab-style for XML attributes and XML Tag namespaces

## Motivation and additional information

Closes #2164

This is currently not possible for `XMLTag` names due to the `IQN-` variants using upper-case

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
