### PR TITLE
Provide time window end to perform acceleration

### DIFF
--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -34,7 +34,7 @@ public:
 
   virtual void initialize(const DataMap &cpldata) = 0;
 
-  virtual void performAcceleration(DataMap &cpldata, double windowStart) = 0;
+  virtual void performAcceleration(DataMap &cpldata, double windowStart, double windowEnd) = 0;
 
   virtual void iterationsConverged(const DataMap &cpldata, double windowStart) = 0;
 

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -125,14 +125,14 @@ void AitkenAcceleration::concatenateCouplingData(
   for (auto id : dataIDs) {
     Eigen::Index size = cplData.at(id)->values().size();
 
-    Eigen::VectorXd values    = cplData.at(id)->timeStepsStorage().sample(windowEnd).values();
-    Eigen::VectorXd oldValues = cplData.at(id)->getPreviousValuesAtTime(windowEnd).values();
+    auto valuesSample    = cplData.at(id)->timeStepsStorage().sample(windowEnd);
+    auto oldValuesSample = cplData.at(id)->getPreviousValuesAtTime(windowEnd);
 
     PRECICE_ASSERT(targetValues.size() >= offset + size, "Target vector was not initialized.", targetValues.size(), offset + size);
     PRECICE_ASSERT(targetOldValues.size() >= offset + size, "Target vector was not initialized.");
     for (Eigen::Index i = 0; i < size; i++) {
-      targetValues(i + offset)    = values(i);
-      targetOldValues(i + offset) = oldValues(i);
+      targetValues(i + offset)    = valuesSample.values()(i);
+      targetOldValues(i + offset) = oldValuesSample.values()(i);
     }
     offset += size;
   }

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -125,8 +125,8 @@ void AitkenAcceleration::concatenateCouplingData(
   for (auto id : dataIDs) {
     Eigen::Index size = cplData.at(id)->values().size();
 
-    Eigen::VectorXd values    = cplData.at(id)->timeStepsStorage().sample(windowEnd);
-    Eigen::VectorXd oldValues = cplData.at(id)->getPreviousValuesAtTime(windowEnd);
+    Eigen::VectorXd values    = cplData.at(id)->timeStepsStorage().sample(windowEnd).values();
+    Eigen::VectorXd oldValues = cplData.at(id)->getPreviousValuesAtTime(windowEnd).values();
 
     PRECICE_ASSERT(targetValues.size() >= offset + size, "Target vector was not initialized.", targetValues.size(), offset + size);
     PRECICE_ASSERT(targetOldValues.size() >= offset + size, "Target vector was not initialized.");

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -32,7 +32,8 @@ public:
 
   virtual void performAcceleration(
       DataMap &cpldata,
-      double   windowStart) override final;
+      double   windowStart,
+      double   windowEnd) override final;
 
   virtual void iterationsConverged(
       const DataMap &cpldata, double windowStart) override final;
@@ -40,7 +41,7 @@ public:
 private:
   /// @brief Concatenates the data and old data in cplData into two long vectors
   void concatenateCouplingData(
-      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues, double windowStart) const;
+      const DataMap &cplData, const std::vector<DataID> &dataIDs, Eigen::VectorXd &targetValues, Eigen::VectorXd &targetOldValues, double windowStart, double windowEnd) const;
 
   logging::Logger _log{"acceleration::AitkenAcceleration"};
 

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -211,7 +211,8 @@ void BaseQNAcceleration::updateDifferenceMatrices(
  */
 void BaseQNAcceleration::performAcceleration(
     DataMap &cplData,
-    double   windowStart)
+    double   windowStart,
+    double   windowEnd)
 {
   PRECICE_TRACE(_primaryDataIDs.size(), cplData.size());
 

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -105,7 +105,7 @@ public:
    *
    * Has to be called after every implicit coupling iteration.
    */
-  virtual void performAcceleration(DataMap &cplData, double windowStart) override final;
+  virtual void performAcceleration(DataMap &cplData, double windowStart, double windowEnd) override final;
 
   /**
    * @brief Marks a iteration sequence as converged.

--- a/src/acceleration/ConstantRelaxationAcceleration.cpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.cpp
@@ -29,7 +29,7 @@ void ConstantRelaxationAcceleration::initialize(const DataMap &cplData)
   checkDataIDs(cplData);
 }
 
-void ConstantRelaxationAcceleration::performAcceleration(DataMap &cplData, double windowStart)
+void ConstantRelaxationAcceleration::performAcceleration(DataMap &cplData, double windowStart, double windowEnd)
 {
   PRECICE_TRACE();
   applyRelaxation(_relaxation, cplData, windowStart);

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -23,7 +23,7 @@ public:
 
   virtual void initialize(const DataMap &cplData) override;
 
-  virtual void performAcceleration(DataMap &cplData, double windowStart) override;
+  virtual void performAcceleration(DataMap &cplData, double windowStart, double windowEnd) override;
 
   virtual void iterationsConverged(const DataMap &cplData, double windowStart) override
   {

--- a/src/acceleration/test/AccelerationIntraCommTest.cpp
+++ b/src/acceleration/test/AccelerationIntraCommTest.cpp
@@ -210,7 +210,7 @@ BOOST_DATA_TEST_CASE(testVIQNILSppWithoutSubsteps, boost::unit_test::data::make(
     fpcd->setSampleAtTime(windowEnd, fpcd->sample());
   }
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   Eigen::VectorXd newdvalues;
   if (context.isPrimary()) { // Primary
@@ -262,7 +262,7 @@ BOOST_DATA_TEST_CASE(testVIQNILSppWithoutSubsteps, boost::unit_test::data::make(
   dpcd->setSampleAtTime(windowEnd, dpcd->sample());
   fpcd->setSampleAtTime(windowEnd, fpcd->sample());
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   if (context.isPrimary()) { // Primary
     BOOST_TEST(testing::equals(data.at(0)->values()(0), -1.51483105223442748866e+00), data.at(0)->values()(0));
@@ -522,7 +522,7 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     BOOST_TEST(testing::equals(data.at(1)->values()(1), 0.1), data.at(1)->values()(1));
   }
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   Eigen::VectorXd newdvalues;
   if (context.isPrimary()) { // Primary
@@ -567,7 +567,7 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
   dpcd->setSampleAtTime(windowEnd, dpcd->sample());
   fpcd->setSampleAtTime(windowEnd, fpcd->sample());
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   if (context.isPrimary()) { // Primary
     BOOST_TEST(testing::equals(data.at(0)->values()(0), -1.51483105223442748866e+00), data.at(0)->values()(0));
@@ -756,7 +756,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     pp.initialize(data);
   }
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
   for (auto &pair : data) {
@@ -830,7 +830,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   }
 
   // QN- Update, 2. iteration
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
   for (auto &pair : data) {
@@ -909,7 +909,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   }
 
   // QN- Update, 3. iteration
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
   for (auto &pair : data) {
@@ -983,7 +983,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   }
 
   // QN- Update, 4. iteration
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
   for (auto &pair : data) {
@@ -1057,7 +1057,7 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
   }
 
   // QN- Update, 5. iteratidataon
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   // necessary because acceleration does not directly work on storage, but on CouplingData::values. See and https://github.com/precice/precice/issues/1645 current implementation in BaseCouplingScheme::doImplicitStep()
   for (auto &pair : data) {
@@ -1209,7 +1209,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   dpcd->setSampleAtTime(windowStart, dpcd->sample());
   dpcd->setSampleAtTime(windowEnd, dpcd->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   Eigen::VectorXd newdvalues1;
   if (context.isPrimary()) {
@@ -1225,7 +1225,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   data.begin()->second->values() = newdvalues1;
   dpcd->setSampleAtTime(windowEnd, dpcd->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   Eigen::VectorXd newdvalues2;
   if (context.isPrimary()) {
@@ -1261,7 +1261,7 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
   data.begin()->second->values() = newdvalues3;
   dpcd->setSampleAtTime(windowEnd, dpcd->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   Eigen::VectorXd newdvalues4;
   if (context.isPrimary()) {

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -98,7 +98,7 @@ void testIQNIMVJPP(bool exchangeSubsteps)
   forces->values() << 0.1, 0.1, 0.1, 0.1;
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(testing::equals(data.at(0)->values()(0), 1.00000000000000000000));
   BOOST_TEST(testing::equals(data.at(0)->values()(1), 1.01000000000000000888));
@@ -115,7 +115,7 @@ void testIQNIMVJPP(bool exchangeSubsteps)
   displacements->setSampleAtTime(windowEnd, displacements->sample());
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(testing::equals(data.at(0)->values()(0), -5.63401340929695848558e-01));
   BOOST_TEST(testing::equals(data.at(0)->values()(1), 6.10309919173602111186e-01));
@@ -203,7 +203,7 @@ void testVIQNPP(bool exchangeSubsteps)
   forces->values() << 0.1, 0.1, 0.1, 0.1;
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(testing::equals(data.at(0)->values()(0), 1.00));
   BOOST_TEST(testing::equals(data.at(0)->values()(1), 1.01));
@@ -224,7 +224,7 @@ void testVIQNPP(bool exchangeSubsteps)
   displacements->setSampleAtTime(windowEnd, displacements->sample());
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  pp.performAcceleration(data, windowStart);
+  pp.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(testing::equals(data.at(0)->values()(0), -5.63401340929692295845e-01));
   BOOST_TEST(testing::equals(data.at(0)->values()(1), 6.10309919173607440257e-01));
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithSubsteps)
   forces->values() << 0.1, 0.1, 0.1, 0.1;
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 2);
   BOOST_TEST(data.at(0)->values()(1) == 2);
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithSubsteps)
   displacements->setSampleAtTime(windowEnd, displacements->sample());
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 4.6);
   BOOST_TEST(data.at(0)->values()(1) == 5.2);
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithoutSubsteps)
   forces->values() << 0.1, 0.1, 0.1, 0.1;
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 2);
   BOOST_TEST(data.at(0)->values()(1) == 2);
@@ -380,7 +380,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithoutSubsteps)
   displacements->setSampleAtTime(windowEnd, displacements->sample());
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 1.2689851805508461);
   BOOST_TEST(data.at(0)->values()(1) == 2.2390979382674185);
@@ -459,7 +459,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
   data4->values() << 40, 60, 80, 100;
   data4->setSampleAtTime(windowEnd, data4->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 8.8);
   BOOST_TEST(data.at(0)->values()(1) == 21.6);
@@ -482,7 +482,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
   data4->values() << 41, 61, 81, 90;
   data4->setSampleAtTime(windowEnd, data4->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == -17.745640722103754);
   BOOST_TEST(data.at(0)->values()(1) == -20.295060201548626);
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
   data4->values() << 50, 70, 90, 110;
   data4->setSampleAtTime(windowEnd, data4->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 10.4);
   BOOST_TEST(data.at(0)->values()(1) == 28.8);
@@ -594,7 +594,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithSubsteps)
   forces->gradients().setConstant(3);
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   // Test value data
   BOOST_TEST(data.at(0)->values()(0) == 2);
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithSubsteps)
   displacements->setSampleAtTime(windowEnd, displacements->sample());
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   // Check that store iteration works properly
   BOOST_TEST(data.at(0)->values()(0) == 4.6);
@@ -689,7 +689,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
   forces->values() << 0.1, 0.1, 0.1, 0.1;
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 2);
   BOOST_TEST(data.at(0)->values()(1) == 2);
@@ -704,7 +704,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
   displacements->setSampleAtTime(windowEnd, displacements->sample());
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   BOOST_TEST(data.at(0)->values()(0) == 4.6);
   BOOST_TEST(data.at(0)->values()(1) == 5.2);
@@ -771,7 +771,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithoutSubsteps)
   forces->gradients().setConstant(3);
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   // Test value data
   BOOST_TEST(data.at(0)->values()(0) == 2);
@@ -802,7 +802,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithoutSubsteps)
   displacements->setSampleAtTime(windowEnd, displacements->sample());
   forces->setSampleAtTime(windowEnd, forces->sample());
 
-  acc.performAcceleration(data, windowStart);
+  acc.performAcceleration(data, windowStart, windowEnd);
 
   // Check that store iteration works properly
   BOOST_TEST(data.at(0)->values()(0) == 4.6);

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -914,7 +914,7 @@ void BaseCouplingScheme::doImplicitStep()
         data->sample() = stamples.back().sample;
       }
 
-      _acceleration->performAcceleration(getAccelerationData(), getTimeWindowStart());
+      _acceleration->performAcceleration(getAccelerationData(), getTimeWindowStart(), getWindowEndTime());
 
       // Store from buffer
       // @todo Currently only data at end of window is accelerated. Remaining data in storage stays as it is.


### PR DESCRIPTION
## Main changes of this PR
As the title

## Motivation and additional information
To synchronize with QN in Aitken, we want to get the value at a clear time point than getting the latest data by default while concatenating data. For Aitken, it's the end time of the time window.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
