### PR TITLE
Add emplaceSample to data to simplify tests

### DIFF
--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -86,6 +86,25 @@ void Data::setSampleAtTime(double time, const time::Sample &sample)
   _waveform.timeStepsStorage().setSampleAtTime(time, sample);
 }
 
+void Data::emplaceSampleAtTime(double time)
+{
+  setSampleAtTime(time, time::Sample{getDimensions()});
+}
+
+void Data::emplaceSampleAtTime(double time, std::initializer_list<double> values)
+{
+  setSampleAtTime(time, time::Sample{getDimensions(),
+                                     Eigen::Map<const Eigen::VectorXd>(values.begin(), values.size())});
+}
+
+void Data::emplaceSampleAtTime(double time, std::initializer_list<double> values, std::initializer_list<double> gradients)
+{
+  PRECICE_ASSERT(gradients.size() == values.size() * getSpatialDimensions(), "Gradient isn't correctly sized", values.size(), gradients.size());
+  setSampleAtTime(time, time::Sample{getDimensions(),
+                                     Eigen::Map<const Eigen::VectorXd>(values.begin(), values.size()),
+                                     Eigen::Map<const Eigen::MatrixXd>(gradients.begin(), values.size(), getDimensions() * getSpatialDimensions())});
+}
+
 const std::string &Data::getName() const
 {
   return _name;

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -100,9 +100,10 @@ void Data::emplaceSampleAtTime(double time, std::initializer_list<double> values
 void Data::emplaceSampleAtTime(double time, std::initializer_list<double> values, std::initializer_list<double> gradients)
 {
   PRECICE_ASSERT(gradients.size() == values.size() * getSpatialDimensions(), "Gradient isn't correctly sized", values.size(), gradients.size());
+  auto nVertices = values.size() / getDimensions();
   setSampleAtTime(time, time::Sample{getDimensions(),
                                      Eigen::Map<const Eigen::VectorXd>(values.begin(), values.size()),
-                                     Eigen::Map<const Eigen::MatrixXd>(gradients.begin(), values.size(), getDimensions() * getSpatialDimensions())});
+                                     Eigen::Map<const Eigen::MatrixXd>(gradients.begin(), nVertices, getDimensions() * getSpatialDimensions())});
 }
 
 const std::string &Data::getName() const

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Eigen/Core>
+#include <initializer_list>
 #include <stddef.h>
 #include <string>
 
@@ -104,6 +105,15 @@ public:
 
   /// Add sample at given time to _timeStepsStorage.
   void setSampleAtTime(double time, const time::Sample &sample);
+
+  /// Creates an empty sample at given time
+  void emplaceSampleAtTime(double time);
+
+  /// Creates a sample at given time with given values
+  void emplaceSampleAtTime(double time, std::initializer_list<double> values);
+
+  /// Creates a sample at given time with given values and gradients
+  void emplaceSampleAtTime(double time, std::initializer_list<double> values, std::initializer_list<double> gradients);
 
   /// Returns the name of the data set, as set in the config file.
   const std::string &getName() const;

--- a/src/precice/tests/WatchIntegralTest.cpp
+++ b/src/precice/tests/WatchIntegralTest.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->emplaceSampleAtTime(0, {1., 2., 3., 4.});
 
   std::string fileName("precice-WatchIntegralTest-scalarData-noConnectivity.log");
 
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5.}}));
+    doubleData->emplaceSampleAtTime(1, {2., 3., 4., 5.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
   mesh->createVertex(Eigen::Vector2d(1.0, 1.0));
 
   PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
-  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  vectorData->emplaceSampleAtTime(0, {1., 2., 3., 4., 5., 6., 7., 8.});
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity.log");
 
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    vectorData->emplaceSampleAtTime(1, {2., 3., 4., 5., 6., 7., 8., 9.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -150,8 +150,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
   mesh->createEdge(v2, v3);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3.}}));
-
+  doubleData->emplaceSampleAtTime(0, {1., 2., 3.});
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity.log");
 
   {
@@ -162,7 +161,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4.}}));
+    doubleData->emplaceSampleAtTime(1, {2., 3., 4.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -199,7 +198,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
   mesh->createEdge(v2, v3);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3.}}));
