### PR TITLE
Assert correct sample data dimensions

### DIFF
--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -73,7 +73,7 @@ void runCoupling(
   std::vector<int>::const_iterator iterValidIterations = validIterations.begin();
 
   if (nameParticipant == nameParticipant0) {
-    mesh->data(0)->setSampleAtTime(0, time::Sample{1, mesh->data(0)->values()});
+    mesh->data(0)->setSampleAtTime(0, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
     cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
@@ -90,7 +90,7 @@ void runCoupling(
       // The max time step size is required to be obeyed.
       double maxTimeStepSize = cplScheme.getNextTimeStepMaxSize();
       cplScheme.addComputedTime(maxTimeStepSize);
-      mesh->data(0)->setSampleAtTime(cplScheme.getTime(), time::Sample{1, mesh->data(0)->values()});
+      mesh->data(0)->setSampleAtTime(cplScheme.getTime(), time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -142,7 +142,7 @@ void runCoupling(
     BOOST_TEST(testing::equals(computedTime, 0.3));
     BOOST_TEST(computedTimesteps == 3);
   } else if (nameParticipant == nameParticipant1) {
-    mesh->data(1)->setSampleAtTime(0, time::Sample{1, mesh->data(1)->values()});
+    mesh->data(1)->setSampleAtTime(0, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
     cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
@@ -162,7 +162,7 @@ void runCoupling(
       // The max time step size is required to be obeyed.
       double maxTimeStepSize = cplScheme.getNextTimeStepMaxSize();
       cplScheme.addComputedTime(maxTimeStepSize);
-      mesh->data(1)->setSampleAtTime(cplScheme.getTime(), time::Sample{1, mesh->data(1)->values()});
+      mesh->data(1)->setSampleAtTime(cplScheme.getTime(), time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -246,7 +246,7 @@ void runCouplingWithSubcycling(
 
   if (nameParticipant == nameParticipant0) {
     iterationCount++; // different handling due to subcycling
-    mesh->data(0)->setSampleAtTime(0, time::Sample{1, mesh->data(0)->values()});
+    mesh->data(0)->setSampleAtTime(0, time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
     cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
@@ -268,7 +268,7 @@ void runCouplingWithSubcycling(
     // Main coupling loop
     while (cplScheme.isCouplingOngoing()) {
       cplScheme.addComputedTime(computedTimeStepSize);
-      mesh->data(0)->setSampleAtTime(cplScheme.getTime(), time::Sample{1, mesh->data(0)->values()});
+      mesh->data(0)->setSampleAtTime(cplScheme.getTime(), time::Sample{mesh->data(0)->getDimensions(), mesh->data(0)->values()});
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -335,7 +335,7 @@ void runCouplingWithSubcycling(
 
   else if (nameParticipant == nameParticipant1) {
     iterationCount++; // different handling due to subcycling
-    mesh->data(1)->setSampleAtTime(0, time::Sample{1, mesh->data(1)->values()});
+    mesh->data(1)->setSampleAtTime(0, time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
     cplScheme.initialize();
     BOOST_TEST(not cplScheme.isTimeWindowComplete());
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::WriteCheckpoint));
@@ -358,7 +358,7 @@ void runCouplingWithSubcycling(
     // Main coupling loop
     while (cplScheme.isCouplingOngoing()) {
       cplScheme.addComputedTime(computedTimeStepSize);
-      mesh->data(1)->setSampleAtTime(cplScheme.getTime(), time::Sample{1, mesh->data(1)->values()});
+      mesh->data(1)->setSampleAtTime(cplScheme.getTime(), time::Sample{mesh->data(1)->getDimensions(), mesh->data(1)->values()});
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -743,7 +743,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(testing::equals(sendCouplingData->values()(0), 0.0));
 
     BOOST_TEST(Fixture::isImplicitCouplingScheme(cplScheme));
-    sendCouplingData->setSampleAtTime(0, time::Sample{1, sendCouplingData->values()});
+    sendCouplingData->setSampleAtTime(0, time::Sample{sendCouplingData->getDimensions(), sendCouplingData->values()});
     cplScheme.initialize();
     BOOST_TEST(cplScheme.hasDataBeenReceived());
     // ensure that initial data was read
@@ -763,9 +763,9 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
       BOOST_TEST(cplScheme.getNextTimeStepMaxSize() == timeStepSize);
-      sendCouplingData->setSampleAtTime(cplScheme.getTime() + timeStepSize, time::Sample{1, Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0)});
+      sendCouplingData->setSampleAtTime(cplScheme.getTime() + timeStepSize, time::Sample{sendCouplingData->getDimensions(), Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0)});
       cplScheme.addComputedTime(timeStepSize);
-      sendCouplingData->setSampleAtTime(cplScheme.getTime(), time::Sample{1, Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0)});
+      sendCouplingData->setSampleAtTime(cplScheme.getTime(), time::Sample{sendCouplingData->getDimensions(), Eigen::VectorXd::Constant(sendCouplingData->getSize(), 4.0)});
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();
       cplScheme.secondSynchronization();
@@ -780,7 +780,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
     BOOST_TEST(cplScheme.isActionRequired(CouplingScheme::Action::InitializeData));
     Eigen::VectorXd v(3);
     v << 1.0, 2.0, 3.0;
-    sendCouplingData->setSampleAtTime(0, time::Sample{1, v});
+    sendCouplingData->setSampleAtTime(0, time::Sample{sendCouplingData->getDimensions(), v});
     cplScheme.markActionFulfilled(CouplingScheme::Action::InitializeData);
     BOOST_TEST(receiveCouplingData->getSize() == 1);
     BOOST_TEST(testing::equals(receiveCouplingData->values()(0), 0.0));
@@ -801,7 +801,7 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
         cplScheme.markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
       }
       BOOST_TEST(cplScheme.getNextTimeStepMaxSize() == timeStepSize);
-      sendCouplingData->setSampleAtTime(cplScheme.getTime() + timeStepSize, time::Sample{1, v});
+      sendCouplingData->setSampleAtTime(cplScheme.getTime() + timeStepSize, time::Sample{sendCouplingData->getDimensions(), v});
       cplScheme.addComputedTime(timeStepSize);
       cplScheme.firstSynchronization({});
       cplScheme.firstExchange();

--- a/src/io/tests/ExportVTKTest.cpp
+++ b/src/io/tests/ExportVTKTest.cpp
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient)
   time::Sample vectorial(dimensions, 2, dimensions);
   vectorial.values.setLinSpaced(0, 1);
   vectorial.gradients.setOnes();
-  dataScalar->setSampleAtTime(0, vectorial);
+  dataVector->setSampleAtTime(0, vectorial);
 
   io::ExportVTK exportVTK{"io-VTKExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTK.doExport(0, 0.0);

--- a/src/io/tests/ExportVTPTest.cpp
+++ b/src/io/tests/ExportVTPTest.cpp
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   time::Sample vectorial(dimensions, 2, dimensions);
   vectorial.values.setLinSpaced(0, 1);
   vectorial.gradients.setOnes();
-  dataScalar->setSampleAtTime(0, vectorial);
+  dataVector->setSampleAtTime(0, vectorial);
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   time::Sample vectorial(dimensions, 2, dimensions);
   vectorial.values.setLinSpaced(0, 1);
   vectorial.gradients.setOnes();
-  dataScalar->setSampleAtTime(0, vectorial);
+  dataVector->setSampleAtTime(0, vectorial);
 
   io::ExportVTP exportVTP{"io-VTPExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTP.doExport(0, 0.0);

--- a/src/io/tests/ExportVTUTest.cpp
+++ b/src/io/tests/ExportVTUTest.cpp
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient2D)
   time::Sample vectorial(dimensions, 2, dimensions);
   vectorial.values.setLinSpaced(0, 1);
   vectorial.gradients.setOnes();
-  dataScalar->setSampleAtTime(0, vectorial);
+  dataVector->setSampleAtTime(0, vectorial);
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(ExportDataWithGradient3D)
   time::Sample vectorial(dimensions, 2, dimensions);
   vectorial.values.setLinSpaced(0, 1);
   vectorial.gradients.setOnes();
-  dataScalar->setSampleAtTime(0, vectorial);
+  dataVector->setSampleAtTime(0, vectorial);
 
   io::ExportVTU exportVTU{"io-VTUExport", ".", mesh, io::Export::ExportKind::TimeWindows, 1, context.rank, context.size};
   exportVTU.doExport(0, 0.0);

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -81,6 +81,7 @@ void Data::moveToNextWindow()
 
 void Data::setSampleAtTime(double time, const time::Sample &sample)
 {
+  PRECICE_ASSERT(sample.dataDims == getDimensions(), "Sample has incorrect data dimension");
   _sample = sample; // @todo at some point we should not need this anymore, when mapping, acceleration ... directly work on _timeStepsStorage
   _waveform.timeStepsStorage().setSampleAtTime(time, sample);
 }

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -81,14 +81,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
         0.0, 10.0,
         1.0, 14.0,
         2.0, 14.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -108,7 +101,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
   PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity.log");
 
@@ -120,7 +113,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -135,14 +128,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
         0.0, 16.0, 20.0,
         1.0, 20.0, 24.0,
         2.0, 20.0, 24.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -191,14 +177,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
         0.0, 6.5, 3.0,
         1.0, 9.5, 3.0,
         2.0, 9.5, 3.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -247,14 +226,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
         0.0, 6.0, 3.0,
         1.0, 9.0, 3.0,
         2.0, 9.0, 3.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -276,7 +248,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   mesh->createEdge(v2, v3);
 
   PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
+  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity.log");
 
@@ -288,7 +260,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
+    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -304,14 +276,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
           0.0, 10.0, 13.0, 3.0,
           1.0, 13.0, 56.0, 3.0,
           2.0, 13.0, 56.0, 3.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }
@@ -334,7 +299,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   mesh->createEdge(v2, v3);
 
   PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
+  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-noScale.log");
 
@@ -346,7 +311,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
+    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -362,14 +327,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
           0.0, 9.0, 12.0, 3.0,
           1.0, 12.0, 15.0, 3.0,
           2.0, 12.0, 15.0, 3.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }
@@ -426,14 +384,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
         0.0, 28.0, 12.0,
         1.0, 40.0, 12.0,
         2.0, 40.0, 12.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -489,14 +440,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
         0.0, 10.0, 12.0,
         1.0, 14.0, 12.0,
         2.0, 14.0, 12.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -525,7 +469,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity.log");
 
@@ -537,7 +481,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -552,14 +496,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
         0.0, 44.0, 56.0, 12.0,
         1.0, 56.0, 68.0, 12.0,
         2.0, 56.0, 68.0, 12.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -588,7 +525,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity-noScale.log");
 
@@ -600,7 +537,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -615,14 +552,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
         0.0, 16.0, 20.0, 12.0,
         1.0, 20.0, 24.0, 12.0,
         2.0, 20.0, 24.0, 12.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -678,14 +608,7 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
         0.0, 28.0, 12.0,
         1.0, 40.0, 18.0,
         2.0, 40.0, 18.0};
-    BOOST_TEST(result.size() == expected.size());
-    for (size_t i = 0; i < result.size(); ++i) {
-      BOOST_TEST_CONTEXT("entry index: " << i)
-      {
-        using testing::equals;
-        BOOST_TEST(equals(result.at(i), expected.at(i)));
-      }
-    }
+    BOOST_TEST(result == expected, boost::test_tools::per_element());
   }
 }
 
@@ -758,14 +681,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
           0.0, 36.0,
           1.0, 44.0,
           2.0, 44.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }
@@ -796,13 +712,13 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   }
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
   } else if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
   } else if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
   } else if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity-parallel.log");
@@ -816,13 +732,13 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
     } else if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
     } else if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
     } else if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
     }
 
     // Write output again
