### PR TITLE
Disable Nagle alogrithm in sockets

### DIFF
--- a/docs/changelog/2208.md
+++ b/docs/changelog/2208.md
@@ -1,0 +1,1 @@
+- Changed `m2n:sockets` and `intra-comm:sockets` to disable Nagle's algorithm using TCP_NODELAY, which improves data communication delay. This is especially noticeable when using substeps.

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -94,6 +94,9 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
       auto socket = std::make_shared<Socket>(*_ioContext);
 
       acceptor.accept(*socket);
+      boost::asio::ip::tcp::no_delay option(true);
+      socket->set_option(option);
+
       PRECICE_DEBUG("Accepted connection at {}", address);
       _isConnected = true;
 
@@ -178,6 +181,8 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
     for (int connection = 0; connection < requesterCommunicatorSize; ++connection) {
       auto socket = std::make_shared<Socket>(*_ioContext);
       acceptor.accept(*socket);
+      boost::asio::ip::tcp::no_delay option(true);
+      socket->set_option(option);
       PRECICE_DEBUG("Accepted connection at {}", address);
       _isConnected = true;
 
@@ -235,6 +240,8 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
         timer.wait();
       }
     }
+    boost::asio::ip::tcp::no_delay option(true);
+    socket->set_option(option);
 
     PRECICE_DEBUG("Requested connection to {}", address);
 
@@ -297,6 +304,8 @@ void SocketCommunication::requestConnectionAsClient(std::string const &  accepto
           timer.wait();
         }
       }
+      boost::asio::ip::tcp::no_delay option(true);
+      socket->set_option(option);
 
       PRECICE_DEBUG("Requested connection to {}, rank = {}", address, acceptorRank);
       _sockets[acceptorRank] = std::move(socket);


### PR DESCRIPTION
## Main changes of this PR

This PR disables the Nagle algorithm in the sockets communication, which purpose is to reduce package count in the network at the cost of latency.


## Motivation and additional information

This introduced latency which leads to performance degradation in https://github.com/precice/precice/issues/1679#issuecomment-2671898614

This could lead to network congestion and may be a good candidate for a configuration option. 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