+  doubleData->emplaceSampleAtTime(0, {1., 2., 3.});
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-noScale.log");
 
@@ -211,7 +210,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4.}}));
+    doubleData->emplaceSampleAtTime(1, {2., 3., 4.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -248,7 +247,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
   mesh->createEdge(v2, v3);
 
   PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
-  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
+  vectorData->emplaceSampleAtTime(0, {1., 2., 3., 4., 5., 6.});
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity.log");
 
@@ -260,7 +259,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
+    vectorData->emplaceSampleAtTime(1, {2., 3., 4., 5., 6., 7.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -299,7 +298,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
   mesh->createEdge(v2, v3);
 
   PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
-  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6.}}));
+  vectorData->emplaceSampleAtTime(0, {1., 2., 3., 4., 5., 6.});
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-noScale.log");
 
@@ -311,7 +310,7 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7.}}));
+    vectorData->emplaceSampleAtTime(1, {2., 3., 4., 5., 6., 7.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -357,7 +356,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->emplaceSampleAtTime(0, {1., 2., 3., 4.});
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity.log");
 
@@ -369,7 +368,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5.}}));
+    doubleData->emplaceSampleAtTime(1, {2., 3., 4., 5.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -413,7 +412,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->emplaceSampleAtTime(0, {1., 2., 3., 4.});
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity-noScale.log");
 
@@ -425,7 +424,7 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5.}}));
+    doubleData->emplaceSampleAtTime(1, {2., 3., 4., 5.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -469,7 +468,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
-  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  vectorData->emplaceSampleAtTime(0, {1., 2., 3., 4., 5., 6., 7., 8.});
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity.log");
 
@@ -481,7 +480,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivity)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    vectorData->emplaceSampleAtTime(1, {2., 3., 4., 5., 6., 7., 8., 9.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -525,7 +524,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
-  vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4., 5., 6., 7., 8.}}));
+  vectorData->emplaceSampleAtTime(0, {1., 2., 3., 4., 5., 6., 7., 8.});
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity-noScale.log");
 
@@ -537,7 +536,7 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityNoScale)
     watchIntegral.exportIntegralData(0.0);
 
     // Change data (next timestep)
-    vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2., 3., 4., 5., 6., 7., 8., 9.}}));
+    vectorData->emplaceSampleAtTime(1, {2., 3., 4., 5., 6., 7., 8., 9.});
 
     // Write output again
     watchIntegral.exportIntegralData(1.0);
@@ -581,7 +580,7 @@ BOOST_AUTO_TEST_CASE(MeshChangeFaceConnectivity)
   mesh->createTriangle(e3, e4, e5);
 
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
-  doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1., 2., 3., 4.}}));
+  doubleData->emplaceSampleAtTime(0, {1., 2., 3., 4.});
 
   std::string fileName("precice-WatchIntegralTest-meshChange-faceConnectivity.log");
 
@@ -638,13 +637,13 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
   }
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 2.0}}));
+    doubleData->emplaceSampleAtTime(0, {1.0, 2.0});
   } else if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{3.0, 4.0}}));
+    doubleData->emplaceSampleAtTime(0, {3.0, 4.0});
   } else if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{5.0, 6.0}}));
+    doubleData->emplaceSampleAtTime(0, {5.0, 6.0});
   } else if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{7.0, 8.0}}));
+    doubleData->emplaceSampleAtTime(0, {7.0, 8.0});
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-noConnectivity-parallel.log");
@@ -658,13 +657,13 @@ BOOST_AUTO_TEST_CASE(ScalarDataNoConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 3.0}}));
+      doubleData->emplaceSampleAtTime(1, {2.0, 3.0});
     } else if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{4.0, 5.0}}));
+      doubleData->emplaceSampleAtTime(1, {4.0, 5.0});
     } else if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{6.0, 7.0}}));
+      doubleData->emplaceSampleAtTime(1, {6.0, 7.0});
     } else if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{8.0, 9.0}}));