@@ -839,14 +755,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
           0.0, 64.0, 72.0,
           1.0, 72.0, 80.0,
           2.0, 72.0, 80.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }
@@ -934,14 +843,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
           0.0, 25.5, 5.0,
           1.0, 30.5, 5.0,
           2.0, 30.5, 5.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }
@@ -980,16 +882,16 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
   PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-parallel.log");
@@ -1003,16 +905,16 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
     }
 
     // Write output again
@@ -1029,14 +931,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
           0.0, 46.0, 51.0, 5.0,
           1.0, 51.0, 56.0, 5.0,
           2.0, 51.0, 56.0, 5.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }
@@ -1126,14 +1021,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
           0.0, 28.0, 12.0,
           1.0, 40.0, 12.0,
           2.0, 40.0, 12.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }
@@ -1171,19 +1059,19 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
     mesh->createTriangle(e3, e4, e5);
   }
 
-  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  PtrData doubleData = mesh->createData("DoubleData", 3, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0, 5.0, 6.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(3, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}}));
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(1));
+    doubleData->setSampleAtTime(0, time::Sample(3));
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(1));
+    doubleData->setSampleAtTime(0, time::Sample(3));
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 5.0, 6.0, 7.0, 8.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(3, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity-parallel.log");
@@ -1197,16 +1085,16 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0, 6.0, 7.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(3, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}}));
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(1));
+      doubleData->setSampleAtTime(1, time::Sample(3));
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(1));
+      doubleData->setSampleAtTime(1, time::Sample(3));
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 6.0, 7.0, 8.0, 9.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(3, Eigen::VectorXd{{2.0, 3.0, 6.0, 7.0, 8.0, 9.0, 8.0, 9.0, 10.0}}));
     }
 
     // Write output again
