### PR TITLE
Update Docker base image to ubuntu:24.04

### DIFF
--- a/tools/releasing/packaging/docker/README.md
+++ b/tools/releasing/packaging/docker/README.md
@@ -6,12 +6,12 @@ All images contain the user `precice`, allowing them to run executables using MP
 
 ## Release images `release.dockerfile`
 
-This Dockerfile uses named releases of preCICE such as `2.1.1` and installs the attached debian package in the container.
+This Dockerfile uses named releases of preCICE such as `3.1.2` and installs the attached debian package in the container.
 
-Use the following to build the `2.1.1` image locally:
+Use the following to build the `3.1.2` image locally:
 ```
 cd tools/releasing/packaging/docker/
-docker build -f release.dockerfile  -t precice/precice:2.1.1 --build-arg=version=2.1.1 .
+docker build -f release.dockerfile  -t precice/precice:3.1.2 --build-arg=version=3.1.2 .
 ```
 
 ## Nightly release images `nightly.dockerfile`

--- a/tools/releasing/packaging/docker/nightly.dockerfile
+++ b/tools/releasing/packaging/docker/nightly.dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to build a ubuntu image containing the installed develop version of preCICE
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 # Add the precice user
 RUN useradd -m -s /bin/bash precice
 ENV TZ=Europe/Berlin

--- a/tools/releasing/packaging/docker/release.dockerfile
+++ b/tools/releasing/packaging/docker/release.dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to build a ubuntu image containing the installed Debian package of a release
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 # Add the precice user
 RUN useradd -m -s /bin/bash precice
 # Fix the installation of tzdata for Ubuntu


### PR DESCRIPTION
## Main changes of this PR

Bumps the base Docker image from `ubuntu:22.04` to `ubuntu:24.04`. Also updates the example version, because 2.1.1 looked weird.

Closes #1950.

I have checked that the images build locally.

## Motivation and additional information

Implements the decision in #1950 to use the latest Ubuntu LTS.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
