### PR TITLE
Fix ginkgo mapping executor selection

### DIFF
--- a/docs/changelog/2169.md
+++ b/docs/changelog/2169.md
@@ -1,0 +1,1 @@
+- Added support for Kokkos configured with parallel host and device executors.

--- a/src/mapping/GinkgoRadialBasisFctSolver.hpp
+++ b/src/mapping/GinkgoRadialBasisFctSolver.hpp
@@ -282,8 +282,8 @@ GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::GinkgoRadialBasisFctSolver(
     _matrixV->fill(0.0);
 
     precice::profiling::Event _assemblyEvent{"map.rbf.ginkgo.assembleMatrices"};
-    kernel::fill_polynomial_matrix(_deviceExecutor, _matrixQ, dInputVertices, separatePolyParams);
-    kernel::fill_polynomial_matrix(_deviceExecutor, _matrixV, dOutputVertices, separatePolyParams);
+    kernel::fill_polynomial_matrix(_deviceExecutor, _ginkgoParameter.enableUnifiedMemory, _matrixQ, dInputVertices, separatePolyParams);
+    kernel::fill_polynomial_matrix(_deviceExecutor, _ginkgoParameter.enableUnifiedMemory, _matrixV, dOutputVertices, separatePolyParams);
     _assemblyEvent.stop();
 
     _deviceExecutor->synchronize();
@@ -315,14 +315,14 @@ GinkgoRadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::GinkgoRadialBasisFctSolver(
   // Launch RBF fill kernel on device
   precice::profiling::Event _assemblyEvent{"map.rbf.ginkgo.assembleMatrices"};
   precice::profiling::Event systemMatrixAssemblyEvent{"map.rbf.ginkgo.assembleSystemMatrix"};
-  kernel::create_rbf_system_matrix(_deviceExecutor, _rbfSystemMatrix, activeAxis, dInputVertices, dInputVertices, basisFunction,
+  kernel::create_rbf_system_matrix(_deviceExecutor, _ginkgoParameter.enableUnifiedMemory, _rbfSystemMatrix, activeAxis, dInputVertices, dInputVertices, basisFunction,
                                    basisFunction.getFunctionParameters(), Polynomial::ON == polynomial,
                                    polyparams); // polynomial evaluates to true only if ON is set
   _deviceExecutor->synchronize();
   systemMatrixAssemblyEvent.stop();
 
   precice::profiling::Event outputMatrixAssemblyEvent{"map.rbf.ginkgo.assembleOutputMatrix"};
-  kernel::create_rbf_system_matrix(_deviceExecutor, _matrixA, activeAxis, dInputVertices, dOutputVertices, basisFunction,
+  kernel::create_rbf_system_matrix(_deviceExecutor, _ginkgoParameter.enableUnifiedMemory, _matrixA, activeAxis, dInputVertices, dOutputVertices, basisFunction,
                                    basisFunction.getFunctionParameters(), Polynomial::ON == polynomial, polyparams);
 
   // Wait for the kernels to finish

--- a/src/mapping/device/GinkgoRBFKernels.cpp
+++ b/src/mapping/device/GinkgoRBFKernels.cpp
@@ -20,17 +20,17 @@ std::shared_ptr<gko::Executor> create_device_executor(const std::string &execNam
     return gko::ext::kokkos::create_executor(Kokkos::Serial{});
   }
 #endif
-#ifdef KOKKOS_ENABLE_OPENMP
+#ifdef PRECICE_WITH_OPENMP
   if (execName == "omp-executor") {
     return gko::ext::kokkos::create_executor(Kokkos::OpenMP{});
   }
 #endif
-#ifdef KOKKOS_ENABLE_CUDA
+#ifdef PRECICE_WITH_CUDA
   if (execName == "cuda-executor") {
     return gko::ext::kokkos::create_executor(Kokkos::Cuda{});
   }
 #endif
-#ifdef KOKKOS_ENABLE_HIP
+#ifdef PRECICE_WITH_HIP
   if (execName == "hip-executor") {
     return gko::ext::kokkos::create_executor(Kokkos::HIP{});
   }
@@ -124,19 +124,19 @@ void create_rbf_system_matrix(std::shared_ptr<const gko::Executor>      exec,
     return;
   }
 #endif
-#ifdef KOKKOS_ENABLE_OPENMP
+#ifdef PRECICE_WITH_OPENMP
   if (std::dynamic_pointer_cast<const gko::OmpExecutor>(exec)) {
     create_rbf_system_matrix_impl<Kokkos::OpenMP::memory_space>(exec, mtx, activeAxis, supportPoints, targetPoints, f, rbf_params, addPolynomial, extraDims);
     return;
   }
 #endif
-#ifdef KOKKOS_ENABLE_CUDA
+#ifdef PRECICE_WITH_CUDA
   if (std::dynamic_pointer_cast<const gko::CudaExecutor>(exec)) {
     create_rbf_system_matrix_impl<Kokkos::Cuda::memory_space>(exec, mtx, activeAxis, supportPoints, targetPoints, f, rbf_params, addPolynomial, extraDims);
     return;
   }
 #endif
-#ifdef KOKKOS_ENABLE_HIP
+#ifdef PRECICE_WITH_HIP
   if (std::dynamic_pointer_cast<const gko::HipExecutor>(exec)) {
     create_rbf_system_matrix_impl<Kokkos::Hip::memory_space>(exec, mtx, activeAxis, supportPoints, targetPoints, f, rbf_params, addPolynomial, extraDims);
     return;
@@ -214,19 +214,19 @@ void fill_polynomial_matrix(std::shared_ptr<const gko::Executor> exec,
     return;
   }
 #endif
-#ifdef KOKKOS_ENABLE_OPENMP
+#ifdef PRECICE_WITH_OPENMP
   if (std::dynamic_pointer_cast<const gko::OmpExecutor>(exec)) {
     fill_polynomial_matrix_impl<Kokkos::OpenMP::memory_space>(exec, mtx, x, dims);
     return;
   }
 #endif
-#ifdef KOKKOS_ENABLE_CUDA
-  if (std::dynamic_pointer_cast<const gko::CudaExecutor>(exec)) {
+#ifdef PRECICE_WITH_CUDA
+  if (auto p = std::dynamic_pointer_cast<const gko::CudaExecutor>(exec); p) {
     fill_polynomial_matrix_impl<Kokkos::Cuda::memory_space>(exec, mtx, x, dims);
     return;
   }
 #endif
-#ifdef KOKKOS_ENABLE_HIP
+#ifdef PRECICE_WITH_HIP
   if (std::dynamic_pointer_cast<const gko::HipExecutor>(exec)) {
     fill_polynomial_matrix_impl<Kokkos::Hip::memory_space>(exec, mtx, x, dims);
     return;

--- a/src/mapping/device/GinkgoRBFKernels.hpp
+++ b/src/mapping/device/GinkgoRBFKernels.hpp
@@ -12,11 +12,13 @@ namespace kernel {
 
 template <typename EvalFunctionType>
 void create_rbf_system_matrix(std::shared_ptr<const gko::Executor> exec,
+                              bool                                 unifiedMemory,
                               gko::ptr_param<GinkgoMatrix> mtx, const std::array<bool, 3> activeAxis,
                               gko::ptr_param<GinkgoMatrix> supportPoints, gko::ptr_param<GinkgoMatrix> targetPoints,
                               EvalFunctionType f, ::precice::mapping::RadialBasisParameters rbf_params, bool addPolynomial, unsigned int extraDims = 0);
 
 void fill_polynomial_matrix(std::shared_ptr<const gko::Executor> exec,
+                            bool                                 unifiedMemory,
                             gko::ptr_param<GinkgoMatrix> mtx, gko::ptr_param<const GinkgoMatrix> x, const unsigned int dims);
 
 } // namespace kernel


### PR DESCRIPTION
## Main changes of this PR

Based on #2168

This PR fixes the executor selection of the Ginkgo mappings to pick exactly what is configured in preCICE.

## Motivation and additional information

Currently, preCICE picks an executor in a way that is heavily dependent on the build-configuration of Kokkos.
This leads to the situation, that if Kokkos is build with host-parallel OpenMP and device-parallel Cuda, then preCICE will pick Cuda even though `<executor:openmp>` was provided, leading to incorrect mapping results.

While this is a valid configuration for Kokkos, it isn't for preCICE, which only supports a single parallel executor to be configured.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