@@ -1218,19 +1106,12 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
   BOOST_TEST_CONTEXT("Validating WatchIntegral VectorData FaceConnectivity Parallel")
   {
     if (utils::IntraComm::isPrimary()) {
-      auto result   = readDoublesFromTXTFile(fileName, 4);
+      auto result   = readDoublesFromTXTFile(fileName, 5);
       auto expected = std::vector<double>{
-          0.0, 44.0, 56.0, 12.0,
-          1.0, 56.0, 68.0, 12.0,
-          2.0, 56.0, 68.0, 12.0};
-      BOOST_TEST(result.size() == expected.size());
-      for (size_t i = 0; i < result.size(); ++i) {
-        BOOST_TEST_CONTEXT("entry index: " << i)
-        {
-          using testing::equals;
-          BOOST_TEST(equals(result.at(i), expected.at(i)));
-        }
-      }
+          0.0, 48.0, 60.0, 72.0, 12.0,
+          1.0, 64.0, 76.0, 92.0, 12.0,
+          2.0, 64.0, 76.0, 92.0, 12.0};
+      BOOST_TEST(result == expected, boost::test_tools::per_element());
     }
   }
 }

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-noConnectivity.log");
 
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5.}}));
+    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -100,8 +100,8 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
-  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
+  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity.log");
 
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
   mesh->createEdge(v2, v3);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity.log");
 
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4.}}));
+    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
   mesh->createEdge(v2, v3);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-noScale.log");
 
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4.}}));
+    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -247,8 +247,8 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
+  PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
+  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity.log");
 
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
+    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -298,8 +298,8 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   mesh->createEdge(v1, v2);
   mesh->createEdge(v2, v3);
 