+      doubleData->emplaceSampleAtTime(1, {8.0, 9.0});
     }
 
     // Write output again
@@ -712,13 +711,13 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
   }
 
   if (utils::IntraComm::isPrimary()) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
+    vectorData->emplaceSampleAtTime(0, {1.0, 2.0, 3.0, 4.0});
   } else if (context.isRank(1)) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
+    vectorData->emplaceSampleAtTime(0, {5.0, 6.0, 7.0, 8.0});
   } else if (context.isRank(2)) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
+    vectorData->emplaceSampleAtTime(0, {9.0, 10.0, 11.0, 12.0});
   } else if (context.isRank(3)) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
+    vectorData->emplaceSampleAtTime(0, {13.0, 14.0, 15.0, 16.0});
   }
 
   std::string fileName("precice-WatchIntegralTest-vectorData-noConnectivity-parallel.log");
@@ -732,13 +731,13 @@ BOOST_AUTO_TEST_CASE(VectorDataNoConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
+      vectorData->emplaceSampleAtTime(1, {2.0, 3.0, 4.0, 5.0});
     } else if (context.isRank(1)) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
+      vectorData->emplaceSampleAtTime(1, {6.0, 7.0, 8.0, 9.0});
     } else if (context.isRank(2)) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
+      vectorData->emplaceSampleAtTime(1, {10.0, 11.0, 12.0, 13.0});
     } else if (context.isRank(3)) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
+      vectorData->emplaceSampleAtTime(1, {14.0, 15.0, 16.0, 17.0});
     }
 
     // Write output again
@@ -794,16 +793,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 2.0}}));
+    doubleData->emplaceSampleAtTime(0, {1.0, 2.0});
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{3.0, 4.0}}));
+    doubleData->emplaceSampleAtTime(0, {3.0, 4.0});
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{5.0, 6.0}}));
+    doubleData->emplaceSampleAtTime(0, {5.0, 6.0});
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{7.0, 8.0}}));
+    doubleData->emplaceSampleAtTime(0, {7.0, 8.0});
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-parallel.log");
@@ -817,16 +816,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataEdgeConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 3.0}}));
+      doubleData->emplaceSampleAtTime(1, {2.0, 3.0});
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{4.0, 5.0}}));
+      doubleData->emplaceSampleAtTime(1, {4.0, 5.0});
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{6.0, 7.0}}));
+      doubleData->emplaceSampleAtTime(1, {6.0, 7.0});
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{8.0, 9.0}}));
+      doubleData->emplaceSampleAtTime(1, {8.0, 9.0});
     }
 
     // Write output again
@@ -882,16 +881,16 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
   PtrData vectorData = mesh->createData("DoubleData", 2, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0}}));
+    vectorData->emplaceSampleAtTime(0, {1.0, 2.0, 3.0, 4.0});
   }
   if (context.isRank(1)) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{5.0, 6.0, 7.0, 8.0}}));
+    vectorData->emplaceSampleAtTime(0, {5.0, 6.0, 7.0, 8.0});
   }
   if (context.isRank(2)) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{9.0, 10.0, 11.0, 12.0}}));
+    vectorData->emplaceSampleAtTime(0, {9.0, 10.0, 11.0, 12.0});
   }
   if (context.isRank(3)) {
-    vectorData->setSampleAtTime(0, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{13.0, 14.0, 15.0, 16.0}}));
+    vectorData->emplaceSampleAtTime(0, {13.0, 14.0, 15.0, 16.0});
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-edgeConnectivity-parallel.log");
@@ -905,16 +904,16 @@ BOOST_AUTO_TEST_CASE(VectorDataEdgeConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0}}));
+      vectorData->emplaceSampleAtTime(1, {2.0, 3.0, 4.0, 5.0});
     }
     if (context.isRank(1)) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{6.0, 7.0, 8.0, 9.0}}));
+      vectorData->emplaceSampleAtTime(1, {6.0, 7.0, 8.0, 9.0});
     }
     if (context.isRank(2)) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{10.0, 11.0, 12.0, 13.0}}));
