### PR TITLE
Make shape in gradients consistent

### DIFF
--- a/src/com/tests/SerializedStamplesTest.cpp
+++ b/src/com/tests/SerializedStamplesTest.cpp
@@ -63,8 +63,8 @@ BOOST_AUTO_TEST_CASE(DeserializeValues)
   PRECICE_TEST();
   std::vector<int> vertexOffsets{4, 8, 8, 10};
 
-  const int meshDimensions = 3;
   const int nValues        = 4;
+  const int dataDimensions = 1;
   const int nTimeSteps     = 3;
 
   Eigen::VectorXd serializedValues(nTimeSteps * nValues);
@@ -72,8 +72,12 @@ BOOST_AUTO_TEST_CASE(DeserializeValues)
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
+  dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
-  mesh::PtrData              toData(new mesh::Data("to", -1, 1));
+  mesh::PtrData              toData(new mesh::Data("to", -1, dataDimensions));
   cplscheme::PtrCouplingData toDataPtr = makeCouplingData(toData, dummyMesh);
   toDataPtr->sample().values           = Eigen::VectorXd(nValues);
   toDataPtr->sample().setZero();
@@ -124,6 +128,10 @@ BOOST_AUTO_TEST_CASE(SerializeValuesAndGradients)
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", meshDimensions, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
+  dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
   mesh::PtrData fromData(new mesh::Data("from", -1, dataDimensions));
   fromData->requireDataGradient();
@@ -134,21 +142,18 @@ BOOST_AUTO_TEST_CASE(SerializeValuesAndGradients)
   insert05 << 10.0, 20.0, 30.0, 40.0;
   Eigen::VectorXd insert1(nValues);
   insert1 << 100.0, 200.0, 300.0, 400.0;
-  Eigen::MatrixXd insertGradients0(nValues, meshDimensions);
-  insertGradients0 << 1.0, 2.0, 3.0,
-      4.0, 1.0, 2.0,
-      3.0, 4.0, 1.0,
-      2.0, 3.0, 4.0;
-  Eigen::MatrixXd insertGradients05(nValues, meshDimensions);
-  insertGradients05 << 11.0, 21.0, 31.0,
-      41.0, 11.0, 21.0,
-      31.0, 41.0, 11.0,
-      21.0, 31.0, 41.0;
-  Eigen::MatrixXd insertGradients1(nValues, meshDimensions);
-  insertGradients1 << 111.0, 211.0, 311.0,
-      411.0, 111.0, 211.0,
-      311.0, 411.0, 111.0,
-      211.0, 311.0, 411.0;
+  Eigen::MatrixXd insertGradients0(meshDimensions, nValues * dataDimensions);
+  insertGradients0 << 10.0, 20.0, 30.0, 40.0,
+      11.0, 21.0, 31.0, 41.0,
+      12.0, 22.0, 32.0, 42.0;
+  Eigen::MatrixXd insertGradients05(meshDimensions, nValues * dataDimensions);
+  insertGradients05 << 100.0, 200.0, 300.0, 400.0,
+      101.0, 201.0, 301.0, 401.0,
+      102.0, 202.0, 302.0, 402.0;
+  Eigen::MatrixXd insertGradients1(meshDimensions, nValues * dataDimensions);
+  insertGradients1 << 1000.0, 2000.0, 3000.0, 4000.0,
+      1001.0, 2001.0, 3001.0, 4001.0,
+      1002.0, 2002.0, 3002.0, 4002.0;
 
   cplscheme::PtrCouplingData fromDataPtr = makeCouplingData(fromData, dummyMesh);
 
@@ -162,7 +167,10 @@ BOOST_AUTO_TEST_CASE(SerializeValuesAndGradients)
   expectedSerializedValues << 1.0, 10.0, 100.0, 2.0, 20.0, 200.0, 3.0, 30.0, 300.0, 4.0, 40.0, 400.0;
 
   Eigen::VectorXd expectedSerializedGradients(nTimeSteps * nValues * meshDimensions);