-  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
+  PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
+  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-noScale.log");
 
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
+    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -357,7 +357,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity.log");
 
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5.}}));
+    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity-noScale.log");
 
@@ -425,7 +425,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4., 5.}}));
+    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -468,8 +468,8 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
+  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity.log");
 
@@ -481,7 +481,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -524,8 +524,8 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   mesh->createTriangle(e1, e2, e5);
   mesh->createTriangle(e3, e4, e5);
 
-  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
+  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity-noScale.log");
 
@@ -537,7 +537,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string fileName("precice-WatchIntegralTest-meshChange-faceConnectivity.log");
 
@@ -638,13 +638,13 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
   }
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 2.0}}));
   } else if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{3.0, 4.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{3.0, 4.0}}));
   } else if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{5.0, 6.0}}));
   } else if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{7.0, 8.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{7.0, 8.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-noConnectivity-parallel.log");
@@ -658,13 +658,13 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 3.0}}));
     } else if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{4.0, 5.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{4.0, 5.0}}));
     } else if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{6.0, 7.0}}));
     } else if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{8.0, 9.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{8.0, 9.0}}));
     }
 
     // Write output again
@@ -695,7 +695,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   std::string name("rectangle");
   int         dimensions = 2;
   PtrMesh     mesh(new Mesh(name, dimensions, testing::nextMeshID()));
-  PtrData     doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  PtrData     vectorData = mesh->createData("DoubleData", 2, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
     mesh->createVertex(Eigen::Vector2d(0.0, 0.0));
@@ -712,13 +712,13 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   }
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
   } else if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
   } else if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
   } else if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity-parallel.log");
@@ -732,13 +732,13 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
     } else if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
     } else if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
     } else if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
     }
 
     // Write output again
@@ -794,16 +794,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 2.0}}));
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{3.0, 4.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{3.0, 4.0}}));
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{5.0, 6.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{5.0, 6.0}}));
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{7.0, 8.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{7.0, 8.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-parallel.log");
@@ -817,16 +817,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 3.0}}));
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{4.0, 5.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{4.0, 5.0}}));
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{6.0, 7.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{6.0, 7.0}}));
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{8.0, 9.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{8.0, 9.0}}));
     }
 
     // Write output again
@@ -879,19 +879,19 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
     mesh->createEdge(v7, v8);
   }
 
-  PtrData doubleData = mesh->createData("DoubleData", 2, 0_dataID);
+  PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-parallel.log");
@@ -905,16 +905,16 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
     }
 
     // Write output again
@@ -972,16 +972,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0, 3.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 2.0, 3.0}}));
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(1));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions()));
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(1));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions()));
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 3.0, 4.0}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 3.0, 4.0}}));
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity-parallel.log");
@@ -995,16 +995,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 3.0, 4.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 3.0, 4.0}}));
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(1));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions()));
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(1));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions()));
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2.0, 4.0, 5.0}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 4.0, 5.0}}));
     }
 
     // Write output again

