### PR TITLE
Add an error if participants use different preCICE versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://www.precice.org/fundamentals-roadmap.html).
 
-## 3.2.0
-
-- Throw an error if participants using different preCICE versions attempt coupling (https://github.com/precice/precice/pull/2202).
-
 ## 3.1.2
 
 - Fixed incorrect handling of compositional coupling involving an implicit scheme. Explicit schemes now run after the implicit scheme has reached convergence, correctly receive data of the final iteration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. For future plans, see our [Roadmap](https://www.precice.org/fundamentals-roadmap.html).
 
+## 3.2.0
+
+- Throw an error if participants using different preCICE versions attempt coupling (https://github.com/precice/precice/pull/2202).
+
 ## 3.1.2
 
 - Fixed incorrect handling of compositional coupling involving an implicit scheme. Explicit schemes now run after the implicit scheme has reached convergence, correctly receive data of the final iteration.

--- a/docs/changelog/2202.md
+++ b/docs/changelog/2202.md
@@ -1,0 +1,1 @@
+- Throw an error if participants using different preCICE versions attempt coupling (https://github.com/precice/precice/pull/2202).

--- a/docs/changelog/2202.md
+++ b/docs/changelog/2202.md
@@ -1,1 +1,1 @@
-- Throw an error if participants using different preCICE versions attempt coupling (https://github.com/precice/precice/pull/2202).
+- Added an error if participants using different preCICE versions attempt coupling.

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -57,9 +57,7 @@ void M2N::acceptPrimaryRankConnection(
     auto        requesterVersion = acceptorVersion;
     _interComm->send(acceptorVersion, 0);
     _interComm->receive(requesterVersion, 0);
-    if (requesterVersion != acceptorVersion) {
-      PRECICE_ERROR("Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
-    }
+    PRECICE_CHECK(requesterVersion != acceptorVersion, "Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);
@@ -82,11 +80,9 @@ void M2N::requestPrimaryRankConnection(
     //check that local and remote have the same precice version
     std::string requesterVersion = PRECICE_VERSION;
     auto        acceptorVersion  = requesterVersion;
-    _interComm->send(requesterVersion, 0);
     _interComm->receive(acceptorVersion, 0);
-    if (acceptorVersion != requesterVersion) {
-      PRECICE_ERROR("Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", acceptorName, acceptorVersion, requesterName, requesterVersion);
-    }
+    _interComm->send(requesterVersion, 0);
+    PRECICE_CHECK(requesterVersion != acceptorVersion, "Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -4,15 +4,14 @@
 #include "DistributedCommunication.hpp"
 #include "M2N.hpp"
 #include "com/Communication.hpp"
+#include "logging/LogConfiguration.hpp"
 #include "logging/LogMacros.hpp"
 #include "mesh/Mesh.hpp"
 #include "precice/impl/Types.hpp"
+#include "precice/impl/versions.hpp"
 #include "profiling/Event.hpp"
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
-#include "precice/impl/versions.hpp"
-#include "logging/LogConfiguration.hpp"
-#include "logging/LogMacros.hpp"
 
 using precice::profiling::Event;
 
@@ -53,12 +52,12 @@ void M2N::acceptPrimaryRankConnection(
     PRECICE_DEBUG("Accept primary connection");
     PRECICE_ASSERT(_interComm);
     _interComm->acceptConnection(acceptorName, requesterName, "PRIMARYCOM", utils::IntraComm::getRank());
-    _isPrimaryRankConnected = _interComm->isConnected();
-    std::string acceptorVersion = PRECICE_VERSION;
-    auto requesterVersion = acceptorVersion;
+    _isPrimaryRankConnected      = _interComm->isConnected();
+    std::string acceptorVersion  = PRECICE_VERSION;
+    auto        requesterVersion = acceptorVersion;
     _interComm->send(acceptorVersion, 0);
     _interComm->receive(requesterVersion, 0);
-    if (requesterVersion != acceptorVersion){
+    if (requesterVersion != acceptorVersion) {
       PRECICE_ERROR("Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
     }
   }
@@ -80,16 +79,14 @@ void M2N::requestPrimaryRankConnection(
     _interComm->requestConnection(acceptorName, requesterName, "PRIMARYCOM", 0, 1);
     _isPrimaryRankConnected = _interComm->isConnected();
 
-
     //check that local and remote have the same precice version
     std::string requesterVersion = PRECICE_VERSION;
-    auto acceptorVersion = requesterVersion;
+    auto        acceptorVersion  = requesterVersion;
     _interComm->send(requesterVersion, 0);
     _interComm->receive(acceptorVersion, 0);
-    if (acceptorVersion != requesterVersion){
-      PRECICE_ERROR("Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", acceptorName, acceptorVersion, requesterName, requesterVersion);  
-    } 
-  
+    if (acceptorVersion != requesterVersion) {
+      PRECICE_ERROR("Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", acceptorName, acceptorVersion, requesterName, requesterVersion);
+    }
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -57,7 +57,7 @@ void M2N::acceptPrimaryRankConnection(
     auto        requesterVersion = acceptorVersion;
     _interComm->send(acceptorVersion, 0);
     _interComm->receive(requesterVersion, 0);
-    PRECICE_CHECK(requesterVersion != acceptorVersion, "This participant {} uses preCICE version {} but the requester participant {} uses preCICE version {}.", acceptorName, acceptorVersion, requesterName, requesterVersion);
+    PRECICE_CHECK(requesterVersion == acceptorVersion, "This participant {} uses preCICE version {} but the requester participant {} uses preCICE version {}.", acceptorName, acceptorVersion, requesterName, requesterVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);
@@ -82,7 +82,7 @@ void M2N::requestPrimaryRankConnection(
     auto        acceptorVersion  = requesterVersion;
     _interComm->receive(acceptorVersion, 0);
     _interComm->send(requesterVersion, 0);
-    PRECICE_CHECK(requesterVersion != acceptorVersion, "This participant {} uses preCICE version {} but the acceptor participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
+    PRECICE_CHECK(requesterVersion == acceptorVersion, "This participant {} uses preCICE version {} but the acceptor participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -57,7 +57,7 @@ void M2N::acceptPrimaryRankConnection(
     auto        requesterVersion = acceptorVersion;
     _interComm->send(acceptorVersion, 0);
     _interComm->receive(requesterVersion, 0);
-    PRECICE_CHECK(requesterVersion == acceptorVersion, "This participant {} uses preCICE version {} but the requester participant {} uses preCICE version {}.", acceptorName, acceptorVersion, requesterName, requesterVersion);
+    PRECICE_CHECK(requesterVersion == acceptorVersion, "This participant {} uses preCICE version {} but the requester participant {} uses preCICE version {}. Mixing preCICE versions can lead to undefined behavior and is, thus, forbidden.", acceptorName, acceptorVersion, requesterName, requesterVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);
@@ -82,7 +82,7 @@ void M2N::requestPrimaryRankConnection(
     auto        acceptorVersion  = requesterVersion;
     _interComm->receive(acceptorVersion, 0);
     _interComm->send(requesterVersion, 0);
-    PRECICE_CHECK(requesterVersion == acceptorVersion, "This participant {} uses preCICE version {} but the acceptor participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
+    PRECICE_CHECK(requesterVersion == acceptorVersion, "This participant {} uses preCICE version {} but the acceptor participant {} uses preCICE version {}. Mixing preCICE versions can lead to undefined behavior and is, thus, forbidden.", requesterName, requesterVersion, acceptorName, acceptorVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -57,7 +57,7 @@ void M2N::acceptPrimaryRankConnection(
     auto        requesterVersion = acceptorVersion;
     _interComm->send(acceptorVersion, 0);
     _interComm->receive(requesterVersion, 0);
-    PRECICE_CHECK(requesterVersion != acceptorVersion, "Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
+    PRECICE_CHECK(requesterVersion != acceptorVersion, "This participant {} uses preCICE version {} but the requester participant {} uses preCICE version {}.", acceptorName, acceptorVersion, requesterName, requesterVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);
@@ -82,7 +82,7 @@ void M2N::requestPrimaryRankConnection(
     auto        acceptorVersion  = requesterVersion;
     _interComm->receive(acceptorVersion, 0);
     _interComm->send(requesterVersion, 0);
-    PRECICE_CHECK(requesterVersion != acceptorVersion, "Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
+    PRECICE_CHECK(requesterVersion != acceptorVersion, "This participant {} uses preCICE version {} but the acceptor participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
   }
 
   utils::IntraComm::broadcast(_isPrimaryRankConnected);


### PR DESCRIPTION
## Main changes of this PR

Directly after connecting the primary ranks, we check the preCICE versions (e.g., 3.1.2) of the requester and acceptor and add an error if they differ. 

```
PRECICE_ERROR("Participant {} uses preCICE version {} but participant {} uses preCICE version {}.", requesterName, requesterVersion, acceptorName, acceptorVersion);
```

## Motivation and additional information

This PR is motivated by #669 .

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
