### PR TITLE
Do not check exchangeSubsteps in QN acceleration

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -647,18 +647,9 @@ void BaseQNAcceleration::concatenateCouplingData(Eigen::VectorXd &data, Eigen::V
 
 void BaseQNAcceleration::initializeVectorsAndPreconditioner(const DataMap &cplData)
 {
-
-  // If we are not subcycling then we only want to use the last time step in the QN system
-  bool subcycling = false;
-  for (const auto &data : cplData | boost::adaptors::map_values) {
-    if (data->exchangeSubsteps()) {
-      subcycling = true;
-    }
-  }
-
   // Saves the time grid of each waveform in the data field to be used in the QN method
-  _timeGrids.emplace(cplData, _dataIDs, !subcycling);
-  _primaryTimeGrids.emplace(cplData, _primaryDataIDs, !(subcycling and !_reducedTimeGrid));
+  _timeGrids.emplace(cplData, _dataIDs, false);
+  _primaryTimeGrids.emplace(cplData, _primaryDataIDs, _reducedTimeGrid);
 
   // Helper function
   auto addTimeSliceSize = [&](size_t sum, int id, precice::time::TimeGrids timeGrids) { return sum + timeGrids.getTimeGrid(id).size() * cplData.at(id)->getSize(); };


### PR DESCRIPTION
:warning: This is still WIP and I need to investigate the issue more closely; opening this PR to use CI for running tests :warning: 

## Main changes of this PR

Removes the check of `data->exchangeSubsteps()` from BaseQNAcceleration.

## Motivation and additional information

* From my understanding especially the secondary data should be influenced by `substeps="true"/"false"`. If `substeps="false"` data at the beginning of the window will be ignored (or even deleted?).
* ~~Trying to fix #2172~~ (*edit:* was fixed by https://github.com/precice/precice/pull/2194; this turns this PR into a pure refactoring)

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
