### PR TITLE
Add working directory to preCICE hello

### DIFF
--- a/docs/changelog/2170.md
+++ b/docs/changelog/2170.md
@@ -1,0 +1,1 @@
+- Added current working directory of participant to the startup output of preCICE.

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include <deque>
+#include <filesystem>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -196,6 +197,11 @@ void ParticipantImpl::configure(
 #endif
 #endif // NDEBUG
     );
+    try {
+      PRECICE_INFO("Working directory \"{}\"", std::filesystem::current_path().string());
+    } catch (std::filesystem::filesystem_error &fse) {
+      PRECICE_INFO("Working directory unknown due to error \"{}\"", fse.what());
+    }
     PRECICE_INFO("Configuring preCICE with configuration \"{}\"", configurationFileName);
     PRECICE_INFO("I am participant \"{}\"", _accessorName);
   }


### PR DESCRIPTION
## Main changes of this PR

This PR adds the absolute path to the current working directory of the participant to the hello output of preCICE.

## Motivation and additional information

It can sometimes be very challenging to debug non-matching exchange-directories due to inconsistent working directories.
This additional output should significantly simplify spotting this problem directly from the log files.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
