### PR TITLE
Skip sample at beginning of window

### DIFF
--- a/src/acceleration/Acceleration.cpp
+++ b/src/acceleration/Acceleration.cpp
@@ -26,6 +26,10 @@ void Acceleration::applyRelaxation(double omega, DataMap &cplData)
     // calling performAcceleration the first time. Computations at the
     // previousValuesAtTime/oldValues don't change anything and are unneeded
     for (auto &stample : couplingData.timeStepsStorage().stamples()) {
+      if (stample.timestamp == couplingData.timeStepsStorage().stamples().front().timestamp) {
+        continue; // skip stample at beginning of this window since this is either initial data or already converged data from previous window
+      }
+
       auto &values    = stample.sample.values;
       auto  oldValues = couplingData.getPreviousValuesAtTime(stample.timestamp); // IMPORTANT DETAIL: The interpolation that we use for resampling does not necessarily have to be the same interpolation as the interpolation the user accesses via read-data. (But probably it is easier to just use the same)
       values          = values * omega + oldValues * (1.0 - omega);
@@ -36,7 +40,6 @@ void Acceleration::applyRelaxation(double omega, DataMap &cplData)
         gradients          = gradients * omega + oldGradients * (1.0 - omega);
       }
     }
-
     // @todo remove
     // update the "sample"
     couplingData.sample() = couplingData.timeStepsStorage().last().sample;

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -118,6 +118,7 @@ void AitkenAcceleration::iterationsConverged(
 void AitkenAcceleration::concatenateCouplingData(
     const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues) const
 {
+  //@todo need to skip sample at beginning of window as well.
   Eigen::Index offset = 0;
   for (auto id : dataIDs) {
     Eigen::Index size      = cplData.at(id)->values().size();


### PR DESCRIPTION
## Main changes of this PR

Skips the sample at the beginning of the window. The sample at the beginning of the window has converged and we do not want to change it anymore. This applies to

* Constant underrelaxation
* TODO: Aitken
* initial relaxation of QN
* TODO: later QN iterations

## Motivation and additional information

Related to the regression I reported in #2172. I observed that the data at the beginning of the window is changing under certain conditions. This is generally unwanted. I assume this error has not been noticed since we often do not sample at the beginning of the window and we often do not use any initial data.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
