### PR TITLE
Fix confusing output at the end of the simulation

### DIFF
--- a/docs/changelog/2182.md
+++ b/docs/changelog/2182.md
@@ -1,0 +1,1 @@
+- Fixed confusing output of the final advance at the end of the simulation.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -595,24 +595,28 @@ std::string BaseCouplingScheme::printBasicState(
     double time) const
 {
   std::ostringstream os;
-  os << "time-window: " << timeWindows;
-  if (_maxTimeWindows != UNDEFINED_TIME_WINDOWS) {
-    os << " of " << _maxTimeWindows;
+  if (isCouplingOngoing()) {
+    os << "time-window: " << timeWindows;
+    if (_maxTimeWindows != UNDEFINED_TIME_WINDOWS) {
+      os << " of " << _maxTimeWindows;
+    }
+    os << ", time: " << time;
+    if (_maxTime != UNDEFINED_MAX_TIME) {
+      os << " of " << _maxTime;
+    }
+    if (hasTimeWindowSize()) {
+      os << ", time-window-size: " << _timeWindowSize;
+    }
+    if (hasTimeWindowSize() || (_maxTime != UNDEFINED_MAX_TIME)) {
+      os << ", max-time-step-size: " << getNextTimeStepMaxSize();
+    }
+    os << ", ongoing: ";
+    isCouplingOngoing() ? os << "yes" : os << "no";
+    os << ", time-window-complete: ";
+    _isTimeWindowComplete ? os << "yes" : os << "no";
+  } else {
+    os << "Reached end at: time-window: " << timeWindows << ", time: " << time;
   }
-  os << ", time: " << time;
-  if (_maxTime != UNDEFINED_MAX_TIME) {
-    os << " of " << _maxTime;
-  }
-  if (hasTimeWindowSize()) {
-    os << ", time-window-size: " << _timeWindowSize;
-  }
-  if (hasTimeWindowSize() || (_maxTime != UNDEFINED_MAX_TIME)) {
-    os << ", max-time-step-size: " << getNextTimeStepMaxSize();
-  }
-  os << ", ongoing: ";
-  isCouplingOngoing() ? os << "yes" : os << "no";
-  os << ", time-window-complete: ";
-  _isTimeWindowComplete ? os << "yes" : os << "no";
   return os.str();
 }
 

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -402,7 +402,7 @@ void BaseCouplingScheme::secondExchange()
           requireAction(CouplingScheme::Action::WriteCheckpoint);
         }
       }