-  expectedSerializedGradients << 1.0, 11.0, 111.0, 4.0, 41.0, 411.0, 3.0, 31.0, 311.0, 2.0, 21.0, 211.0, 2.0, 21.0, 211.0, 1.0, 11.0, 111.0, 4.0, 41.0, 411.0, 3.0, 31.0, 311.0, 3.0, 31.0, 311.0, 2.0, 21.0, 211.0, 1.0, 11.0, 111.0, 4.0, 41.0, 411.0;
+  expectedSerializedGradients << 10.0, 100.0, 1000.0, 11.0, 101.0, 1001.0, 12.0, 102.0, 1002.0,
+      20.0, 200.0, 2000.0, 21.0, 201.0, 2001.0, 22.0, 202.0, 2002.0,
+      30.0, 300.0, 3000.0, 31.0, 301.0, 3001.0, 32.0, 302.0, 3002.0,
+      40.0, 400.0, 4000.0, 41.0, 401.0, 4001.0, 42.0, 402.0, 4002.0;
 
   for (int i = 0; i < nTimeSteps * nValues; i++) {
     BOOST_TEST(testing::equals(serialized.values()(i), expectedSerializedValues(i)));
@@ -181,18 +189,26 @@ BOOST_AUTO_TEST_CASE(DeserializeValuesAndGradients)
 
   const int meshDimensions = 3;
   const int nValues        = 4;
+  const int dataDimensions = 1;
   const int nTimeSteps     = 3;
 
   Eigen::VectorXd serializedValues(nTimeSteps * nValues);
   serializedValues << 1.0, 10.0, 100.0, 2.0, 20.0, 200.0, 3.0, 30.0, 300.0, 4.0, 40.0, 400.0;
 
   Eigen::VectorXd serializedGradients(nTimeSteps * nValues * meshDimensions);
-  serializedGradients << 1.0, 11.0, 111.0, 4.0, 41.0, 411.0, 3.0, 31.0, 311.0, 2.0, 21.0, 211.0, 2.0, 21.0, 211.0, 1.0, 11.0, 111.0, 4.0, 41.0, 411.0, 3.0, 31.0, 311.0, 3.0, 31.0, 311.0, 2.0, 21.0, 211.0, 1.0, 11.0, 111.0, 4.0, 41.0, 411.0;
+  serializedGradients << 10.0, 100.0, 1000.0, 11.0, 101.0, 1001.0, 12.0, 102.0, 1002.0,
+      20.0, 200.0, 2000.0, 21.0, 201.0, 2001.0, 22.0, 202.0, 2002.0,
+      30.0, 300.0, 3000.0, 31.0, 301.0, 3001.0, 32.0, 302.0, 3002.0,
+      40.0, 400.0, 4000.0, 41.0, 401.0, 4001.0, 42.0, 402.0, 4002.0;
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
+  dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
+  dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
-  mesh::PtrData toData(new mesh::Data("to", -1, 1));
+  mesh::PtrData toData(new mesh::Data("to", -1, dataDimensions));
   toData->requireDataGradient();
 
   cplscheme::PtrCouplingData toDataPtr = makeCouplingData(toData, dummyMesh);
@@ -227,21 +243,18 @@ BOOST_AUTO_TEST_CASE(DeserializeValuesAndGradients)
 
   std::vector<Eigen::MatrixXd> expectedGradients;
 
-  Eigen::MatrixXd insertGradients0(nValues, meshDimensions);
-  insertGradients0 << 1.0, 2.0, 3.0,
-      4.0, 1.0, 2.0,
-      3.0, 4.0, 1.0,
-      2.0, 3.0, 4.0;
-  Eigen::MatrixXd insertGradients05(nValues, meshDimensions);
-  insertGradients05 << 11.0, 21.0, 31.0,
-      41.0, 11.0, 21.0,
-      31.0, 41.0, 11.0,
-      21.0, 31.0, 41.0;
-  Eigen::MatrixXd insertGradients1(nValues, meshDimensions);
-  insertGradients1 << 111.0, 211.0, 311.0,
-      411.0, 111.0, 211.0,
-      311.0, 411.0, 111.0,
-      211.0, 311.0, 411.0;
+  Eigen::MatrixXd insertGradients0(meshDimensions, dataDimensions * nValues);
+  insertGradients0 << 10.0, 20.0, 30.0, 40.0,
+      11.0, 21.0, 31.0, 41.0,
+      12.0, 22.0, 32.0, 42.0;
+  Eigen::MatrixXd insertGradients05(meshDimensions, nValues * dataDimensions);
+  insertGradients05 << 100.0, 200.0, 300.0, 400.0,
+      101.0, 201.0, 301.0, 401.0,
+      102.0, 202.0, 302.0, 402.0;
+  Eigen::MatrixXd insertGradients1(meshDimensions, nValues * dataDimensions);
+  insertGradients1 << 1000.0, 2000.0, 3000.0, 4000.0,
+      1001.0, 2001.0, 3001.0, 4001.0,
+      1002.0, 2002.0, 3002.0, 4002.0;
 
   expectedGradients.push_back(insertGradients0);
   expectedGradients.push_back(insertGradients05);

--- a/src/com/tests/SerializedStamplesTest.cpp
+++ b/src/com/tests/SerializedStamplesTest.cpp
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(DeserializeValuesAndGradients)
 
   cplscheme::PtrCouplingData toDataPtr = makeCouplingData(toData, dummyMesh);
   toDataPtr->sample().values           = Eigen::VectorXd(nValues);
-  toDataPtr->sample().gradients        = Eigen::MatrixXd(nValues, meshDimensions);
+  toDataPtr->sample().gradients        = Eigen::MatrixXd(meshDimensions, nValues);
   toDataPtr->sample().setZero();
 
   toDataPtr->setSampleAtTime(0, toDataPtr->sample());

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -201,14 +201,18 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
 
       serialized.deserializeInto(timesAscending, data);
     } else {
-      // Data is only received on ranks with size>0, which is checked in the derived class implementation
-      m2n->receive(data->values(), data->getMeshID(), data->getDimensions());
-
       if (data->hasGradient()) {
-        PRECICE_ASSERT(data->hasGradient());
-        m2n->receive(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
+        // Data is only received on ranks with size>0, which is checked in the derived class implementation
+        time::Sample recvSample(data->getDimensions(), data->nVertices(), data->meshDimensions());
+        m2n->receive(recvSample.values, data->getMeshID(), data->getDimensions());
+        m2n->receive(recvSample.gradients, data->getMeshID(), data->getDimensions() * data->meshDimensions());
+        data->setSampleAtTime(getTime(), recvSample);
+      } else {
+        // Data is only received on ranks with size>0, which is checked in the derived class implementation
+        time::Sample recvSample(data->getDimensions(), data->nVertices());
+        m2n->receive(recvSample.values, data->getMeshID(), data->getDimensions());
+        data->setSampleAtTime(getTime(), recvSample);
       }
-      data->setSampleAtTime(getTime(), data->sample());
     }
   }
 }

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -143,14 +143,15 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
         m2n->send(serialized.gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions() * serialized.nTimeSteps());
       }
     } else {
-      data->sample() = stamples.back().sample;
-
-      // Data is only received on ranks with size>0, which is checked in the derived class implementation
-      m2n->send(data->values(), data->getMeshID(), data->getDimensions());
-
       if (data->hasGradient()) {
-        PRECICE_ASSERT(data->hasGradient());
+        data->sample() = stamples.back().sample;
+        // Data is only received on ranks with size>0, which is checked in the derived class implementation
+        m2n->send(data->values(), data->getMeshID(), data->getDimensions());
         m2n->send(data->gradients(), data->getMeshID(), data->getDimensions() * data->meshDimensions());
+      } else {
+        data->sample() = stamples.back().sample;
+        // Data is only received on ranks with size>0, which is checked in the derived class implementation
+        m2n->send(data->values(), data->getMeshID(), data->getDimensions());
       }
     }
   }

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -116,7 +116,7 @@ void CouplingData::reinitialize()
   // Meaning all samples are based on a different mesh.
   // Without remapping, the best we can do is setting them to zero samples.
   // We keep the timestamps not to break convergence measures, accelerations, and actions
