### PR TITLE
Decouple couplingData dims from samples

### DIFF
--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -123,11 +123,13 @@ void AitkenAcceleration::concatenateCouplingData(
   Eigen::Index offset = 0;
 
   for (auto id : dataIDs) {
-    Eigen::Index size = cplData.at(id)->values().size();
+    Eigen::Index size = cplData.at(id)->getSize();
 
     auto valuesSample    = cplData.at(id)->timeStepsStorage().sample(windowEnd);
     auto oldValuesSample = cplData.at(id)->getPreviousValuesAtTime(windowEnd);
 
+    PRECICE_ASSERT(valuesSample.values().size() == size, valuesSample.values().size(), size);
+    PRECICE_ASSERT(oldValuesSample.values().size() == size, oldValuesSample.values().size(), size);
     PRECICE_ASSERT(targetValues.size() >= offset + size, "Target vector was not initialized.", targetValues.size(), offset + size);
     PRECICE_ASSERT(targetOldValues.size() >= offset + size, "Target vector was not initialized.");
     for (Eigen::Index i = 0; i < size; i++) {

--- a/src/acceleration/test/AccelerationIntraCommTest.cpp
+++ b/src/acceleration/test/AccelerationIntraCommTest.cpp
@@ -21,6 +21,7 @@
 #include "cplscheme/SharedPointer.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
+#include "testing/Meshes.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 #include "utils/EigenHelperFunctions.hpp"
@@ -61,10 +62,6 @@ BOOST_DATA_TEST_CASE(testVIQNILSppWithoutSubsteps, boost::unit_test::data::make(
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
-  dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                         timeWindowsReused, filter, singularityLimit, dataIDs, prec, !exchangeSubsteps);
@@ -88,6 +85,10 @@ BOOST_DATA_TEST_CASE(testVIQNILSppWithoutSubsteps, boost::unit_test::data::make(
     /**
      * processor with 4 vertices
      */
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
     // init displacements & forces
     dpcd->emplaceSampleAtTime(windowStart, {1.0, 1.0, 1.0, 1.0});
@@ -109,6 +110,10 @@ BOOST_DATA_TEST_CASE(testVIQNILSppWithoutSubsteps, boost::unit_test::data::make(
     /**
      * processor with 4 vertices
      */
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
     // init displacements & forces
     dpcd->emplaceSampleAtTime(windowStart, {1.0, 1.0, 1.0, 1.0});
@@ -155,6 +160,8 @@ BOOST_DATA_TEST_CASE(testVIQNILSppWithoutSubsteps, boost::unit_test::data::make(
     /**
      * processor with 2 vertices
      */
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
 
     // init displacements & forces
     dpcd->emplaceSampleAtTime(windowStart, {1.0, 1.0});
@@ -284,10 +291,6 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
-  dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                          timeWindowsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
@@ -311,6 +314,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     /**
      * processor with 4 vertices
      */
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
     // init displacements & forces
     //Need to store 2 values in the waveform iteration
@@ -354,6 +361,10 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     /**
      * processor with 4 vertices
      */
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
 
     // init displacements & forces
     dpcd->emplaceSampleAtTime(windowStart, {1.0, 1.0, 1.0, 1.0});
@@ -419,6 +430,8 @@ BOOST_AUTO_TEST_CASE(testVIQNIMVJppWithoutSubsteps)
     /**
      * processor with 2 vertices
      */
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
 
     // init displacements & forces
     dpcd->emplaceSampleAtTime(windowStart, {1.0, 1.0});
@@ -549,10 +562,6 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("dummyMesh", 2, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
-  dummyMesh->createVertex(Eigen::Vector2d{0, 0});
-  dummyMesh->createVertex(Eigen::Vector2d{1, 0});
-  dummyMesh->createVertex(Eigen::Vector2d{2, 0});
-  dummyMesh->createVertex(Eigen::Vector2d{3, 0});
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                          timeWindowsReused, filter, singularityLimit, dataIDs, _preconditioner, alwaysBuildJacobian,
@@ -599,8 +608,9 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
     pp.initialize(data);
   } else if (context.isRank(1)) { // SecondaryRank1
     /**
-     * processor with 4 vertices
+     * processor with 11 vertices
      */
+    testing::addDummyVertices(11, *dummyMesh);
 
     // init displacements & forces
     dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
@@ -624,8 +634,9 @@ BOOST_AUTO_TEST_CASE(testIMVJ_effUpdate_ppWithoutSubsteps)
 
   } else if (context.isRank(2)) { // Secondary rank 2
     /**
-     * processor with 4 vertices
+     * processor with 11 vertices
      */
+    testing::addDummyVertices(11, *dummyMesh);
 
     // init displacements & forces
     dpcd = makeCouplingData(displacements, dummyMesh, exchangeSubsteps);
@@ -1058,10 +1069,15 @@ BOOST_AUTO_TEST_CASE(testColumnsLoggingWithoutSubsteps)
 
   mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
   dummyMesh->setVertexOffsets(vertexOffsets);
-  dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{2, 0, 0});
-  dummyMesh->createVertex(Eigen::Vector3d{3, 0, 0});
+  if (context.isPrimary()) { // 2 vertices
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+    dummyMesh->createVertex(Eigen::Vector3d{1, 0, 0});
+  } else if (context.isRank(1)) { // 1 vertex
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+  } else if (context.isRank(2)) { // no vertices
+  } else {                        // 1 vertex
+    dummyMesh->createVertex(Eigen::Vector3d{0, 0, 0});
+  }
 
   IQNILSAcceleration acc(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                          timeWindowsReused, filter, singularityLimit, dataIDs, prec, !exchangeSubsteps);

--- a/src/acceleration/test/AccelerationSerialTest.cpp
+++ b/src/acceleration/test/AccelerationSerialTest.cpp
@@ -14,6 +14,7 @@
 #include "acceleration/test/helper.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "cplscheme/SharedPointer.hpp"
+#include "testing/Meshes.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"
 #include "utils/EigenHelperFunctions.hpp"
@@ -59,7 +60,7 @@ void testIQNIMVJPP(bool exchangeSubsteps)
   std::vector<double> factors;
   factors.resize(2, 1.0);
   impl::PtrPreconditioner prec(new impl::ConstantPreconditioner(factors));
-  mesh::PtrMesh           dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
+  auto                    dummyMesh = testing::makeDummy2DMesh(4);
 
   IQNIMVJAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                          timeWindowsReused, filter, singularityLimit, dataIDs, prec, alwaysBuildJacobian,
@@ -155,7 +156,7 @@ void testVIQNPP(bool exchangeSubsteps)
   std::map<int, double> scalings;
   scalings.insert(std::make_pair(0, 1.0));
   scalings.insert(std::make_pair(1, 1.0));
-  mesh::PtrMesh dummyMesh(new mesh::Mesh("DummyMesh", 3, testing::nextMeshID()));
+  auto dummyMesh = testing::makeDummy2DMesh(4);
 
   IQNILSAcceleration pp(initialRelaxation, enforceInitialRelaxation, maxIterationsUsed,
                         timeWindowsReused, filter, singularityLimit, dataIDs, prec, !exchangeSubsteps);
@@ -237,7 +238,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithSubsteps)
   // use two vectors and see if underrelaxation works
   double           relaxation = 0.4;
   std::vector<int> dataIDs{0, 1};
-  mesh::PtrMesh    dummyMesh   = std::make_shared<mesh::Mesh>("DummyMesh", 3, testing::nextMeshID());
+  auto             dummyMesh   = testing::makeDummy3DMesh(4);
   const double     windowStart = 0;
   const double     windowEnd   = 1;
 
@@ -300,7 +301,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithoutSubsteps)
   double              relaxation = 0.4;
   std::vector<int>    dataIDs{0, 1};
   std::vector<double> factors{1, 1};
-  mesh::PtrMesh       dummyMesh   = std::make_shared<mesh::Mesh>("DummyMesh", 3, testing::nextMeshID());
+  auto                dummyMesh   = testing::makeDummy3DMesh(4);
   const double        windowStart = 0;
   const double        windowEnd   = 1;
 
@@ -361,7 +362,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
 
   double           relaxation = 0.8;
   std::vector<int> dataIDs{0, 1, 2, 3};
-  mesh::PtrMesh    dummyMesh = std::make_shared<mesh::Mesh>("DummyMesh", 3, testing::nextMeshID());
+  auto             dummyMesh = testing::makeDummy2DMesh(2);
 
   double       windowStart = 0;
   double       windowEnd   = 1;
@@ -372,13 +373,13 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
 
   mesh::PtrData data1 = std::make_shared<mesh::Data>("dvalues", -1, 1);
   mesh::PtrData data2 = std::make_shared<mesh::Data>("fvalues", -1, 1);
-  mesh::PtrData data3 = std::make_shared<mesh::Data>("gvalues", -1, 3);
-  mesh::PtrData data4 = std::make_shared<mesh::Data>("hvalues", -1, 1);
+  mesh::PtrData data3 = std::make_shared<mesh::Data>("gvalues", -1, 2);
+  mesh::PtrData data4 = std::make_shared<mesh::Data>("hvalues", -1, 2);
 
   // init data
   data1->emplaceSampleAtTime(windowStart, {40, 80});
   data2->emplaceSampleAtTime(windowStart, {5, 5});
-  data3->emplaceSampleAtTime(windowStart, {1, 2, 3});
+  data3->emplaceSampleAtTime(windowStart, {1, 2, 3, 4});
   data4->emplaceSampleAtTime(windowStart, {20, 40, 60, 80});
 
   cplscheme::PtrCouplingData dpcd = makeCouplingData(data1, dummyMesh, false);
@@ -400,7 +401,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
 
   data1->emplaceSampleAtTime(windowEnd, {1, 7});
   data2->emplaceSampleAtTime(windowEnd, {10, 10});
-  data3->emplaceSampleAtTime(windowEnd, {10, 11, 12});
+  data3->emplaceSampleAtTime(windowEnd, {10, 11, 12, 13});
   data4->emplaceSampleAtTime(windowEnd, {40, 60, 80, 100});
 
   acc.performAcceleration(data, windowStart, windowEnd);
@@ -419,7 +420,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
 
   data1->emplaceSampleAtTime(windowEnd, {2, 14});
   data2->emplaceSampleAtTime(windowEnd, {8, 8});
-  data3->emplaceSampleAtTime(windowEnd, {13, 14, 15});
+  data3->emplaceSampleAtTime(windowEnd, {13, 14, 15, 16});
   data4->emplaceSampleAtTime(windowEnd, {41, 61, 81, 90});
 
   acc.performAcceleration(data, windowStart, windowEnd);
@@ -438,7 +439,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
 
   data1->emplaceSampleAtTime(windowEnd, {2.1, 14.1});
   data2->emplaceSampleAtTime(windowEnd, {8, 8});
-  data3->emplaceSampleAtTime(windowEnd, {13.05, 14.07, 15.1});
+  data3->emplaceSampleAtTime(windowEnd, {13.05, 14.07, 15.1, 16.1});
   data4->emplaceSampleAtTime(windowEnd, {42, 60, 81.3, 91});
 
   acc.iterationsConverged(data, windowStart);
@@ -453,7 +454,7 @@ BOOST_AUTO_TEST_CASE(testAitkenUnderrelaxationWithPreconditioner)
 
   data1->emplaceSampleAtTime(windowEnd, {3, 16});
   data2->emplaceSampleAtTime(windowEnd, {7, 7});
-  data3->emplaceSampleAtTime(windowEnd, {18, 19, 20});
+  data3->emplaceSampleAtTime(windowEnd, {18, 19, 20, 21});
   data4->emplaceSampleAtTime(windowEnd, {50, 70, 90, 110});
 
   acc.performAcceleration(data, windowStart, windowEnd);
@@ -479,7 +480,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithSubsteps)
   double           relaxation = 0.4;
   std::vector<int> dataIDs{0, 1};
   const int        dim         = 3;
-  mesh::PtrMesh    dummyMesh   = std::make_shared<mesh::Mesh>("DummyMesh", dim, testing::nextMeshID());
+  auto             dummyMesh   = testing::makeDummy3DMesh(4);
   const double     windowStart = 0;
   const double     windowEnd   = 1;
 
@@ -576,7 +577,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithoutSubsteps)
   //use two vectors and see if underrelaxation works
   double           relaxation = 0.4;
   std::vector<int> dataIDs{0, 1};
-  mesh::PtrMesh    dummyMesh   = std::make_shared<mesh::Mesh>("DummyMesh", 3, testing::nextMeshID());
+  auto             dummyMesh   = testing::makeDummy3DMesh(4);
   const double     windowStart = 0;
   const double     windowEnd   = 1;
 
@@ -639,7 +640,7 @@ BOOST_AUTO_TEST_CASE(testConstantUnderrelaxationWithGradientWithoutSubsteps)
   double           relaxation = 0.4;
   std::vector<int> dataIDs{0, 1};
   const int        dim         = 3;
-  mesh::PtrMesh    dummyMesh   = std::make_shared<mesh::Mesh>("DummyMesh", dim, testing::nextMeshID());
+  auto             dummyMesh   = testing::makeDummy3DMesh(4);
   const double     windowStart = 0;
   const double     windowEnd   = 1;
 

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -36,16 +36,12 @@ int CouplingData::getDimensions() const
 
 int CouplingData::getSize() const
 {
-  // @todo this correct implementation breaks a ton of tests that don't define vertices of a test mesh
-  //return _mesh->nVertices() * getDimensions();
-  return sample().values.size();
+  return _mesh->nVertices() * getDimensions();
 }
 
 int CouplingData::nVertices() const
 {
-  // @todo this correct implementation breaks a ton of tests that don't define vertices of a test mesh
-  //return _mesh->nVertices();
-  return sample().values.size() / getDimensions();
+  return _mesh->nVertices();
 }
 
 const Eigen::VectorXd &CouplingData::values() const

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -91,8 +91,11 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
     double computedTime      = 0.0;
     int    computedTimesteps = 0;
 
+    time::Sample ssample{1, Eigen::VectorXd::Zero(mesh->nVertices())};
+    time::Sample vsample{3, Eigen::VectorXd::Zero(mesh->nVertices() * 3)};
+
     if (participantName == std::string("Participant0")) {
-      mesh->data(0)->setSampleAtTime(0, time::Sample{1, mesh->data(0)->values()});
+      mesh->data("Data0")->setSampleAtTime(0, ssample);
       cplScheme->initialize();
       BOOST_TEST(not cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
@@ -104,7 +107,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         double stepSize = cplScheme->getNextTimeStepMaxSize();
-        mesh->data(0)->setSampleAtTime(computedTime + stepSize, time::Sample{1, mesh->data(0)->values()});
+        mesh->data("Data0")->setSampleAtTime(computedTime + stepSize, ssample);
         BOOST_TEST(cplScheme->getTime() == computedTime);
         cplScheme->addComputedTime(stepSize);
         BOOST_TEST(cplScheme->getTime() == computedTime + stepSize); // ensure that time is correctly updated, even if iterating. See https://github.com/precice/precice/pull/1792.
@@ -129,8 +132,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(not cplScheme->isCouplingOngoing());
       BOOST_TEST(cplScheme->getNextTimeStepMaxSize() == 0.0);
     } else if (participantName == std::string("Participant1")) {
-      auto ddims = mesh->data(1)->getDimensions();
-      mesh->data(1)->setSampleAtTime(0, time::Sample{ddims, mesh->data(1)->values()});
+      mesh->data("Data1")->setSampleAtTime(0, vsample);
       cplScheme->initialize();
       BOOST_TEST(cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
@@ -142,7 +144,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         double stepSize = cplScheme->getNextTimeStepMaxSize();
-        mesh->data(1)->setSampleAtTime(computedTime + stepSize, time::Sample{ddims, mesh->data(1)->values()});
+        mesh->data("Data1")->setSampleAtTime(computedTime + stepSize, vsample);
         BOOST_TEST(cplScheme->getTime() == computedTime);
         cplScheme->addComputedTime(stepSize);
         BOOST_TEST(cplScheme->getTime() == computedTime + stepSize); // ensure that time is correctly updated, even if iterating. See https://github.com/precice/precice/pull/1792.
@@ -167,9 +169,8 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
       BOOST_TEST(not cplScheme->isCouplingOngoing());
       BOOST_TEST(cplScheme->getNextTimeStepMaxSize() == 0.0);
     } else {
-      auto ddims = mesh->data(2)->getDimensions();
       BOOST_TEST(participantName == std::string("Participant2"), participantName);
-      mesh->data(2)->setSampleAtTime(0, time::Sample{ddims, mesh->data(2)->values()});
+      mesh->data("Data2")->setSampleAtTime(0, vsample);
       cplScheme->initialize();
       BOOST_TEST(cplScheme->hasDataBeenReceived());
       BOOST_TEST(not cplScheme->isTimeWindowComplete());
@@ -181,7 +182,7 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
           cplScheme->markActionFulfilled(CouplingScheme::Action::WriteCheckpoint);
         }
         double stepSize = cplScheme->getNextTimeStepMaxSize();
-        mesh->data(2)->setSampleAtTime(cplScheme->getNextTimeStepMaxSize(), time::Sample{ddims, mesh->data(2)->values()});
+        mesh->data("Data2")->setSampleAtTime(cplScheme->getNextTimeStepMaxSize(), vsample);
         BOOST_TEST(cplScheme->getTime() == computedTime);
         cplScheme->addComputedTime(stepSize);
         BOOST_TEST(cplScheme->getTime() == computedTime + stepSize); // ensure that time is correctly updated, even if iterating. See https://github.com/precice/precice/pull/1792.

--- a/src/testing/Meshes.hpp
+++ b/src/testing/Meshes.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Eigen/Core"
+#include "Testing.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
+
+namespace precice::testing {
+
+inline void addDummyVertices(size_t nVertices, mesh::Mesh &mesh)
+{
+  for (size_t i = 0; i < nVertices; ++i) {
+    if (mesh.getDimensions() == 2) {
+      mesh.createVertex(Eigen::Vector2d(i, 0.0));
+    } else {
+      mesh.createVertex(Eigen::Vector3d(i, 0.0, 0.0));
+    }
+  }
+}
+
+inline auto makeDummy2DMesh(size_t nVertices)
+{
+  auto mesh = std::make_shared<mesh::Mesh>("DummyMesh2D", 2, testing::nextMeshID());
+  addDummyVertices(nVertices, *mesh);
+  return mesh;
+}
+
+inline auto makeDummy3DMesh(size_t nVertices)
+{
+  auto mesh = std::make_shared<mesh::Mesh>("DummyMesh3D", 3, testing::nextMeshID());
+  addDummyVertices(nVertices, *mesh);
+  return mesh;
+}
+
+} // namespace precice::testing

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -85,6 +85,7 @@ target_sources(testprecice
     src/testing/DataContextFixture.cpp
     src/testing/DataContextFixture.hpp
     src/testing/GlobalFixtures.cpp
+    src/testing/Meshes.hpp
     src/testing/ParallelCouplingSchemeFixture.cpp
     src/testing/ParallelCouplingSchemeFixture.hpp
     src/testing/QuickTest.hpp


### PR DESCRIPTION
## Main changes of this PR

This PR decouples the CouplingData dimension queries from the internal sample and uses mesh and data instead.

## Motivation and additional information

This is mostly a TODO note as this change should be trivial, but triggers errors in tests that use meshes but don't define vertices.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
