### PR TITLE
Add a codemeta.json metadata file

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,24 @@
+{
+    "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
+    "type": "SoftwareSourceCode",
+    "codeRepository": "https://github.com/precice/precice",
+    "dateModified": "2024-06-24",
+    "description": "A coupling library for partitioned multi-physics simulations.",
+    "downloadUrl": "https://github.com/precice/precice/archive/refs/tags/v3.1.2.tar.gz",
+    "isPartOf": "https://precice.org/",
+    "license": "https://spdx.org/licenses/LGPL-3.0-or-later",
+    "name": "preCICE",
+    "operatingSystem": [
+        "Linux",
+        "macOS"
+    ],
+    "programmingLanguage": "C++",
+    "softwareRequirements": "https://precice.org/installation-source-dependencies.html",
+    "version": "3.1.2",
+    "contIntegration": "https://github.com/precice/precice/actions",
+    "codemeta:continuousIntegration": {
+        "id": "https://github.com/precice/precice/actions"
+    },
+    "issueTracker": "https://github.com/precice/precice/issues",
+    "referencePublication": "https://doi.org/10.12688/openreseurope.14445.2"
+}


### PR DESCRIPTION
## Main changes of this PR

Adds a [CodeMeta](https://codemeta.github.io/user-guide/) metadata file.

This is only a first draft, generated with https://codemeta.github.io/codemeta-generator/

## Motivation and additional information

This should generally help other tools discover and correctly list preCICE in registries.

We should compare with (and use the related crosswalks for)

- [wikidata entry](https://www.wikidata.org/wiki/Q67123602)
- [Software Heritage entry](https://archive.softwareheritage.org/browse/origin/directory/?origin_url=https://github.com/precice/precice)

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* I added a test to cover the proposed changes in our test suite. -> N/A
* For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). -> N/A
* I stuck to C++17 features. -> N/A
* I stuck to CMake version 3.22.1. -> N/A
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