-  auto zero = time::Sample(_data->getDimensions(), _mesh->nVertices());
+  auto zero = time::Sample(getDimensions(), nVertices());
   zero.setZero();
 
   _data->timeStepsStorage().setAllSamples(zero);

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -36,7 +36,16 @@ int CouplingData::getDimensions() const
 
 int CouplingData::getSize() const
 {
+  // @ŧodo this correct implementation breaks a ton of tests that don't define vertices of a test mesh
+  //return _mesh->nVertices() * getDimensions();
   return sample().values.size();
+}
+
+int CouplingData::nVertices() const
+{
+  // @ŧodo this correct implementation breaks a ton of tests that don't define vertices of a test mesh
+  //return _mesh->nVertices();
+  return sample().values.size() / getDimensions();
 }
 
 Eigen::VectorXd &CouplingData::values()

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -26,6 +26,8 @@ public:
 
   int getSize() const;
 
+  int nVertices() const;
+
   /// Returns a reference to the data values.
   Eigen::VectorXd &values();
 

--- a/src/mesh/Data.cpp
+++ b/src/mesh/Data.cpp
@@ -103,7 +103,7 @@ void Data::emplaceSampleAtTime(double time, std::initializer_list<double> values
   auto nVertices = values.size() / getDimensions();
   setSampleAtTime(time, time::Sample{getDimensions(),
                                      Eigen::Map<const Eigen::VectorXd>(values.begin(), values.size()),
-                                     Eigen::Map<const Eigen::MatrixXd>(gradients.begin(), nVertices, getDimensions() * getSpatialDimensions())});
+                                     Eigen::Map<const Eigen::MatrixXd>(gradients.begin(), getSpatialDimensions(), nVertices * getDimensions())});
 }
 
 const std::string &Data::getName() const

