### PR TITLE
Fix finding existing stamples

### DIFF
--- a/docs/changelog/2191.md
+++ b/docs/changelog/2191.md
@@ -1,0 +1,1 @@
+- Fixes a bug handling timestamp in sample retrieval which leads to crashes for some combinations of time-window-sizes and time-windows.

--- a/src/time/Storage.cpp
+++ b/src/time/Storage.cpp
@@ -206,10 +206,14 @@ Eigen::VectorXd Storage::sample(double time) const
 
   PRECICE_ASSERT(usedDegree >= 1);
 
-  //Return the sample corresponding to time if it exists
-  const int i = findTimeId(time);
-  if (i > -1) {                              // _stampleStorage contains sample at given time
-    return _stampleStorage[i].sample.values; // don't use getTimesAndValues, because this would iterate over the complete _stampleStorage.
+  // Find existing samples
+  for (const auto &stample : _stampleStorage) {
+    if (math::equals(stample.timestamp, time)) {
+      return stample.sample.values;
+    }
+    if (math::greater(stample.timestamp, time)) {
+      break;
+    }
   }
 
   //Create a new bspline if _bspline does not already contain a spline
@@ -246,18 +250,6 @@ time::Sample Storage::getSampleAtBeginning()
 time::Sample Storage::getSampleAtEnd()
 {
   return _stampleStorage.back().sample;
-}
-
-int Storage::findTimeId(double time) const
-{
-  int i = 0;
-  while (math::smallerEquals(_stampleStorage[i].timestamp, time)) {
-    if (math::equals(_stampleStorage[i].timestamp, time)) {
-      return i;
-    }
-    i++;
-  }
-  return -1; // time not found in times
 }
 
 } // namespace precice::time

--- a/src/time/Storage.hpp
+++ b/src/time/Storage.hpp
@@ -173,8 +173,6 @@ private:
   time::Sample getSampleAtBeginning();
 
   time::Sample getSampleAtEnd();
-
-  int findTimeId(double time) const;
 };
 
 } // namespace precice::time

--- a/tests/serial/time/explicit/serial-coupling/SecondTimeBug.cpp
+++ b/tests/serial/time/explicit/serial-coupling/SecondTimeBug.cpp
@@ -1,0 +1,58 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Explicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief Test based on #2160 reported by Claudio and Leonardo
+ * Triggers an assertion in tw=7, t=60.06
+ * Original issue used Dt=0.013 and crashed at t=64.012 after 4925 time windows
+ */
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank))
+BOOST_AUTO_TEST_CASE(SecondTimeBug)
+{
+  PRECICE_TEST();
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  std::array<double, 3> value{1, 1, 1}; // value doesn't matter
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName = "SolverOne-Mesh";
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName = "SolverTwo-Mesh";
+  }
+
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
+  precice.initialize();
+  while (precice.isCouplingOngoing()) {
+    double dt = precice.getMaxTimeStepSize();
+    if (context.isNamed("SolverTwo")) {
+      // Bug #2160, read fails in tw=7 t=60.06
+      precice.readData(meshName, "Data-One", {&vertexID, 1}, dt, value);
+    } else {
+      precice.writeData(meshName, "Data-One", {&vertexID, 1}, value);
+    }
+    precice.advance(dt);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Explicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/explicit/serial-coupling/SecondTimeBug.xml
+++ b/tests/serial/time/explicit/serial-coupling/SecondTimeBug.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time value="72" />
+    <time-window-size value="10.01" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -382,6 +382,7 @@ target_sources(testprecice
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+    tests/serial/time/explicit/serial-coupling/SecondTimeBug.cpp
     tests/serial/time/implicit/compositional/DoNothingWithSubcycling.cpp
     tests/serial/time/implicit/compositional/ReadWriteScalarDataWithSubcycling.cpp
     tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a bug in the way we currently try to find stample.
In some situations, this can lead to out of bounds access.

## Motivation and additional information

Fixes #2160

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