-      //update iterations
+      // update iterations
       _totalIterations++;
       if (not hasConverged()) {
         _iterations++;
@@ -579,14 +579,21 @@ void BaseCouplingScheme::requireAction(
 std::string BaseCouplingScheme::printCouplingState() const
 {
   std::ostringstream os;
-  os << "iteration: " << _iterations; //_iterations;
-  if ((_maxIterations != UNDEFINED_MAX_ITERATIONS) && (_maxIterations != INFINITE_MAX_ITERATIONS)) {
-    os << " of " << _maxIterations;
+  if (isCouplingOngoing()) {
+    os << "iteration: " << _iterations; //_iterations;
+    if ((_maxIterations != UNDEFINED_MAX_ITERATIONS) && (_maxIterations != INFINITE_MAX_ITERATIONS)) {
+      os << " of " << _maxIterations;
+    }
+    if (_minIterations != UNDEFINED_MIN_ITERATIONS) {
+      os << " (min " << _minIterations << ")";
+    }
+    os << ", ";
   }
-  if (_minIterations != UNDEFINED_MIN_ITERATIONS) {
-    os << " (min " << _minIterations << ")";
+  os << printBasicState(_timeWindows, getTime());
+  std::string actionsState = printActionsState();
+  if (!actionsState.empty()) {
+    os << ", " << actionsState;
   }
-  os << ", " << printBasicState(_timeWindows, getTime()) << ", " << printActionsState();
   return os.str();
 }
 
@@ -615,7 +622,7 @@ std::string BaseCouplingScheme::printBasicState(
     os << ", time-window-complete: ";
     _isTimeWindowComplete ? os << "yes" : os << "no";
   } else {
-    os << "Reached end at: time-window: " << timeWindows << ", time: " << time;
+    os << "Reached end at: final time-window: " << (timeWindows - 1) << ", final time: " << time;
   }
   return os.str();
 }


### PR DESCRIPTION
## Main changes of this PR

This PR fixes the confusing output of preCICE, which shows that the simulation has finished.
The output when the simulation is finished is now more understandable.

For example, the end of the output of the Oscillator tutorial is now:

```
... Reached end at: final time-window: 100, final time: 1
```

At the end of the PR are the logs of all the variances of serial/parallel and implicit/explicit, run with the solver dummies.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->
Closes issue #2101.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

Hi @fsimonis, 
this is how I would change the output, which is basically your second proposed scheme.
Do you want any additional changes, for example, that the `_maxTimeWindows` is also included if it is provided?

I am a little confused about ~~the `make changelog` because it says I need a PR first and also~~ what kind of test I should create. 

Edit: I've added a second commit with the new changelog file, I hope this is correct.

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->


## Solver Dummy Logs (short)

### Serial implicit

SolverOne:

```
[...]
preCICE: iteration: 3 of 3 (min 2), time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: no, read-iteration-checkpoint
DUMMY: Reading iteration checkpoint
preCICE: Time window completed
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

SolverTwo:

```
[...]
preCICE: iteration: 3 of 3 (min 2), time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: no, read-iteration-checkpoint
DUMMY: Reading iteration checkpoint
preCICE: Mapping "Data-Two" for t=2 from "SolverTwo-Mesh" to "SolverOne-Mesh"
preCICE: No converge measures defined.
preCICE: Time window completed
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

### Serial explicit

SolverOne:

```
[...]
preCICE: iteration: 1, time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: yes
DUMMY: Advancing in time
preCICE: Time window completed
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

SolverTwo:

```
[...]
preCICE: iteration: 1, time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: yes
DUMMY: Advancing in time
preCICE: Mapping "Data-Two" for t=2 from "SolverTwo-Mesh" to "SolverOne-Mesh"
preCICE: Time window completed
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

### Parallel implicit

SolverOne:

```
[...]
preCICE: iteration: 3 of 3 (min 2), time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: no, read-iteration-checkpoint
DUMMY: Reading iteration checkpoint
preCICE: Time window completed
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

SolverTwo:

```
[...]
preCICE: iteration: 3 of 3 (min 2), time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: no, read-iteration-checkpoint
DUMMY: Reading iteration checkpoint
preCICE: Mapping "Data-Two" for t=2 from "SolverTwo-Mesh" to "SolverOne-Mesh"
preCICE: No converge measures defined.
preCICE: Time window completed
preCICE: Mapping "Data-One" for t=2 from "SolverOne-Mesh" to "SolverTwo-Mesh"
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

### Parallel explicit

SolverOne:

```
[...]
preCICE: iteration: 1, time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: yes
DUMMY: Advancing in time
preCICE: Time window completed
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

SolverTwo:

```
[...]
preCICE: iteration: 1, time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: yes
DUMMY: Advancing in time
preCICE: Mapping "Data-Two" for t=2 from "SolverTwo-Mesh" to "SolverOne-Mesh"
preCICE: Time window completed
preCICE: Mapping "Data-One" for t=2 from "SolverOne-Mesh" to "SolverTwo-Mesh"
preCICE: Reached end at: final time-window: 2, final time: 2
[...]
```

## Example Composition Coupling Logs

```
[...]
199: 13:02:02.086812|IB|0|impl::ParticipantImpl|l431|advance|EB: iteration: 1, time-window: 2 of 2, time: 2, time-window-size: 1, max-time-step-size: -0, ongoing: yes, time-window-complete: yes
199: IA: iteration: 2 of 2 (min 2), time-window: 2 of 2, time: 1, time-window-size: 1, max-time-step-size: 1, ongoing: yes, time-window-complete: no, read-iteration-checkpoint
--
199: 13:02:02.089375|IB|0|impl::ParticipantImpl|l431|advance|EB: Reached end at: final time-window: 2, final time: 2
199: IA: Reached end at: final time-window: 2, final time: 2
```