### PR TITLE
Silence Ginkgo OpenMP bind warning in tests

### DIFF
--- a/cmake/discover_tests.cmake
+++ b/cmake/discover_tests.cmake
@@ -75,7 +75,7 @@ function(add_test NAME RANKS)
   add_command(set_tests_properties
     "[=[precice.${NAME}]=]"
     PROPERTIES
-    ENVIRONMENT "OMP_NUM_THREADS=2"
+    ENVIRONMENT "OMP_NUM_THREADS=2\;OMP_PROC_BIND=false"
     TIMEOUT "30"
     WORKING_DIRECTORY "${test_dir}"
     LABELS "${labels}"


### PR DESCRIPTION
## Main changes of this PR

This PR explicitly sets the OpenMP procs to unbound in tests. This silences a performance-related warning from ginkgo.

## Motivation and additional information


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
