### PR TITLE
Avoid sample copies when not interpolating

### DIFF
--- a/docs/changelog/2190.md
+++ b/docs/changelog/2190.md
@@ -1,0 +1,1 @@
+- Improved memory footprint when handling non-interpolated data.

--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -32,8 +32,8 @@ void Acceleration::applyRelaxation(double omega, DataMap &cplData, double window
       }
 
       auto &values    = stample.sample.values;
-      auto  oldValues = couplingData.getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
-      values          = values * omega + oldValues * (1.0 - omega);
+      auto  old    = couplingData.getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
+      values       = values * omega + old.values() * (1.0 - omega);
 
       if (couplingData.hasGradient()) {
         auto &gradients    = stample.sample.gradients;

--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -31,7 +31,7 @@ void Acceleration::applyRelaxation(double omega, DataMap &cplData, double window
         continue;
       }
 
-      auto &values    = stample.sample.values;
+      auto &values = stample.sample.values;
       auto  old    = couplingData.getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
       values       = values * omega + old.values() * (1.0 - omega);
 

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -639,15 +639,15 @@ void BaseQNAcceleration::concatenateCouplingData(Eigen::VectorXd &data, Eigen::V
 
     for (int i = 0; i < timeGrid.size(); i++) {
 
-      Eigen::VectorXd values    = cplData.at(id)->timeStepsStorage().sample(timeGrid(i));
-      Eigen::VectorXd oldValues = cplData.at(id)->getPreviousValuesAtTime(timeGrid(i));
+      auto current = cplData.at(id)->timeStepsStorage().sample(timeGrid(i));
+      auto old     = cplData.at(id)->getPreviousValuesAtTime(timeGrid(i));
 
       PRECICE_ASSERT(data.size() >= offset + dataSize, "the values were not initialized correctly");
       PRECICE_ASSERT(oldData.size() >= offset + dataSize, "the values were not initialized correctly");
 
       for (Eigen::Index i = 0; i < dataSize; i++) {
-        data(i + offset)    = values(i);
-        oldData(i + offset) = oldValues(i);
+        data(i + offset)    = current(i);
+        oldData(i + offset) = old(i);
       }
       offset += dataSize;
     }

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -71,7 +71,7 @@ const time::Storage &CouplingData::timeStepsStorage() const
   return _data->timeStepsStorage();
 }
 
-Eigen::VectorXd CouplingData::getPreviousValuesAtTime(double relativeDt)
+time::SampleResult CouplingData::getPreviousValuesAtTime(double relativeDt)
 {
   return _previousTimeStepsStorage.sample(relativeDt);
 }

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -48,7 +48,7 @@ public:
   time::Storage &timeStepsStorage();
 
   /// returns previous data interpolated to the relativeDt time
-  Eigen::VectorXd getPreviousValuesAtTime(double relativeDt);
+  time::SampleResult getPreviousValuesAtTime(double relativeDt);
 
   Eigen::MatrixXd getPreviousGradientsAtTime(double relativeDt);
 

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -55,7 +55,7 @@ const time::Sample &Data::sample() const
   return _sample;
 }
 
-Eigen::VectorXd Data::sampleAtTime(double time) const
+time::SampleResult Data::sampleAtTime(double time) const
 {
   return _waveform.sample(time);
 }

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -83,7 +83,7 @@ public:
    * @param time Time where the sampling happens.
    * @return Value of _waveform at time \ref time.
    */