+      vectorData->emplaceSampleAtTime(1, {10.0, 11.0, 12.0, 13.0});
     }
     if (context.isRank(3)) {
-      vectorData->setSampleAtTime(1, time::Sample(vectorData->getDimensions(), Eigen::VectorXd{{14.0, 15.0, 16.0, 17.0}}));
+      vectorData->emplaceSampleAtTime(1, {14.0, 15.0, 16.0, 17.0});
     }
 
     // Write output again
@@ -972,16 +971,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
   PtrData doubleData = mesh->createData("DoubleData", 1, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 2.0, 3.0}}));
+    doubleData->emplaceSampleAtTime(0, {1.0, 2.0, 3.0});
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions()));
+    doubleData->emplaceSampleAtTime(0);
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions()));
+    doubleData->emplaceSampleAtTime(0);
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{1.0, 3.0, 4.0}}));
+    doubleData->emplaceSampleAtTime(0, {1.0, 3.0, 4.0});
   }
 
   std::string fileName("precice-WatchIntegralTest-scalarData-faceConnectivity-parallel.log");
@@ -995,16 +994,16 @@ BOOST_AUTO_TEST_CASE(ScalarDataFaceConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 3.0, 4.0}}));
+      doubleData->emplaceSampleAtTime(1, {2.0, 3.0, 4.0});
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions()));
+      doubleData->emplaceSampleAtTime(1);
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions()));
+      doubleData->emplaceSampleAtTime(1);
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(doubleData->getDimensions(), Eigen::VectorXd{{2.0, 4.0, 5.0}}));
+      doubleData->emplaceSampleAtTime(1, {2.0, 4.0, 5.0});
     }
 
     // Write output again
@@ -1062,16 +1061,16 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
   PtrData doubleData = mesh->createData("DoubleData", 3, 0_dataID);
 
   if (utils::IntraComm::isPrimary()) {
-    doubleData->setSampleAtTime(0, time::Sample(3, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}}));
+    doubleData->emplaceSampleAtTime(0, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0});
   }
   if (context.isRank(1)) {
-    doubleData->setSampleAtTime(0, time::Sample(3));
+    doubleData->emplaceSampleAtTime(0);
   }
   if (context.isRank(2)) {
-    doubleData->setSampleAtTime(0, time::Sample(3));
+    doubleData->emplaceSampleAtTime(0);
   }
   if (context.isRank(3)) {
-    doubleData->setSampleAtTime(0, time::Sample(3, Eigen::VectorXd{{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0}}));
+    doubleData->emplaceSampleAtTime(0, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0});
   }
 
   std::string fileName("precice-WatchIntegralTest-vectorData-faceConnectivity-parallel.log");
@@ -1085,16 +1084,16 @@ BOOST_AUTO_TEST_CASE(VectorDataFaceConnectivityParallel)
 
     // Change data (next timestep)
     if (utils::IntraComm::isPrimary()) {
-      doubleData->setSampleAtTime(1, time::Sample(3, Eigen::VectorXd{{2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}}));
+      doubleData->emplaceSampleAtTime(1, {2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0});
     }
     if (context.isRank(1)) {
-      doubleData->setSampleAtTime(1, time::Sample(3));
+      doubleData->emplaceSampleAtTime(1);
     }
     if (context.isRank(2)) {
-      doubleData->setSampleAtTime(1, time::Sample(3));
+      doubleData->emplaceSampleAtTime(1);
     }
     if (context.isRank(3)) {
-      doubleData->setSampleAtTime(1, time::Sample(3, Eigen::VectorXd{{2.0, 3.0, 6.0, 7.0, 8.0, 9.0, 8.0, 9.0, 10.0}}));
+      doubleData->emplaceSampleAtTime(1, {2.0, 3.0, 6.0, 7.0, 8.0, 9.0, 8.0, 9.0, 10.0});
     }
 
     // Write output again


### PR DESCRIPTION
## Main changes of this PR

This PR adds `Data::emplaceSampleAtTime` variants, which simplifies adding samples to tests.

## Motivation and additional information

We need to move more tests to sample only variants and currently creating samples for data is pretty verbose.
This makes the creation simpler.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
