### PR TITLE
Add NP projection information

### DIFF
--- a/docs/changelog/2184.md
+++ b/docs/changelog/2184.md
@@ -1,0 +1,1 @@
+- Added a log info statement showing the amount of selected elements when computing a nearest-projection mapping.

--- a/src/mapping/NearestProjectionMapping.cpp
+++ b/src/mapping/NearestProjectionMapping.cpp
@@ -81,6 +81,7 @@ void NearestProjectionMapping::computeMapping()
   constexpr int nnearest = 4;
 
   utils::statistics::DistanceAccumulator distanceStatistics;
+  std::size_t                            toTriangles{0}, toEdges{0}, toVertices{0};
 
   _interpolations.clear();
   _interpolations.reserve(fVertices.size());
@@ -91,6 +92,20 @@ void NearestProjectionMapping::computeMapping()
     // Nearest projection element is triangle for 3d if exists, if not the edge and at the worst case it is the nearest vertex
     auto match = index.findNearestProjection(fVertex.getCoords(), nnearest);
     distanceStatistics(match.polation.distance());
+    switch (match.polation.nElements()) {
+    case 1:
+      ++toVertices;
+      break;
+    case 2:
+      ++toEdges;
+      break;
+    case 3:
+      ++toTriangles;
+      break;
+    default:
+      PRECICE_UNREACHABLE("");
+    }
+
     _interpolations.push_back(std::move(match.polation));
   }
 
@@ -98,6 +113,7 @@ void NearestProjectionMapping::computeMapping()
     PRECICE_INFO("Mapping distance not available due to empty partition.");
   } else {
     PRECICE_INFO("Mapping distance {}", distanceStatistics);
+    PRECICE_INFO("Nearest-projections are {} triangles, {} edges, and {} vertices", toTriangles, toEdges, toVertices);
   }
 
   _hasComputedMapping = true;

--- a/src/mapping/Polation.cpp
+++ b/src/mapping/Polation.cpp
@@ -83,6 +83,11 @@ const std::vector<WeightedElement> &Polation::getWeightedElements() const
   return _weightedElements;
 }
 
+std::size_t Polation::nElements() const
+{
+  return _weightedElements.size();
+}
+
 bool Polation::isInterpolation() const
 {
   return std::all_of(_weightedElements.begin(), _weightedElements.end(), [](const mapping::WeightedElement &elem) { return precice::math::greaterEquals(elem.weight, 0.0); });

--- a/src/mapping/Polation.hpp
+++ b/src/mapping/Polation.hpp
@@ -35,6 +35,9 @@ public:
   /// Calculate projection to a tetrahedron
   Polation(const Eigen::VectorXd &location, const mesh::Tetrahedron &element);
 
+  /// Amount of weighted elements
+  std::size_t nElements() const;
+
   /// Get the weights and indices of the calculated interpolation
   const std::vector<WeightedElement> &getWeightedElements() const;
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds an info statement to the nearest projection mapping about which elements have been selected for the projection, namely Triangles, Edges, or Vertices.

## Motivation and additional information

Currently, I am tring to understand why macOS produces different NP mappings in https://github.com/precice/aste/pull/212.
This is a good quick indicator to check if the underlying implementation does something very different.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