-  Eigen::VectorXd sampleAtTime(double time) const;
+  time::SampleResult sampleAtTime(double time) const;
 
   /**
    * @brief get degree of _waveform.

--- a/src/precice/impl/ReadDataContext.cpp
+++ b/src/precice/impl/ReadDataContext.cpp
@@ -30,9 +30,9 @@ bool ReadDataContext::hasSamples() const
 
 void ReadDataContext::readValues(::precice::span<const VertexID> vertices, double readTime, ::precice::span<double> values) const
 {
-  Eigen::Map<Eigen::MatrixXd>       outputData(values.data(), getDataDimensions(), values.size());
-  const Eigen::MatrixXd             sample{_providedData->sampleAtTime(readTime)};
-  Eigen::Map<const Eigen::MatrixXd> localData(sample.data(), getDataDimensions(), getMeshVertexCount());
+  Eigen::Map<Eigen::MatrixXd> outputData(values.data(), getDataDimensions(), values.size());
+  auto                        sampleResult = _providedData->sampleAtTime(readTime);
+  auto                        localData    = sampleResult.values().reshaped(getDataDimensions(), getMeshVertexCount());
   for (int i = 0; i < static_cast<int>(vertices.size()); ++i) {
     outputData.col(i) = localData.col(vertices[i]);
   }

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -290,6 +290,7 @@ target_sources(preciceCore
     src/query/Index.hpp
     src/query/impl/RTreeAdapter.hpp
     src/time/Sample.hpp
+    src/time/SampleResult.hpp
     src/time/Stample.hpp
     src/time/Storage.cpp
     src/time/Storage.hpp

--- a/src/time/SampleResult.hpp
+++ b/src/time/SampleResult.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Eigen/Core>
+
+namespace precice::time {
+
+/** Result of a sampling operation which is optionally owning.
+ *
+ * This covers two cases:
+ *
+ * 1. The sampling operation doesn't need to interpolate and returns a view into an existing sample.
+ * 2. The sampling operation needs to interpolate values and returns them as part of the object and exposes a view into it.
+ */
+class SampleResult {
+public:
+  /// Creates a non-owning SampleResult
+  SampleResult(const Eigen::VectorXd &ref) noexcept
+      : _view(ref.data(), ref.size()) {}
+
+  /// Creates an owning SampleResult
+  SampleResult(Eigen::VectorXd &&vec)
+      : _owned(std::move(vec)), _view(_owned.data(), _owned.size()) {}
+
+  // No copy
+  SampleResult(const SampleResult &other) = delete;
+  SampleResult &operator=(const SampleResult &other) = delete;
+
+  // Move is allowed
+  SampleResult(SampleResult &&other) = default;
+  SampleResult &operator=(SampleResult &&other) = default;
+
+  /// Access the values as a vector
+  Eigen::Map<const Eigen::VectorXd> values() const noexcept
+  {
+    return _view;
+  }
+
+  /// Direct read-access to a value in the underlying view
+  auto operator()(Eigen::Index index) const
+  {
+    return _view(index);
+  }
+
+private:
+  Eigen::VectorXd                   _owned;
+  Eigen::Map<const Eigen::VectorXd> _view;
+};
+
+} // namespace precice::time

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -195,7 +195,7 @@ std::pair<Eigen::VectorXd, Eigen::MatrixXd> Storage::getTimesAndValues() const
   return std::make_pair(times, values);
 }
 
-Eigen::VectorXd Storage::sample(double time) const
+SampleResult Storage::sample(double time) const
 {
   PRECICE_ASSERT(this->nTimes() != 0, "There are no samples available");
   const int usedDegree = computeUsedDegree(_degree, nTimes());

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include "logging/Logger.hpp"
 #include "math/Bspline.hpp"
+#include "time/SampleResult.hpp"
 #include "time/Stample.hpp"
 
 namespace precice::time {
@@ -144,7 +145,7 @@ public:
    * @param time a double, where we want to sample the waveform
    * @return Eigen::VectorXd values in this Storage at or directly after "before"
   */
-  Eigen::VectorXd sample(double time) const;
+  SampleResult sample(double time) const;
 
   Eigen::MatrixXd sampleGradients(double time) const;
 

--- a/src/time/Waveform.cpp
+++ b/src/time/Waveform.cpp
@@ -23,7 +23,7 @@ const time::Storage &Waveform::timeStepsStorage() const
   return _timeStepsStorage;
 }
 
-Eigen::VectorXd Waveform::sample(double time) const
+SampleResult Waveform::sample(double time) const
 {
   return _timeStepsStorage.sample(time);
 }

--- a/src/time/Waveform.hpp
+++ b/src/time/Waveform.hpp
@@ -52,7 +52,7 @@ public:
    * @param time Time where the sampling inside the window happens.
    * @return Value of Waveform at given time.
    */
-  Eigen::VectorXd sample(const double time) const;
+  SampleResult sample(const double time) const;
 
 private:
   /// Stores time steps in the current time window


### PR DESCRIPTION
## Main changes of this PR

This PR prevents copying data values when not interpolating by creating a proxy-class called `SampleResult`.
Results are either

* non-owning, pointing to an existing data. This is common for reading at the beginning or end of the time window.
* owning, including the interpolated data. This is always the case  when interpolating data.

## Motivation and additional information

This prevents copies of the whole data sample when:

* reading data
* accelerating data

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
