### PR TITLE
Add five participants test

### DIFF
--- a/tests/serial/compositional/FiveParticipants.cpp
+++ b/tests/serial/compositional/FiveParticipants.cpp
@@ -1,0 +1,135 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <boost/test/tools/detail/per_element_manip.hpp>
+#include <precice/Participant.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Compositional)
+PRECICE_TEST_SETUP("M1SM"_on(1_rank), "M2SM"_on(1_rank), "M1"_on(1_rank), "M2"_on(1_rank),"Tendon"_on(1_rank));
+BOOST_AUTO_TEST_CASE(FiveParticipants)
+{
+  PRECICE_TEST();
+
+  precice::Participant participant(context.name, context.config(), context.rank, context.size);
+
+  const std::vector<double> surfaceCoords{1, 0, 2, 0};
+  const std::vector<double> neuralCoords{0, 0};
+
+  std::vector<int> surface1VertexIDs(2);
+  std::vector<int> surface2VertexIDs(2);
+
+  std::vector<int> activationVertexIDs(1);
+  std::vector<int> stretchVertexIDs(1);
+
+  double timestepSize = 1.0;
+
+  if (context.isNamed("M1SM")) {
+
+    participant.setMeshVertices("Surface_M1SM_Mesh", surfaceCoords, surface1VertexIDs);
+    participant.setMeshVertices("Activation_M1SM_Mesh", neuralCoords, activationVertexIDs);
+    participant.setMeshVertices("Stretch_M1SM_Mesh", neuralCoords, stretchVertexIDs);
+
+  } else if (context.isNamed("M2SM")) {
+
+    participant.setMeshVertices("Surface_M2SM_Mesh", surfaceCoords, surface2VertexIDs);
+    participant.setMeshVertices("Activation_M2SM_Mesh", neuralCoords, activationVertexIDs);
+    participant.setMeshVertices("Stretch_M2SM_Mesh", neuralCoords, stretchVertexIDs);
+
+  } else if (context.isNamed("M1"))  {
+
+    participant.setMeshVertices("Stretch_M1_Mesh", neuralCoords, stretchVertexIDs);
+    participant.setMeshVertices("Activation_M1_Mesh", neuralCoords, activationVertexIDs);
+
+  } else {
+    participant.setMeshVertices("Stretch_M2_Mesh", neuralCoords, stretchVertexIDs);
+    participant.setMeshVertices("Activation_M2_Mesh", neuralCoords, activationVertexIDs);
+  }
+
+  participant.initialize();
+
+  std::vector<double> tractions1{1.2, 1.4};
+  std::vector<double> displacements1{1.2, 1.4};
+  std::vector<double> tractions2{2.2, 2.4};
+  std::vector<double> displacements2{2.2, 2.4};
+  std::vector<double> activation1{1.0};
+  std::vector<double> activation2{2.0};
+  std::vector<double> stretch1{1.1};
+  std::vector<double> stretch2{2.2};
+
+  std::vector<double> receivedDisplacements1{0.0, 0.0};
+  std::vector<double> receivedDisplacements2{0.0, 0.0};
+  std::vector<double> receivedActivation1{0.0};
+ std::vector<double> receivedActivation2{0.0};
+  std::vector<double> receivedStretch1{0.0};
+  std::vector<double> receivedCrossStretch1{0.0};
+  std::vector<double> receivedStretch2{0.0};
+
+
+  for (int timestep = 0; timestep < 2; ++timestep) {
+
+    if (context.isNamed("M1SM")) {
+      participant.writeData("Surface_M1SM_Mesh", "Displacement", surface1VertexIDs, displacements1);
+      participant.readData("Activation_M1SM_Mesh", "Activation1", activationVertexIDs, timestepSize, receivedActivation1);
+      participant.writeData("Stretch_M1SM_Mesh", "stretch1", stretchVertexIDs, stretch1);
+
+    } else  if (context.isNamed("Tendon")) {
+      participant.readData("SurfaceTendon_M1SM_Mesh", "Displacement1", surface1VertexIDs, timestepSize, receivedDisplacements1);
+      participant.writeData("SurfaceTendon_M2SM_Mesh", "Displacement2", surface2VertexIDs, displacements2);
+    }
+    else if (context.isNamed("M2SM")) {
+
+      participant.readData("Surface_M2SM_Mesh", "Displacement2", surface2VertexIDs, timestepSize, receivedDisplacements2);
+      participant.writeData("Stretch_M2SM_Mesh", "stretch2", stretchVertexIDs, stretch2);
+      participant.readData("Activation_M2SM_Mesh", "Activation2", activationVertexIDs, timestepSize, receivedActivation2);
+
+
+    }   else if (context.isNamed("M2")) {
+
+      participant.readData("Stretch_M2_Mesh", "stretch2", stretchVertexIDs, timestepSize, receivedStretch2);
+      participant.writeData("Activation_M2_Mesh", "activation2", stretchVertexIDs, activation2);
+
+    }else {
+
+      BOOST_TEST(context.isNamed("M1"));
+
+      participant.writeData("Activation_M1_Mesh", "Activation1", activationVertexIDs, activation1);
+      participant.readData("Stretch_M1_Mesh", "stretch1", stretchVertexIDs, timestepSize, receivedStretch1);
+      participant.readData("Stretch_M1_Mesh", "stretch2", stretchVertexIDs, timestepSize, receivedCrossStretch1);
+
+    } 
+
+    if (participant.requiresWritingCheckpoint()) {
+    }
+    participant.advance(timestepSize);
+    if (participant.requiresReadingCheckpoint()) {
+    }
+  }
+
+  // Test read and write
+  if (context.isNamed("M1SM")) {
+
+    BOOST_TEST(receivedActivation1 == activation1, boost::test_tools::per_element());
+
+  } else if (context.isNamed("M2SM")) {
+
+    BOOST_TEST(receivedDisplacements2 == displacements2, boost::test_tools::per_element());
+
+  } else {
+
+    BOOST_TEST(receivedStretch1 == stretch1, boost::test_tools::per_element());
+    BOOST_TEST(receivedCrossStretch1 == stretch2, boost::test_tools::per_element());
+
+  } 
+
+  participant.finalize();
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Compositional
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/compositional/FiveParticipants.cpp
+++ b/tests/serial/compositional/FiveParticipants.cpp
@@ -73,6 +73,7 @@ BOOST_AUTO_TEST_CASE(FiveParticipants)
   std::vector<double> receivedStretch1{0.0};
   std::vector<double> receivedCrossStretch1{0.0};
   std::vector<double> receivedStretch2{0.0};
+  std::vector<double> receivedCrossStretch2{0.0};
 
   for (int timestep = 0; timestep < 2; ++timestep) {
 
@@ -96,7 +97,7 @@ BOOST_AUTO_TEST_CASE(FiveParticipants)
       participant.readData("Activation_M2SM_Mesh", "Activation2", activationVertexIDs, timestepSize, receivedActivation2);
 
     } else if (context.isNamed("M2")) {
-
+      participant.readData("Stretch_M2_Mesh", "Stretch1", stretchVertexIDs, timestepSize, receivedCrossStretch2);
       participant.readData("Stretch_M2_Mesh", "Stretch2", stretchVertexIDs, timestepSize, receivedStretch2);
       participant.writeData("Activation_M2_Mesh", "Activation2", stretchVertexIDs, activation2);
 
@@ -134,6 +135,8 @@ BOOST_AUTO_TEST_CASE(FiveParticipants)
 
     BOOST_TEST(receivedStretch1 == stretch1, boost::test_tools::per_element());
     BOOST_TEST(receivedCrossStretch1 == stretch2, boost::test_tools::per_element());
+  } else {
+    BOOST_TEST(receivedCrossStretch2 == stretch1, boost::test_tools::per_element());
   }
 
   participant.finalize();

--- a/tests/serial/compositional/FiveParticipants.xml
+++ b/tests/serial/compositional/FiveParticipants.xml
@@ -45,6 +45,7 @@
   </mesh>
 
   <mesh name="Stretch_M2_Mesh" dimensions="2">
+    <use-data name="Stretch1" />
     <use-data name="Stretch2" />
   </mesh>
 
@@ -134,6 +135,7 @@
     <provide-mesh name="Activation_M2_Mesh" />
     <receive-mesh name="Activation_M2SM_Mesh" from="M2SM" />
     <provide-mesh name="Stretch_M2_Mesh" />
+    <receive-mesh name="Stretch_M1SM_Mesh" from="M1SM" />
     <receive-mesh name="Stretch_M2SM_Mesh" from="M2SM" />
     <mapping:nearest-neighbor
       direction="write"
@@ -143,8 +145,14 @@
     <mapping:nearest-neighbor
       direction="read"
       to="Stretch_M2_Mesh"
+      from="Stretch_M1SM_Mesh"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      to="Stretch_M2_Mesh"
       from="Stretch_M2SM_Mesh"
       constraint="consistent" />
+    <read-data name="Stretch1" mesh="Stretch_M2_Mesh" />
     <read-data name="Stretch2" mesh="Stretch_M2_Mesh" />
     <write-data name="Activation2" mesh="Activation_M2_Mesh" />
   </participant>
@@ -161,6 +169,7 @@
   <m2n:sockets acceptor="M1" connector="M1SM" />
   <m2n:sockets acceptor="M2" connector="M2SM" />
   <m2n:sockets acceptor="M2SM" connector="M1" />
+  <m2n:sockets acceptor="M1SM" connector="M2" />
   <m2n:sockets acceptor="Tendon" connector="M1SM" />
   <m2n:sockets acceptor="Tendon" connector="M2SM" />
 
@@ -169,6 +178,13 @@
     <time-window-size value="1" />
     <max-time-windows value="2" />
     <exchange data="Stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M1" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-explicit>
+    <participants first="M2" second="M1SM" />
+    <time-window-size value="1" />
+    <max-time-windows value="2" />
+    <exchange data="Stretch1" mesh="Stretch_M1SM_Mesh" from="M1SM" to="M2" />
   </coupling-scheme:serial-explicit>
 
   <coupling-scheme:serial-explicit>

--- a/tests/serial/compositional/FiveParticipants.xml
+++ b/tests/serial/compositional/FiveParticipants.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Traction1" />
+  <data:scalar name="Traction2" />
+  <data:scalar name="Displacement1" />
+  <data:scalar name="Displacement2" />
+  <data:scalar name="Activation1" />
+  <data:scalar name="Activation2" />
+  <data:scalar name="stretch1" />
+  <data:scalar name="stretch2" />
+
+  <mesh name="Surface_M1SM_Mesh" dimensions="2">
+    <use-data name="Traction1" />
+    <use-data name="Displacement1" />
+  </mesh>
+
+  <mesh name="Surface_M2SM_Mesh" dimensions="2">
+    <use-data name="Traction2" />
+    <use-data name="Displacement2" />
+  </mesh>
+
+  <mesh name="Activation_M1_Mesh" dimensions="2">
+    <use-data name="Activation1" />
+  </mesh>
+
+  <mesh name="Activation_M1SM_Mesh" dimensions="2">
+    <use-data name="Activation1" />
+  </mesh>
+
+  <mesh name="Activation_M2_Mesh" dimensions="2">
+    <use-data name="Activation2" />
+  </mesh>
+
+  <mesh name="Activation_M2SM_Mesh" dimensions="2">
+    <use-data name="Activation2" />
+  </mesh>
+
+  <mesh name="Stretch_M1_Mesh" dimensions="2">
+    <use-data name="stretch1" />
+    <use-data name="stretch2" />
+  </mesh>
+
+  <mesh name="Stretch_M1SM_Mesh" dimensions="2">
+    <use-data name="stretch1" />
+  </mesh>
+
+  <mesh name="Stretch_M2_Mesh" dimensions="2">
+    <use-data name="stretch2" />
+  </mesh>
+
+  <mesh name="Stretch_M2SM_Mesh" dimensions="2">
+    <use-data name="stretch2" />
+  </mesh>
+
+  <mesh name="SurfaceTendon_M1SM_Mesh" dimensions="2">
+    <use-data name="Traction1" />
+    <use-data name="Displacement1" />
+  </mesh>
+
+  <mesh name="SurfaceTendon_M2SM_Mesh" dimensions="2">
+    <use-data name="Traction2" />
+    <use-data name="Displacement2" />
+  </mesh>
+
+  <participant name="M1SM">
+    <provide-mesh name="Surface_M1SM_Mesh" />
+    <receive-mesh name="SurfaceTendon_M1SM_Mesh" from="Tendon" />
+    <provide-mesh name="Activation_M1SM_Mesh" />
+    <provide-mesh name="Stretch_M1SM_Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="Surface_M1SM_Mesh"
+      to="SurfaceTendon_M1SM_Mesh"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SurfaceTendon_M1SM_Mesh"
+      to="Surface_M1SM_Mesh"
+      constraint="consistent" />
+    <write-data name="Displacement1" mesh="Surface_M1SM_Mesh" />
+    <read-data name="Traction1" mesh="Surface_M1SM_Mesh" />
+    <read-data name="Activation1" mesh="Activation_M1SM_Mesh" />
+    <write-data name="stretch1" mesh="Stretch_M1SM_Mesh" />
+  </participant>
+
+  <participant name="M2SM">
+    <provide-mesh name="Surface_M2SM_Mesh" />
+    <provide-mesh name="Activation_M2SM_Mesh" />
+    <provide-mesh name="Stretch_M2SM_Mesh" />
+    <receive-mesh name="SurfaceTendon_M2SM_Mesh" from="Tendon" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="Surface_M2SM_Mesh"
+      to="SurfaceTendon_M2SM_Mesh"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SurfaceTendon_M2SM_Mesh"
+      to="Surface_M2SM_Mesh"
+      constraint="consistent" />
+    <write-data name="Traction2" mesh="Surface_M2SM_Mesh" />
+    <read-data name="Displacement2" mesh="Surface_M2SM_Mesh" />
+    <read-data name="Activation2" mesh="Activation_M2SM_Mesh" />
+    <write-data name="stretch2" mesh="Stretch_M2SM_Mesh" />
+  </participant>
+
+  <participant name="M1">
+    <provide-mesh name="Activation_M1_Mesh" />
+    <receive-mesh name="Activation_M1SM_Mesh" from="M1SM" />
+    <provide-mesh name="Stretch_M1_Mesh" />
+    <receive-mesh name="Stretch_M1SM_Mesh" from="M1SM" />
+    <receive-mesh name="Stretch_M2SM_Mesh" from="M2SM" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="Activation_M1_Mesh"
+      to="Activation_M1SM_Mesh"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      to="Stretch_M1_Mesh"
+      from="Stretch_M1SM_Mesh"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      to="Stretch_M1_Mesh"
+      from="Stretch_M2SM_Mesh"
+      constraint="consistent" />
+    <read-data name="stretch1" mesh="Stretch_M1_Mesh" />
+    <write-data name="Activation1" mesh="Activation_M1_Mesh" />
+    <read-data name="stretch2" mesh="Stretch_M1_Mesh" />
+  </participant>
+
+  <participant name="M2">
+    <provide-mesh name="Activation_M2_Mesh" />
+    <receive-mesh name="Activation_M2SM_Mesh" from="M2SM" />
+    <provide-mesh name="Stretch_M2_Mesh" />
+    <receive-mesh name="Stretch_M2SM_Mesh" from="M2SM" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="Activation_M2_Mesh"
+      to="Activation_M2SM_Mesh"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="read"
+      to="Stretch_M2_Mesh"
+      from="Stretch_M2SM_Mesh"
+      constraint="consistent" />
+    <read-data name="stretch2" mesh="Stretch_M2_Mesh" />
+    <write-data name="Activation2" mesh="Activation_M2_Mesh" />
+  </participant>
+
+    <participant name="Tendon">
+    <provide-mesh name="SurfaceTendon_M1SM_Mesh" />
+    <provide-mesh name="SurfaceTendon_M2SM_Mesh" />
+    <read-data name="Displacement1" mesh="SurfaceTendon_M1SM_Mesh" />
+    <write-data name="Traction1" mesh="SurfaceTendon_M1SM_Mesh" />
+    <write-data name="Displacement2" mesh="SurfaceTendon_M2SM_Mesh" />
+    <read-data name="Traction2" mesh="SurfaceTendon_M2SM_Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="M1" connector="M1SM" />
+  <m2n:sockets acceptor="M2" connector="M2SM" />
+  <m2n:sockets acceptor="M2SM" connector="M1" />
+  <m2n:sockets acceptor="Tendon" connector="M1SM" />
+  <m2n:sockets acceptor="Tendon" connector="M2SM" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="M1" second="M2SM" />
+    <time-window-size value="1" />
+    <max-time-windows value="2" />
+    <exchange data="stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M1" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-explicit>
+    <participants first="M1" second="M1SM" />
+    <time-window-size value="1" />
+    <max-time-windows value="2" />
+    <exchange data="Activation1" mesh="Activation_M1SM_Mesh" from="M1" to="M1SM" />
+    <exchange data="stretch1" mesh="Stretch_M1SM_Mesh" from="M1SM" to="M1" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:serial-explicit>
+    <participants first="M2" second="M2SM" />
+    <time-window-size value="1" />
+    <max-time-windows value="2" />
+    <exchange data="Activation2" mesh="Activation_M2SM_Mesh" from="M2" to="M2SM" />
+    <exchange data="stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M2" />
+  </coupling-scheme:serial-explicit>
+
+  <coupling-scheme:multi>
+    <participant name="Tendon" control="yes" />
+    <participant name="M1SM" />
+    <participant name="M2SM" />
+    <time-window-size value="1" />
+    <max-time-windows value="2" />
+    <exchange data="Displacement1" mesh="SurfaceTendon_M1SM_Mesh" from="M1SM" to="Tendon" />
+    <exchange data="Traction1" mesh="SurfaceTendon_M1SM_Mesh" from="Tendon" to="M1SM" />
+    <exchange data="Displacement2" mesh="SurfaceTendon_M2SM_Mesh" from="Tendon" to="M2SM" />
+    <exchange data="Traction2" mesh="SurfaceTendon_M2SM_Mesh" from="M2SM" to="Tendon" />
+    <max-iterations value="1" />
+    <min-iterations value="1" />
+  </coupling-scheme:multi>
+</precice-configuration>

--- a/tests/serial/compositional/FiveParticipants.xml
+++ b/tests/serial/compositional/FiveParticipants.xml
@@ -6,8 +6,8 @@
   <data:scalar name="Displacement2" />
   <data:scalar name="Activation1" />
   <data:scalar name="Activation2" />
-  <data:scalar name="stretch1" />
-  <data:scalar name="stretch2" />
+  <data:scalar name="Stretch1" />
+  <data:scalar name="Stretch2" />
 
   <mesh name="Surface_M1SM_Mesh" dimensions="2">
     <use-data name="Traction1" />
@@ -36,20 +36,20 @@
   </mesh>
 
   <mesh name="Stretch_M1_Mesh" dimensions="2">
-    <use-data name="stretch1" />
-    <use-data name="stretch2" />
+    <use-data name="Stretch1" />
+    <use-data name="Stretch2" />
   </mesh>
 
   <mesh name="Stretch_M1SM_Mesh" dimensions="2">
-    <use-data name="stretch1" />
+    <use-data name="Stretch1" />
   </mesh>
 
   <mesh name="Stretch_M2_Mesh" dimensions="2">
-    <use-data name="stretch2" />
+    <use-data name="Stretch2" />
   </mesh>
 
   <mesh name="Stretch_M2SM_Mesh" dimensions="2">
-    <use-data name="stretch2" />
+    <use-data name="Stretch2" />
   </mesh>
 
   <mesh name="SurfaceTendon_M1SM_Mesh" dimensions="2">
@@ -80,7 +80,7 @@
     <write-data name="Displacement1" mesh="Surface_M1SM_Mesh" />
     <read-data name="Traction1" mesh="Surface_M1SM_Mesh" />
     <read-data name="Activation1" mesh="Activation_M1SM_Mesh" />
-    <write-data name="stretch1" mesh="Stretch_M1SM_Mesh" />
+    <write-data name="Stretch1" mesh="Stretch_M1SM_Mesh" />
   </participant>
 
   <participant name="M2SM">
@@ -101,7 +101,7 @@
     <write-data name="Traction2" mesh="Surface_M2SM_Mesh" />
     <read-data name="Displacement2" mesh="Surface_M2SM_Mesh" />
     <read-data name="Activation2" mesh="Activation_M2SM_Mesh" />
-    <write-data name="stretch2" mesh="Stretch_M2SM_Mesh" />
+    <write-data name="Stretch2" mesh="Stretch_M2SM_Mesh" />
   </participant>
 
   <participant name="M1">
@@ -125,9 +125,9 @@
       to="Stretch_M1_Mesh"
       from="Stretch_M2SM_Mesh"
       constraint="consistent" />
-    <read-data name="stretch1" mesh="Stretch_M1_Mesh" />
+    <read-data name="Stretch1" mesh="Stretch_M1_Mesh" />
     <write-data name="Activation1" mesh="Activation_M1_Mesh" />
-    <read-data name="stretch2" mesh="Stretch_M1_Mesh" />
+    <read-data name="Stretch2" mesh="Stretch_M1_Mesh" />
   </participant>
 
   <participant name="M2">
@@ -145,11 +145,11 @@
       to="Stretch_M2_Mesh"
       from="Stretch_M2SM_Mesh"
       constraint="consistent" />
-    <read-data name="stretch2" mesh="Stretch_M2_Mesh" />
+    <read-data name="Stretch2" mesh="Stretch_M2_Mesh" />
     <write-data name="Activation2" mesh="Activation_M2_Mesh" />
   </participant>
 
-    <participant name="Tendon">
+  <participant name="Tendon">
     <provide-mesh name="SurfaceTendon_M1SM_Mesh" />
     <provide-mesh name="SurfaceTendon_M2SM_Mesh" />
     <read-data name="Displacement1" mesh="SurfaceTendon_M1SM_Mesh" />
@@ -168,7 +168,7 @@
     <participants first="M1" second="M2SM" />
     <time-window-size value="1" />
     <max-time-windows value="2" />
-    <exchange data="stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M1" />
+    <exchange data="Stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M1" />
   </coupling-scheme:serial-explicit>
 
   <coupling-scheme:serial-explicit>
@@ -176,7 +176,7 @@
     <time-window-size value="1" />
     <max-time-windows value="2" />
     <exchange data="Activation1" mesh="Activation_M1SM_Mesh" from="M1" to="M1SM" />
-    <exchange data="stretch1" mesh="Stretch_M1SM_Mesh" from="M1SM" to="M1" />
+    <exchange data="Stretch1" mesh="Stretch_M1SM_Mesh" from="M1SM" to="M1" />
   </coupling-scheme:serial-explicit>
 
   <coupling-scheme:serial-explicit>
@@ -184,7 +184,7 @@
     <time-window-size value="1" />
     <max-time-windows value="2" />
     <exchange data="Activation2" mesh="Activation_M2SM_Mesh" from="M2" to="M2SM" />
-    <exchange data="stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M2" />
+    <exchange data="Stretch2" mesh="Stretch_M2SM_Mesh" from="M2SM" to="M2" />
   </coupling-scheme:serial-explicit>
 
   <coupling-scheme:multi>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -191,9 +191,10 @@ target_sources(testprecice
     tests/serial/aitken/WithSubsteps.cpp
     tests/serial/circular/Explicit.cpp
     tests/serial/circular/helper.hpp
+    tests/serial/compositional/FiveParticipants.cpp
     tests/serial/compositional/OneActivatedMuscle.cpp
     tests/serial/compositional/TwoActivatedMuscles.cpp
-    tests/serial/compositional/FiveParticipants.cpp
+    tests/serial/compositional/TwoActivatedMuscles1.cpp
     tests/serial/compositional/data/implicit-first/AllParallel.cpp
     tests/serial/compositional/data/implicit-first/Parallel.cpp
     tests/serial/compositional/data/implicit-first/SerialFirst.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -194,7 +194,6 @@ target_sources(testprecice
     tests/serial/compositional/FiveParticipants.cpp
     tests/serial/compositional/OneActivatedMuscle.cpp
     tests/serial/compositional/TwoActivatedMuscles.cpp
-    tests/serial/compositional/TwoActivatedMuscles1.cpp
     tests/serial/compositional/data/implicit-first/AllParallel.cpp
     tests/serial/compositional/data/implicit-first/Parallel.cpp
     tests/serial/compositional/data/implicit-first/SerialFirst.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -193,6 +193,7 @@ target_sources(testprecice
     tests/serial/circular/helper.hpp
     tests/serial/compositional/OneActivatedMuscle.cpp
     tests/serial/compositional/TwoActivatedMuscles.cpp
+    tests/serial/compositional/FiveParticipants.cpp
     tests/serial/compositional/data/implicit-first/AllParallel.cpp
     tests/serial/compositional/data/implicit-first/Parallel.cpp
     tests/serial/compositional/data/implicit-first/SerialFirst.cpp


### PR DESCRIPTION
## Main changes of this PR


## Motivation and additional information

This PR adds a compositional coupling test, in particular a test that uses 5 participants. The test is motivated by my muscle-OpenDiHu application case. The config file is ilustrated here:

![5_participants](https://github.com/user-attachments/assets/fd02c3fa-9b64-4d90-9da8-d127f2fee50f)

I have hidden data access, communicators, mapping and coupling schemes for better visibility. There are 
- 2 serial-explicit schemes (unidirectional)
- 2 serial-explicit schemes (bidirectional)
- 1 multi-coupling scheme (participants M1SM, M2SM and Tendon)

This test is related to https://github.com/precice/precice/issues/1907. When tests were restricted to 4 ranks, I adapted my use-case by removing the tendon: Instead of a multi-coupling scheme connecting M1SM and M2SM through the tendon, I had a parallel-implicit scheme connecting M1SM and M2SM directly. There I observed that I was not able to add the 1 of the 2 serial-explicit schemes (unidirectional) I have in this test, and that the one I could add depended on who was the first participant in the parallel-implicit scheme. 
However adding the second serial-explicit (unidirectional) scheme here did not raise any problem.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist



<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