--- a/src/time/Sample.hpp
+++ b/src/time/Sample.hpp
@@ -39,7 +39,7 @@ struct Sample {
       : dataDims(dims), values(std::move(inValues)), gradients(std::move(inGradients))
   {
     PRECICE_ASSERT(dataDims > 0);
-    PRECICE_ASSERT(gradients.size() == 0 || gradients.cols() == values.size());
+    PRECICE_ASSERT(gradients.size() == 0 || gradients.cols() == values.size(), gradients.size(), gradients.cols(), values.size());
   }
 
   Sample(const Sample &) = default;

--- a/src/time/Sample.hpp
+++ b/src/time/Sample.hpp
@@ -3,6 +3,8 @@
 
 #include <Eigen/Core>
 
+#include "utils/assertion.hpp"
+
 namespace precice::time {
 
 /** Sample of a \ref mesh::Data on a \ref mesh::Mesh
@@ -21,15 +23,24 @@ struct Sample {
 
   /// Constructs a Sample of given data and mesh dimensionality, and size with gradients
   Sample(int dataDims, int nVertices, int meshDims)
-      : dataDims(dataDims), values(nVertices * dataDims), gradients(nVertices, dataDims * meshDims) {}
+      : dataDims(dataDims), values(nVertices * dataDims), gradients(meshDims, nVertices * dataDims)
+  {
+  }
 
   /// Constructs a Sample of given data dimensionality and data values
   Sample(int dims, Eigen::VectorXd inValues)
-      : dataDims(dims), values(std::move(inValues)) {}
+      : dataDims(dims), values(std::move(inValues))
+  {
+    PRECICE_ASSERT(dataDims > 0);
+  }
 
   /// Constructs a Sample of given data dimensionality, data values, and data gradients
   Sample(int dims, Eigen::VectorXd inValues, Eigen::MatrixXd inGradients)
-      : dataDims(dims), values(std::move(inValues)), gradients(std::move(inGradients)) {}
+      : dataDims(dims), values(std::move(inValues)), gradients(std::move(inGradients))
+  {
+    PRECICE_ASSERT(dataDims > 0);
+    PRECICE_ASSERT(gradients.size() == 0 || gradients.cols() == values.size());
+  }
 
   Sample(const Sample &) = default;
   Sample(Sample &&)      = default;


### PR DESCRIPTION
## Main changes of this PR

Fix inconsistent gradient shapes for samples.

## Motivation and additional information

Because this inconsistency led to problems in #2203 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
