### PR TITLE
Simplify communication of time stamps

### DIFF
--- a/src/com/SerializedStamples.cpp
+++ b/src/com/SerializedStamples.cpp
@@ -17,18 +17,18 @@ SerializedStamples SerializedStamples::serialize(const cplscheme::PtrCouplingDat
   return result;
 }
 
-SerializedStamples SerializedStamples::empty(Eigen::VectorXd timeStamps, const cplscheme::PtrCouplingData data)
+SerializedStamples SerializedStamples::empty(int nTimeStamps, const cplscheme::PtrCouplingData data)
 {
   SerializedStamples result;
 
-  result._timeSteps = timeStamps.size();
+  result._timeSteps = nTimeStamps;
 
   result.allocate(data);
 
   return result;
 }
 
-void SerializedStamples::deserializeInto(const Eigen::VectorXd &timeStamps, const cplscheme::PtrCouplingData data)
+void SerializedStamples::deserializeInto(precice::span<const double> timeStamps, const cplscheme::PtrCouplingData data)
 {
   PRECICE_ASSERT(_timeSteps == timeStamps.size());
 
@@ -71,7 +71,7 @@ void SerializedStamples::serializeGradients(const cplscheme::PtrCouplingData dat
   }
 }
 
-void SerializedStamples::deserialize(const Eigen::VectorXd timeStamps, cplscheme::PtrCouplingData data) const
+void SerializedStamples::deserialize(precice::span<const double> timeStamps, cplscheme::PtrCouplingData data) const
 {
   PRECICE_ASSERT(timeStamps.size() * data->getSize() == _values.size(), timeStamps.size() * data->getSize(), _values.size());
 
@@ -80,7 +80,7 @@ void SerializedStamples::deserialize(const Eigen::VectorXd timeStamps, cplscheme
   const auto dataDims = data->getDimensions();
 
   for (int timeId = 0; timeId < timeStamps.size(); timeId++) {
-    const double time = timeStamps(timeId);
+    const double time = timeStamps[timeId];
 
     Eigen::VectorXd slice(data->getSize());
     for (int valueId = 0; valueId < slice.size(); valueId++) {

--- a/src/com/SerializedStamples.hpp
+++ b/src/com/SerializedStamples.hpp
@@ -3,6 +3,7 @@
 #include <Eigen/Core>
 #include <vector>
 #include "cplscheme/SharedPointer.hpp"
+#include "precice/span.hpp"
 
 namespace precice {
 namespace com {
@@ -24,11 +25,11 @@ public:
   /**
    * @brief Create SerializedStamples with allocated buffers according to size of CouplingData
    *
-   * @param timeStamps Corresponding time stamps that will be stored in SerializedSamples
+   * @param nTimeSteps Amount of time stamps that will be stored in SerializedSamples
    * @param data pointer to CouplingData defining size of buffer and whether gradient data exists
    * @return SerializedStamples has allocated data buffers for serialized data
    */
-  static SerializedStamples empty(Eigen::VectorXd timeStamps, const cplscheme::PtrCouplingData data);
+  static SerializedStamples empty(int nTimeSteps, const cplscheme::PtrCouplingData data);
 
   /**
    * @brief Deserialize data from this SerializedStamples into provided CouplingData
@@ -36,7 +37,7 @@ public:
    * @param timeStamps Corresponding time stamps for deserialized data
    * @param data pointer to CouplingData the SerializedStampes will be deserialized into
    */
-  void deserializeInto(const Eigen::VectorXd &timeStamps, const cplscheme::PtrCouplingData data);
+  void deserializeInto(precice::span<const double> timeStamps, const cplscheme::PtrCouplingData data);
 
   /**
    * @brief const reference to serialized values. Used for sending serialized values.
@@ -99,7 +100,7 @@ private:
      * @param timeStamps
      * @param data
      */
-  void deserialize(const Eigen::VectorXd timeStamps, cplscheme::PtrCouplingData data) const;
+  void deserialize(precice::span<const double> timeStamps, cplscheme::PtrCouplingData data) const;
 
   /// Buffer for serialized values of stamples
   Eigen::VectorXd _values;

--- a/src/com/tests/SerializedStamplesTest.cpp
+++ b/src/com/tests/SerializedStamplesTest.cpp
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE(DeserializeValues)
   Eigen::VectorXd timeStamps(nTimeSteps);
   timeStamps << 0, 0.5, 1;
 
-  auto serialized = serialize::SerializedStamples::empty(timeStamps, toDataPtr);
+  auto serialized = serialize::SerializedStamples::empty(timeStamps.size(), toDataPtr);
 
   serialized.values() = serializedValues;
 
@@ -226,7 +226,7 @@ BOOST_AUTO_TEST_CASE(DeserializeValuesAndGradients)
   Eigen::VectorXd timeStamps(nTimeSteps);
   timeStamps << 0, 0.5, 1;
 
-  auto serialized = serialize::SerializedStamples::empty(timeStamps, toDataPtr);
+  auto serialized = serialize::SerializedStamples::empty(timeStamps.size(), toDataPtr);
 
   serialized.values()    = serializedValues;
   serialized.gradients() = serializedGradients;

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -100,16 +100,11 @@ bool BaseCouplingScheme::hasConverged() const
   return _hasConverged;
 }
 
-void BaseCouplingScheme::sendNumberOfTimeSteps(const m2n::PtrM2N &m2n, const int numberOfTimeSteps)
+void BaseCouplingScheme::sendTimes(const m2n::PtrM2N &m2n, precice::span<double const> times)
 {
   PRECICE_TRACE();
-  PRECICE_DEBUG("Sending number or time steps {}...", numberOfTimeSteps);
-  m2n->send(numberOfTimeSteps);
-}
-
-void BaseCouplingScheme::sendTimes(const m2n::PtrM2N &m2n, const Eigen::VectorXd &times)
-{
-  PRECICE_TRACE();
+  PRECICE_DEBUG("Sending number or time steps {}...", times.size());
+  m2n->send(static_cast<int>(times.size()));
   PRECICE_DEBUG("Sending times...");
   m2n->send(times);
 }
@@ -130,8 +125,7 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
     PRECICE_ASSERT(nTimeSteps > 0);
 
     if (data->exchangeSubsteps()) {
-      const Eigen::VectorXd timesAscending = data->timeStepsStorage().getTimes();
-      sendNumberOfTimeSteps(m2n, nTimeSteps);
+      const auto timesAscending = data->timeStepsStorage().getTimes();
       sendTimes(m2n, timesAscending);
 
       const auto serialized = com::serialize::SerializedStamples::serialize(data);
@@ -156,20 +150,16 @@ void BaseCouplingScheme::sendData(const m2n::PtrM2N &m2n, const DataMap &sendDat
   }
 }
 
-int BaseCouplingScheme::receiveNumberOfTimeSteps(const m2n::PtrM2N &m2n)
+std::vector<double> BaseCouplingScheme::receiveTimes(const m2n::PtrM2N &m2n)
 {
   PRECICE_TRACE();
   PRECICE_DEBUG("Receiving number of time steps...");
   int numberOfTimeSteps;
   m2n->receive(numberOfTimeSteps);
-  return numberOfTimeSteps;
-}
+  PRECICE_ASSERT(numberOfTimeSteps > 0);
 
-Eigen::VectorXd BaseCouplingScheme::receiveTimes(const m2n::PtrM2N &m2n, int nTimeSteps)
-{
-  PRECICE_TRACE();
+  std::vector<double> times(numberOfTimeSteps);
   PRECICE_DEBUG("Receiving times....");
-  Eigen::VectorXd times(nTimeSteps);
   m2n->receive(times);
   PRECICE_DEBUG("Received times {}", times);
   return times;
@@ -184,13 +174,10 @@ void BaseCouplingScheme::receiveData(const m2n::PtrM2N &m2n, const DataMap &rece
   for (const auto &data : receiveData | boost::adaptors::map_values) {
 
     if (data->exchangeSubsteps()) {
-      const int nTimeSteps = receiveNumberOfTimeSteps(m2n);
+      auto       timesAscending = receiveTimes(m2n);
+      const auto nTimeSteps     = timesAscending.size();
 
-      Eigen::VectorXd serializedValues(nTimeSteps * data->getSize());
-      PRECICE_ASSERT(nTimeSteps > 0);
-      const Eigen::VectorXd timesAscending = receiveTimes(m2n, nTimeSteps);
-
-      auto serialized = com::serialize::SerializedStamples::empty(timesAscending, data);
+      auto serialized = com::serialize::SerializedStamples::empty(nTimeSteps, data);
 
       // Data is only received on ranks with size>0, which is checked in the derived class implementation
       m2n->receive(serialized.values(), data->getMeshID(), data->getDimensions() * nTimeSteps);

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -236,9 +236,7 @@ protected:
   /// Acceleration method to speedup iteration convergence.
   acceleration::PtrAcceleration _acceleration;
 
-  void sendNumberOfTimeSteps(const m2n::PtrM2N &m2n, const int numberOfTimeSteps);
-
-  void sendTimes(const m2n::PtrM2N &m2n, const Eigen::VectorXd &times);
+  void sendTimes(const m2n::PtrM2N &m2n, precice::span<double const> times);
 
   /**
    * @brief Sends data sendDataIDs given in mapCouplingData with communication.
@@ -248,9 +246,7 @@ protected:
    */
   void sendData(const m2n::PtrM2N &m2n, const DataMap &sendData);
 
-  int receiveNumberOfTimeSteps(const m2n::PtrM2N &m2n);
-
-  Eigen::VectorXd receiveTimes(const m2n::PtrM2N &m2n, int nTimeSteps);
+  std::vector<double> receiveTimes(const m2n::PtrM2N &m2n);
 
   /**
    * @brief Receives data receiveDataIDs given in mapCouplingData with communication.


### PR DESCRIPTION
## Main changes of this PR

This PR simplifies the sending of time stamps in the BaseCouplingScheme and tidies up the interface of the serialization.

## Motivation and additional information

Refactoring allows a more efficient implementation of the M2N communication of ranges.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