--- a/src/precice/tests/WatchPointTest.cpp
+++ b/src/precice/tests/WatchPointTest.cpp
@@ -78,15 +78,15 @@ void testWatchPoint(const TestContext & context,
 
   if (context.size > 1) {
     if (context.isPrimary()) {
-      doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1.0, 2.0}}));
-      vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
+      doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 2.0}}));
+      vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
     } else {
-      doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{2.0, 3.0}}));
-      vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{3.0, 4.0, 5.0, 6.0}}));
+      doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 3.0}}));
+      vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{3.0, 4.0, 5.0, 6.0}}));
     }
   } else {
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3.}}));
-    vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3.}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
   }
 
   std::string filename0("precice-WatchPointTest-timeseries-0.log");
@@ -107,15 +107,15 @@ void testWatchPoint(const TestContext & context,
     // Change data (next timestep)
     if (context.size > 1) {
       if (context.isPrimary()) {
-        doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3.}}));
-        vectorData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5.}}));
+        doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3.}}));
+        vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5.}}));
       } else {
-        doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{3., 4.}}));
-        vectorData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{4., 5., 6., 7.}}));
+        doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{3., 4.}}));
+        vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{4., 5., 6., 7.}}));
       }
     } else {
-      doubleData->setSampleAtTime(1, time::Sample(1, Eigen::VectorXd{{2., 3., 4.}}));
-      vectorData->setSampleAtTime(1, time::Sample(2, Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
+      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4.}}));
+      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
     }
 
     // Write output again
@@ -268,8 +268,8 @@ BOOST_AUTO_TEST_CASE(Reinitialize)
 
   // v1, v2 carry data 1
   // v2 and later v3 carry data 2
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 1., 2.}}));
-  vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 1., 1., 1., 2., 2.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 1., 2.}}));
+  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 1., 1., 1., 2., 2.}}));
 
   std::string filename0("precice-WatchPointTest-reinit-0.log");
   std::string filename1("precice-WatchPointTest-reinit-1.log");
@@ -294,8 +294,8 @@ BOOST_AUTO_TEST_CASE(Reinitialize)
     mesh::Vertex &v4 = mesh->createVertex(Eigen::Vector2d(1.0, 0.0));
     mesh->createEdge(v3, v4);
     mesh->index().clear();
-    doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 1., 2., 2.}}));
-    vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 1., 1., 1., 2., 2., 2., 2.}}));
+    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 1., 2., 2.}}));
+    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 1., 1., 1., 2., 2., 2., 2.}}));
 
     // Re-Initialize
     watchpoint0.initialize();
@@ -362,8 +362,8 @@ BOOST_AUTO_TEST_CASE(VolumetricInterpolation2D)
   PtrData vectorData = mesh->createData("VectorData", 2, 1_dataID);
 
   // Data is (1,1,2) for the scalar, and same for each vector component.
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 1., 2., 2.}}));
-  vectorData->setSampleAtTime(0, time::Sample(2, Eigen::VectorXd{{1., 1., 1., 1., 2., 2., 2., 2.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 1., 2., 2.}}));
+  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 1., 1., 1., 2., 2., 2., 2.}}));
 
   std::string filename0("precice-WatchPointTest-volumetric2d-0.log");
   std::string filename1("precice-WatchPointTest-volumetric2d-1.log");
@@ -437,7 +437,7 @@ BOOST_AUTO_TEST_CASE(VolumetricInterpolation3D)
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   // Data is (1,1,2) for the scalar, and same for each vector component.
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
 
   std::string filename0("precice-WatchPointTest-volumetric3d-0.log");
   std::string filename1("precice-WatchPointTest-volumetric3d-1.log");
@@ -530,7 +530,7 @@ BOOST_AUTO_TEST_CASE(VolumetricParallel)
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   // Data is (1, 2, 3, 4) on the tetra, other ranks agree on their subset
-  doubleData->setSampleAtTime(0, time::Sample(1, Eigen::VectorXd(context.rank + 1).setLinSpaced(1., context.rank + 1)));
+  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd(context.rank + 1).setLinSpaced(1., context.rank + 1)));
 
   std::string filename0("precice-WatchPointTest-volumetricParallel-0.log");
   bool        isClosest;


### PR DESCRIPTION
## Main changes of this PR

This PR asserts correct dimensions when adding a new sample to a `mesh::Data`.

It also fixes a bunch of tests where data and samples mismatched.

## Motivation and additional information

Assertions are lovely

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] ~~Does the changelog entry make sense? Is it formatted correctly?~~ not needed @BenjaminRodenberg 
* [x] Do you understand the code changes? @BenjaminRodenberg 

<!-- add more questions/tasks if necessary -->
