### PR TITLE
Clang-tidy pass

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 # clang-tidy settings to be used with ./tools/linting/run_clang_tidy.sh
 
-Checks:          "-*,modernize-deprecated-headers,modernize-make-shared,modernize-use-bool-literals,modernize-loop-convert,modernize-use-equals-default,modernize-use-emplace,modernize-use-nullptr,modernize-concat-nested-namespaces"
+Checks:          "-*,modernize-deprecated-headers,modernize-make-shared,modernize-use-bool-literals,modernize-loop-convert,modernize-use-equals-default,modernize-use-emplace,modernize-use-nullptr,modernize-concat-nested-namespaces,modernize-use-override"
 
 WarningsAsErrors: '*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,3 +3,4 @@
 Checks:          "-*,modernize-deprecated-headers,modernize-make-shared,modernize-use-bool-literals,modernize-loop-convert,modernize-use-equals-default,modernize-use-emplace,modernize-use-nullptr,modernize-concat-nested-namespaces,modernize-use-override"
 
 WarningsAsErrors: '*'
+HeaderFilterRegex: 'src/'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 # clang-tidy settings to be used with ./tools/linting/run_clang_tidy.sh
 
-Checks:          "-*,modernize-deprecated-headers,modernize-make-shared,modernize-use-bool-literals,modernize-loop-convert,modernize-use-equals-default,modernize-use-emplace,modernize-use-nullptr,modernize-concat-nested-namespaces,modernize-use-override"
+Checks:          "-*,modernize-deprecated-headers,modernize-make-shared,modernize-make-unique,modernize-use-bool-literals,modernize-loop-convert,modernize-use-equals-default,modernize-use-emplace,modernize-use-nullptr,modernize-concat-nested-namespaces,modernize-use-override"
 
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'src/'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,4 +3,4 @@
 Checks:          "-*,modernize-deprecated-headers,modernize-make-shared,modernize-make-unique,modernize-use-bool-literals,modernize-loop-convert,modernize-use-equals-default,modernize-use-emplace,modernize-use-nullptr,modernize-concat-nested-namespaces,modernize-use-override"
 
 WarningsAsErrors: '*'
-HeaderFilterRegex: 'src/'
+HeaderFilterRegex: '/(src|extra|tests)/'

--- a/extras/bindings/c/src/preciceC.cpp
+++ b/extras/bindings/c/src/preciceC.cpp
@@ -33,11 +33,11 @@ void precicec_createParticipant_withCommunicator(
     void *      communicator)
 try {
   PRECICE_CHECK(impl == nullptr, errormsgCreate);
-  impl.reset(new precice::Participant(participantName,
-                                      configFileName,
-                                      solverProcessIndex,
-                                      solverProcessSize,
-                                      communicator));
+  impl = std::make_unique<precice::Participant>(participantName,
+                                                configFileName,
+                                                solverProcessIndex,
+                                                solverProcessSize,
+                                                communicator);
 } catch (::precice::Error &e) {
   std::abort();
 }
@@ -49,10 +49,10 @@ void precicec_createParticipant(
     int         solverProcessSize)
 try {
   PRECICE_CHECK(impl == nullptr, errormsgCreate);
-  impl.reset(new precice::Participant(participantName,
-                                      configFileName,
-                                      solverProcessIndex,
-                                      solverProcessSize));
+  impl = std::make_unique<precice::Participant>(participantName,
+                                                configFileName,
+                                                solverProcessIndex,
+                                                solverProcessSize);
 } catch (::precice::Error &e) {
   std::abort();
 }

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -46,11 +46,11 @@ void precicef_create_(
     int         participantNameLength,
     int         configFileNameLength)
 try {
-  impl.reset(new precice::Participant(
+  impl = std::make_unique<precice::Participant>(
       precice::impl::strippedStringView(participantName, participantNameLength),
       precice::impl::strippedStringView(configFileName, configFileNameLength),
       *solverProcessIndex,
-      *solverProcessSize));
+      *solverProcessSize);
 } catch (::precice::Error &e) {
   std::abort();
 }

--- a/src/acceleration/Acceleration.hpp
+++ b/src/acceleration/Acceleration.hpp
@@ -7,15 +7,12 @@
 #include "cplscheme/BaseCouplingScheme.hpp"
 #include "cplscheme/SharedPointer.hpp"
 
-namespace precice {
-namespace io {
+namespace precice::io {
 class TXTWriter;
 class TXTReader;
-} // namespace io
-} // namespace precice
+} // namespace precice::io
 
-namespace precice {
-namespace acceleration {
+namespace precice::acceleration {
 
 class Acceleration {
 public:
@@ -49,5 +46,4 @@ protected:
   /// performs a relaxation given a relaxation factor omega
   static void applyRelaxation(double omega, DataMap &cplData, double windowStart);
 };
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -20,23 +20,23 @@ public:
       std::vector<int>        dataIDs,
       impl::PtrPreconditioner preconditioner);
 
-  virtual ~AitkenAcceleration() = default;
+  ~AitkenAcceleration() override = default;
 
-  virtual std::vector<int> getPrimaryDataIDs() const override final
+  std::vector<int> getPrimaryDataIDs() const final
   {
     return _primaryDataIDs;
   }
 
-  virtual void initialize(
-      const DataMap &cpldata) override final;
+  void initialize(
+      const DataMap &cpldata) final;
 
-  virtual void performAcceleration(
+  void performAcceleration(
       DataMap &cpldata,
       double   windowStart,
-      double   windowEnd) override final;
+      double   windowEnd) final;
 
-  virtual void iterationsConverged(
-      const DataMap &cpldata, double windowStart) override final;
+  void iterationsConverged(
+      const DataMap &cpldata, double windowStart) final;
 
 private:
   /// @brief Concatenates the data and old data in cplData into two long vectors

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -20,7 +20,7 @@ public:
       std::vector<int>        dataIDs,
       impl::PtrPreconditioner preconditioner);
 
-  virtual ~AitkenAcceleration() {}
+  virtual ~AitkenAcceleration() = default;
 
   virtual std::vector<int> getPrimaryDataIDs() const override final
   {

--- a/src/acceleration/AitkenAcceleration.hpp
+++ b/src/acceleration/AitkenAcceleration.hpp
@@ -10,8 +10,7 @@
 #include "acceleration/impl/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace acceleration {
+namespace precice::acceleration {
 
 class AitkenAcceleration : public Acceleration {
 public:
@@ -60,5 +59,4 @@ private:
   /// Preconditioner for data vector if multiple data sets are used.
   impl::PtrPreconditioner _preconditioner;
 };
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration

--- a/src/acceleration/BaseQNAcceleration.hpp
+++ b/src/acceleration/BaseQNAcceleration.hpp
@@ -77,7 +77,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~BaseQNAcceleration()
+  ~BaseQNAcceleration() override
   {
     // not necessary for user, only for developer, if needed, this should be configurable
     //     if (utils::IntraComm::isPrimary() || !utils::IntraComm::isParallel()) {
@@ -90,7 +90,7 @@ public:
   /**
    * @brief Returns all IQN involved data IDs.
    */
-  virtual std::vector<int> getPrimaryDataIDs() const override final
+  std::vector<int> getPrimaryDataIDs() const final
   {
     return _primaryDataIDs;
   }
@@ -98,14 +98,14 @@ public:
   /**
    * @brief Initializes the acceleration.
    */
-  virtual void initialize(const DataMap &cplData) override final;
+  void initialize(const DataMap &cplData) final;
 
   /**
    * @brief Performs one acceleration step.
    *
    * Has to be called after every implicit coupling iteration.
    */
-  virtual void performAcceleration(DataMap &cplData, double windowStart, double windowEnd) override final;
+  void performAcceleration(DataMap &cplData, double windowStart, double windowEnd) final;
 
   /**
    * @brief Marks a iteration sequence as converged.
@@ -113,19 +113,19 @@ public:
    * Since convergence measurements are done outside the acceleration, this
    * method has to be used to signalize convergence to the acceleration.
    */
-  virtual void iterationsConverged(const DataMap &cplData, double windowStart) override final;
+  void iterationsConverged(const DataMap &cplData, double windowStart) final;
 
   /**
    * @brief Exports the current state of the acceleration to a file.
    */
-  virtual void exportState(io::TXTWriter &writer) override final;
+  void exportState(io::TXTWriter &writer) final;
 
   /**
    * @brief Imports the last exported state of the acceleration from file.
    *
    * Is empty at the moment!!!
    */
-  virtual void importState(io::TXTReader &reader) override final;
+  void importState(io::TXTReader &reader) final;
 
   /// how many QN columns were deleted in this time window
   int getDeletedColumns() const;

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -7,8 +7,7 @@
 #include "acceleration/Acceleration.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace acceleration {
+namespace precice::acceleration {
 
 class ConstantRelaxationAcceleration : public Acceleration {
 public:
@@ -37,5 +36,4 @@ private:
 
   std::vector<int> _dataIDs;
 };
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration

--- a/src/acceleration/ConstantRelaxationAcceleration.hpp
+++ b/src/acceleration/ConstantRelaxationAcceleration.hpp
@@ -16,16 +16,16 @@ public:
       double           relaxation,
       std::vector<int> dataIDs);
 
-  virtual std::vector<int> getPrimaryDataIDs() const override final
+  std::vector<int> getPrimaryDataIDs() const final
   {
     return _dataIDs;
   }
 
-  virtual void initialize(const DataMap &cplData) override;
+  void initialize(const DataMap &cplData) override;
 
-  virtual void performAcceleration(DataMap &cplData, double windowStart, double windowEnd) override;
+  void performAcceleration(DataMap &cplData, double windowStart, double windowEnd) override;
 
-  virtual void iterationsConverged(const DataMap &cplData, double windowStart) override
+  void iterationsConverged(const DataMap &cplData, double windowStart) override
   {
     // function not needed in ConstantRelaxationAcceleration
   }

--- a/src/acceleration/IQNILSAcceleration.hpp
+++ b/src/acceleration/IQNILSAcceleration.hpp
@@ -36,7 +36,7 @@ public:
       impl::PtrPreconditioner preconditioner,
       bool                    reducedTimeGrid);
 
-  virtual ~IQNILSAcceleration() = default;
+  ~IQNILSAcceleration() override = default;
 
   /**
     * @brief Marks a iteration sequence as converged.
@@ -44,23 +44,23 @@ public:
     * called by the iterationsConverged() method in the BaseQNAcceleration class
     * handles the acceleration specific action after the convergence of one iteration
     */
-  virtual void specializedIterationsConverged(const DataMap &cplData);
+  void specializedIterationsConverged(const DataMap &cplData) override;
 
 private:
   /// Secondary data solver output from last iteration.
   std::map<int, Eigen::VectorXd> _secondaryOldXTildes;
 
   /// updates the V, W matrices (as well as the matrices for the secondary data)
-  virtual void updateDifferenceMatrices(const DataMap &cplData);
+  void updateDifferenceMatrices(const DataMap &cplData) override;
 
   /// computes the IQN-ILS update using QR decomposition
-  virtual void computeQNUpdate(Eigen::VectorXd &xUpdate);
+  void computeQNUpdate(Eigen::VectorXd &xUpdate) override;
 
   /// Removes one iteration from V,W matrices and adapts _matrixCols.
-  virtual void removeMatrixColumn(int columnIndex);
+  void removeMatrixColumn(int columnIndex) override;
 
   /// @copydoc precice::Acceleration::BaseQNAcceleration::specializedInitializeVectorsAndPreconditioner()
-  virtual void specializedInitializeVectorsAndPreconditioner(const DataMap &cplData) override final{};
+  void specializedInitializeVectorsAndPreconditioner(const DataMap &cplData) final{};
 };
 } // namespace acceleration
 } // namespace precice

--- a/src/acceleration/IQNILSAcceleration.hpp
+++ b/src/acceleration/IQNILSAcceleration.hpp
@@ -7,8 +7,7 @@
 #include "acceleration/BaseQNAcceleration.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
 
-namespace precice {
-namespace acceleration {
+namespace precice::acceleration {
 
 /**
  * @brief Interface quasi-Newton with interface least-squares approximation.
@@ -62,5 +61,4 @@ private:
   /// @copydoc precice::Acceleration::BaseQNAcceleration::specializedInitializeVectorsAndPreconditioner()
   void specializedInitializeVectorsAndPreconditioner(const DataMap &cplData) final{};
 };
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration

--- a/src/acceleration/IQNILSAcceleration.hpp
+++ b/src/acceleration/IQNILSAcceleration.hpp
@@ -36,7 +36,7 @@ public:
       impl::PtrPreconditioner preconditioner,
       bool                    reducedTimeGrid);
 
-  virtual ~IQNILSAcceleration() {}
+  virtual ~IQNILSAcceleration() = default;
 
   /**
     * @brief Marks a iteration sequence as converged.

--- a/src/acceleration/IQNIMVJAcceleration.hpp
+++ b/src/acceleration/IQNIMVJAcceleration.hpp
@@ -60,7 +60,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~IQNIMVJAcceleration();
+  ~IQNIMVJAcceleration() override;
 
   /**
    * @brief Marks a iteration sequence as converged.
@@ -68,7 +68,7 @@ public:
    * called by the iterationsConverged() method in the BaseQNAcceleration class
    * handles the acceleration specific action after the convergence of one iteration
    */
-  virtual void specializedIterationsConverged(const DataMap &cplData);
+  void specializedIterationsConverged(const DataMap &cplData) override;
 
 private:
   /// @brief stores the approximation of the inverse Jacobian of the system at current time window.
@@ -137,10 +137,10 @@ private:
   /** @brief: computes the IQNIMVJ update using QR decomposition of V,
    *        furthermore it updates the inverse of the system jacobian
    */
-  virtual void computeQNUpdate(Eigen::VectorXd &xUpdate);
+  void computeQNUpdate(Eigen::VectorXd &xUpdate) override;
 
   /// @brief: updates the V, W matrices (as well as the matrices for the secondary data)
-  virtual void updateDifferenceMatrices(const DataMap &cplData);
+  void updateDifferenceMatrices(const DataMap &cplData) override;
 
   /** @brief: computes the quasi-Newton update vector based on the matrices V and W using a QR
    *  decomposition of V. The decomposition is not re-computed en-block in every iteration
@@ -182,10 +182,10 @@ private:
   void restartIMVJ();
 
   /// @brief: Removes one iteration from V,W matrices and adapts _matrixCols.
-  virtual void removeMatrixColumn(int columnIndex);
+  void removeMatrixColumn(int columnIndex) override;
 
   /// @copydoc precice::Acceleration::BaseQNAcceleration::specializedInitializeVectorsAndPreconditioner()
-  virtual void specializedInitializeVectorsAndPreconditioner(const DataMap &cplData) override final;
+  void specializedInitializeVectorsAndPreconditioner(const DataMap &cplData) final;
 
   /// @brief: Removes one column form the V_RSLS and W_RSLS matrices and adapts _matrixCols_RSLS
   void removeMatrixColumnRSLS(int columnINdex);

--- a/src/acceleration/IQNIMVJAcceleration.hpp
+++ b/src/acceleration/IQNIMVJAcceleration.hpp
@@ -14,8 +14,7 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace acceleration {
+namespace precice::acceleration {
 
 /**
  * @brief Multi vector quasi-Newton update scheme
@@ -190,7 +189,6 @@ private:
   /// @brief: Removes one column form the V_RSLS and W_RSLS matrices and adapts _matrixCols_RSLS
   void removeMatrixColumnRSLS(int columnINdex);
 };
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration
 
 #endif /* PRECICE_NO_MPI */

--- a/src/acceleration/SharedPointer.hpp
+++ b/src/acceleration/SharedPointer.hpp
@@ -2,12 +2,10 @@
 
 #include <memory>
 
-namespace precice {
-namespace acceleration {
+namespace precice::acceleration {
 class Acceleration;
 class AccelerationConfiguration;
 
 using PtrAcceleration              = std::shared_ptr<Acceleration>;
 using PtrAccelerationConfiguration = std::shared_ptr<AccelerationConfiguration>;
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -12,8 +12,7 @@
 #include "precice/config/SharedPointer.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace acceleration {
+namespace precice::acceleration {
 
 class AccelerationConfiguration : public xml::XMLTag::Listener {
 public:
@@ -156,5 +155,4 @@ private:
   void addTypeSpecificSubtags(xml::XMLTag &tag);
   void addCommonIQNSubtags(xml::XMLTag &tag);
 };
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration

--- a/src/acceleration/config/AccelerationConfiguration.hpp
+++ b/src/acceleration/config/AccelerationConfiguration.hpp
@@ -23,10 +23,10 @@ public:
   PtrAcceleration getAcceleration();
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
   /// Removes configured acceleration.
   void clear();

--- a/src/acceleration/impl/ConstantPreconditioner.hpp
+++ b/src/acceleration/impl/ConstantPreconditioner.hpp
@@ -19,7 +19,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ConstantPreconditioner() {}
+  virtual ~ConstantPreconditioner() = default;
 
   virtual void initialize(std::vector<size_t> &svs);
 

--- a/src/acceleration/impl/ConstantPreconditioner.hpp
+++ b/src/acceleration/impl/ConstantPreconditioner.hpp
@@ -7,9 +7,7 @@
 #include "acceleration/impl/Preconditioner.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 /// Preconditioner that uses the constant user-defined factors to scale the quasi-Newton system.
 class ConstantPreconditioner : public Preconditioner {
@@ -37,6 +35,4 @@ private:
   std::vector<double> _factors;
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl

--- a/src/acceleration/impl/ConstantPreconditioner.hpp
+++ b/src/acceleration/impl/ConstantPreconditioner.hpp
@@ -19,9 +19,9 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ConstantPreconditioner() = default;
+  ~ConstantPreconditioner() override = default;
 
-  virtual void initialize(std::vector<size_t> &svs);
+  void initialize(std::vector<size_t> &svs) override;
 
 private:
   /**
@@ -29,7 +29,7 @@ private:
    *
    * @param[in] timeWindowComplete True if this FSI iteration also completed a time window
    */
-  virtual void _update_(bool timeWindowComplete, const Eigen::VectorXd &oldValues, const Eigen::VectorXd &res);
+  void _update_(bool timeWindowComplete, const Eigen::VectorXd &oldValues, const Eigen::VectorXd &res) override;
 
   logging::Logger _log{"acceleration::ConstantPreconditioner"};
 

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -49,16 +49,16 @@ public:
 
       // if parallel computation on p processors
     } else {
-      PRECICE_ASSERT(utils::IntraComm::getCommunication() != NULL);
+      PRECICE_ASSERT(utils::IntraComm::getCommunication() != nullptr);
       PRECICE_ASSERT(utils::IntraComm::getCommunication()->isConnected());
 
       // The result matrix is of size (p x r)
       // if the cyclic communication is needed, we use block-wise matrix-matrix multiplication
       if (cyclicComm) {
         PRECICE_ASSERT(_needCyclicComm);
-        PRECICE_ASSERT(_cyclicCommLeft.get() != NULL);
+        PRECICE_ASSERT(_cyclicCommLeft.get() != nullptr);
         PRECICE_ASSERT(_cyclicCommLeft->isConnected());
-        PRECICE_ASSERT(_cyclicCommRight.get() != NULL);
+        PRECICE_ASSERT(_cyclicCommRight.get() != nullptr);
         PRECICE_ASSERT(_cyclicCommRight->isConnected());
 
         _multiply_cyclic(leftMatrix, rightMatrix, result, offsets, p, q, r);
@@ -171,9 +171,9 @@ private:
     for (int cycle = 1; cycle < utils::IntraComm::getSize(); cycle++) {
 
       // wait until W_til from previous processor is fully received
-      if (requestSend != NULL)
+      if (requestSend != nullptr)
         requestSend->wait();
-      if (requestRcv != NULL)
+      if (requestRcv != nullptr)
         requestRcv->wait();
 
       // leftMatrix (leftMatrix_rcv) is available - needed for local multiplication and hand over to next proc
@@ -200,7 +200,7 @@ private:
           requestRcv = _cyclicCommLeft->aReceive(leftMatrix_rcv, 0);
       }
 
-      if (requestSend != NULL)
+      if (requestSend != nullptr)
         requestSend->wait();
       // compute block with new local data
       Eigen::MatrixXd block(rows_rcv, rightMatrix.cols());

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -18,9 +18,7 @@
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 class ParallelMatrixOperations {
 public:
@@ -331,8 +329,6 @@ private:
   void closeCircularCommunication();
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl
 
 #endif

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -30,7 +30,7 @@ public:
   }
 
   /// Destructor, empty.
-  virtual ~Preconditioner() {}
+  virtual ~Preconditioner() = default;
 
   /**
    * @brief initialize the preconditioner

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -9,9 +9,7 @@
 #include "logging/Logger.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 /**
  * @brief Interface for preconditioner variants that can be applied to quasi-Newton acceleration schemes.
@@ -244,6 +242,4 @@ private:
   logging::Logger _log{"acceleration::Preconditioner"};
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -8,9 +8,7 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 /**
  * @brief Class that provides functionality for a dynamic QR-decomposition, that can be updated
@@ -222,6 +220,4 @@ private:
   int _globalRows;
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -60,7 +60,7 @@ public:
   /**
     * @brief Destructor, empty.
     */
-  virtual ~QRFactorization() {}
+  virtual ~QRFactorization() = default;
 
   /**
     * @brief resets the QR factorization zo zero Q(0:0, 0:0)R(0:0, 0:0)

--- a/src/acceleration/impl/ResidualPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualPreconditioner.hpp
@@ -20,7 +20,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ResidualPreconditioner() {}
+  virtual ~ResidualPreconditioner() = default;
 
 private:
   /**

--- a/src/acceleration/impl/ResidualPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualPreconditioner.hpp
@@ -5,9 +5,7 @@
 #include "acceleration/impl/Preconditioner.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 /**
  * @brief Preconditioner that uses the recent residual to scale the quasi-Newton system.
@@ -35,6 +33,4 @@ private:
   logging::Logger _log{"acceleration::ResidualPreconditioner"};
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl

--- a/src/acceleration/impl/ResidualPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualPreconditioner.hpp
@@ -20,7 +20,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ResidualPreconditioner() = default;
+  ~ResidualPreconditioner() override = default;
 
 private:
   /**
@@ -28,9 +28,9 @@ private:
     *
     * @param[in] timeWindowComplete True if this FSI iteration also completed a time window
     */
-  virtual void _update_(bool                   timeWindowComplete,
-                        const Eigen::VectorXd &oldValues,
-                        const Eigen::VectorXd &res);
+  void _update_(bool                   timeWindowComplete,
+                const Eigen::VectorXd &oldValues,
+                const Eigen::VectorXd &res) override;
 
   logging::Logger _log{"acceleration::ResidualPreconditioner"};
 };

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -7,9 +7,7 @@
 #include "acceleration/impl/Preconditioner.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 /**
  * @brief Preconditioner that uses the residuals of all iterations of the current time window summed up to scale the quasi-Newton system.
@@ -38,6 +36,4 @@ private:
   std::vector<double> _residualSum;
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -21,7 +21,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ResidualSumPreconditioner() {}
+  virtual ~ResidualSumPreconditioner() = default;
 
   virtual void initialize(std::vector<size_t> &svs);
 

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -21,9 +21,9 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ResidualSumPreconditioner() = default;
+  ~ResidualSumPreconditioner() override = default;
 
-  virtual void initialize(std::vector<size_t> &svs);
+  void initialize(std::vector<size_t> &svs) override;
 
 private:
   /**
@@ -31,7 +31,7 @@ private:
    *
    * @param[in] timeWindowComplete True if this FSI iteration also completed a time window
    */
-  virtual void _update_(bool timeWindowComplete, const Eigen::VectorXd &oldValues, const Eigen::VectorXd &res);
+  void _update_(bool timeWindowComplete, const Eigen::VectorXd &oldValues, const Eigen::VectorXd &res) override;
 
   logging::Logger _log{"acceleration::ResidualSumPreconditioner"};
 

--- a/src/acceleration/impl/SVDFactorization.hpp
+++ b/src/acceleration/impl/SVDFactorization.hpp
@@ -20,9 +20,7 @@
 
 // ------- CLASS DEFINITION
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 /**
  * @brief Class that provides functionality to maintain a SVD decomposition of a matrix
@@ -296,8 +294,6 @@ private:
   bool _applyFilterQR = false;
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl
 
 #endif /* PRECICE_NO_MPI */

--- a/src/acceleration/impl/SVDFactorization.hpp
+++ b/src/acceleration/impl/SVDFactorization.hpp
@@ -44,7 +44,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~SVDFactorization() {}
+  virtual ~SVDFactorization() = default;
 
   /** @brief: updates the SVD decomposition with the rank-1 update A*B^T, i.e.,
    *               _psi * _sigma * _phi^T + A*B^T

--- a/src/acceleration/impl/SharedPointer.hpp
+++ b/src/acceleration/impl/SharedPointer.hpp
@@ -2,14 +2,10 @@
 
 #include <memory>
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 class ParallelMatrixOperations;
 class Preconditioner;
 
 using PtrParMatrixOps   = std::shared_ptr<ParallelMatrixOperations>;
 using PtrPreconditioner = std::shared_ptr<Preconditioner>;
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl

--- a/src/acceleration/impl/ValuePreconditioner.hpp
+++ b/src/acceleration/impl/ValuePreconditioner.hpp
@@ -17,7 +17,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ValuePreconditioner() = default;
+  ~ValuePreconditioner() override = default;
 
 private:
   logging::Logger _log{"acceleration::ValuePreconditioner"};
@@ -27,7 +27,7 @@ private:
    *
    * @param[in] timeWindowComplete True if this FSI iteration also completed a time window
    */
-  virtual void _update_(bool timeWindowComplete, const Eigen::VectorXd &oldValues, const Eigen::VectorXd &res);
+  void _update_(bool timeWindowComplete, const Eigen::VectorXd &oldValues, const Eigen::VectorXd &res) override;
 
   bool _firstTimeWindow = true;
 };

--- a/src/acceleration/impl/ValuePreconditioner.hpp
+++ b/src/acceleration/impl/ValuePreconditioner.hpp
@@ -17,7 +17,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~ValuePreconditioner() {}
+  virtual ~ValuePreconditioner() = default;
 
 private:
   logging::Logger _log{"acceleration::ValuePreconditioner"};

--- a/src/acceleration/impl/ValuePreconditioner.hpp
+++ b/src/acceleration/impl/ValuePreconditioner.hpp
@@ -5,9 +5,7 @@
 #include "acceleration/impl/Preconditioner.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace acceleration {
-namespace impl {
+namespace precice::acceleration::impl {
 
 /// Preconditioner that uses the values from the previous time window to scale the quasi-Newton system.
 class ValuePreconditioner : public Preconditioner {
@@ -32,6 +30,4 @@ private:
   bool _firstTimeWindow = true;
 };
 
-} // namespace impl
-} // namespace acceleration
-} // namespace precice
+} // namespace precice::acceleration::impl

--- a/src/acceleration/test/ParallelMatrixOperationsTest.cpp
+++ b/src/acceleration/test/ParallelMatrixOperationsTest.cpp
@@ -3,10 +3,10 @@
 
 #include <Eigen/Core>
 #include <algorithm>
-#include <math.h>
+#include <cmath>
+#include <cstdlib>
 #include <memory>
 #include <ostream>
-#include <stdlib.h>
 #include <string>
 #include <vector>
 #include "acceleration/impl/ParallelMatrixOperations.hpp"

--- a/src/acceleration/test/PreconditionerTest.cpp
+++ b/src/acceleration/test/PreconditionerTest.cpp
@@ -1,6 +1,6 @@
 #include <Eigen/Core>
 #include <algorithm>
-#include <stddef.h>
+#include <cstddef>
 #include <vector>
 #include "acceleration/impl/ConstantPreconditioner.hpp"
 #include "acceleration/impl/Preconditioner.hpp"

--- a/src/acceleration/test/PreconditionerTest.cpp
+++ b/src/acceleration/test/PreconditionerTest.cpp
@@ -114,9 +114,7 @@ struct ResPreconditionerFixture {
         6.99999999999999883585e+05,
         7.99999999999999650754e+05;
   }
-  ~ResPreconditionerFixture()
-  {
-  }
+  ~ResPreconditionerFixture() = default;
 };
 
 BOOST_FIXTURE_TEST_SUITE(ResPreconditionerTests, ResPreconditionerFixture)

--- a/src/acceleration/test/QRFactorizationTest.cpp
+++ b/src/acceleration/test/QRFactorizationTest.cpp
@@ -1,5 +1,5 @@
 #include <Eigen/Core>
-#include <math.h>
+#include <cmath>
 #include "acceleration/Acceleration.hpp"
 #include "acceleration/BaseQNAcceleration.hpp"
 #include "acceleration/SharedPointer.hpp"

--- a/src/action/PythonAction.hpp
+++ b/src/action/PythonAction.hpp
@@ -22,9 +22,9 @@ public:
       int                  targetDataID,
       int                  sourceDataID);
 
-  virtual ~PythonAction();
+  ~PythonAction() override;
 
-  virtual void performAction() final override;
+  void performAction() final;
 
 private:
   logging::Logger _log{"action::PythonAction"};

--- a/src/action/RecorderAction.hpp
+++ b/src/action/RecorderAction.hpp
@@ -21,7 +21,7 @@ public:
       const mesh::PtrMesh &mesh);
 
   /// Records the invocation and appends it to the records
-  virtual void performAction() final override;
+  void performAction() final;
 
   struct Record {
     Timing timing;

--- a/src/action/ScaleByAreaAction.hpp
+++ b/src/action/ScaleByAreaAction.hpp
@@ -31,7 +31,7 @@ public:
   /**
    * @brief Scales data on mesh nodes according to selected scaling type.
    */
-  void performAction() final override;
+  void performAction() final;
 
 private:
   logging::Logger _log{"action::ScaleByAreaAction"};

--- a/src/action/SharedPointer.hpp
+++ b/src/action/SharedPointer.hpp
@@ -2,8 +2,7 @@
 
 #include <memory>
 
-namespace precice {
-namespace action {
+namespace precice::action {
 
 class Action;
 class ActionConfiguration;
@@ -11,5 +10,4 @@ class ActionConfiguration;
 using PtrAction              = std::unique_ptr<Action>;
 using PtrActionConfiguration = std::shared_ptr<ActionConfiguration>;
 
-} // namespace action
-} // namespace precice
+} // namespace precice::action

--- a/src/action/SummationAction.hpp
+++ b/src/action/SummationAction.hpp
@@ -26,7 +26,7 @@ public:
       const mesh::PtrMesh &   mesh);
 
   /// Adding data and applying them to target
-  void performAction() final override;
+  void performAction() final;
 
 private:
   logging::Logger _log{"action::SummationAction"};

--- a/src/action/config/ActionConfiguration.hpp
+++ b/src/action/config/ActionConfiguration.hpp
@@ -9,8 +9,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace action {
+namespace precice::action {
 
 /**
  * @brief Configures an Action subclass object.
@@ -122,5 +121,4 @@ private:
   Action::Timing getTiming() const;
 };
 
-} // namespace action
-} // namespace precice
+} // namespace precice::action

--- a/src/action/config/ActionConfiguration.hpp
+++ b/src/action/config/ActionConfiguration.hpp
@@ -26,14 +26,14 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
   /**
    * @brief Returns the id of the mesh used in the data action.

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -55,9 +55,7 @@ public:
   Communication &operator=(Communication &&) = delete;
 
   /// Destructor, empty.
-  virtual ~Communication()
-  {
-  }
+  virtual ~Communication() = default;
 
   /// @name Connection Setup
   /// @{

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -12,8 +12,7 @@
 #include "precice/impl/Types.hpp"
 #include "precice/span.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 
 /**
  * @brief Interface for all interprocess communication classes.
@@ -394,5 +393,4 @@ void connectCircularComm(
     com::Communication &left,
     com::Communication &right);
 
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/CommunicationFactory.hpp
+++ b/src/com/CommunicationFactory.hpp
@@ -4,8 +4,7 @@
 #include <string>
 #include "com/SharedPointer.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 class CommunicationFactory {
 
 public:
@@ -18,5 +17,4 @@ public:
     throw std::runtime_error("Not available!");
   }
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/CommunicationFactory.hpp
+++ b/src/com/CommunicationFactory.hpp
@@ -9,7 +9,7 @@ namespace com {
 class CommunicationFactory {
 
 public:
-  virtual ~CommunicationFactory(){};
+  virtual ~CommunicationFactory() = default;
 
   virtual PtrCommunication newCommunication() = 0;
 

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -23,9 +23,7 @@ public:
   MPICommunication();
 
   /// Destructor, empty.
-  virtual ~MPICommunication()
-  {
-  }
+  virtual ~MPICommunication() = default;
 
   /**
    * @brief Sends a std::string to process with given rank.

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -23,102 +23,102 @@ public:
   MPICommunication();
 
   /// Destructor, empty.
-  virtual ~MPICommunication() = default;
+  ~MPICommunication() override = default;
 
   /**
    * @brief Sends a std::string to process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(std::string const &itemToSend, Rank rankReceiver) override;
+  void send(std::string const &itemToSend, Rank rankReceiver) override;
 
   /// Sends an array of integer values.
-  virtual void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of integer values.
-  virtual PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Sends an array of double values.
-  virtual void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of double values.
-  virtual PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   /**
    * @brief Sends a double to process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(double itemToSend, Rank rankReceiver) override;
+  void send(double itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
 
   /**
    * @brief Sends an int to process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(int itemToSend, Rank rankReceiver) override;
+  void send(int itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
 
   /**
    * @brief Sends a bool to process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void send(bool itemToSend, Rank rankReceiver) override;
+  void send(bool itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
 
   /**
    * @brief Receives a std::string from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(std::string &itemToReceive, Rank rankSender) override;
+  void receive(std::string &itemToReceive, Rank rankSender) override;
 
   /// Receives an array of integer values.
-  virtual void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
+  void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
 
   /// Receives an array of double values.
-  virtual void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
+  void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an array of double values.
-  virtual PtrRequest aReceive(precice::span<double> itemsToReceive, int rankSender) override;
+  PtrRequest aReceive(precice::span<double> itemsToReceive, int rankSender) override;
 
   /**
    * @brief Receives a double from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(double &itemToReceive, Rank rankSender) override;
+  void receive(double &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a double from process with given rank.
-  virtual PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
 
   /**
    * @brief Receives an int from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(int &itemToReceive, Rank rankSender) override;
+  void receive(int &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an int from process with given rank.
-  virtual PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
 
   /**
    * @brief Receives a bool from process with given rank.
    *
    * Default MPI point-to-point communication is used.
    */
-  virtual void receive(bool &itemToReceive, Rank rankSender) override;
+  void receive(bool &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a bool from process with given rank.
-  virtual PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
 
 protected:
   /// Returns the communicator.

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -10,8 +10,7 @@
 #include "logging/Logger.hpp"
 #include "precice/impl/Types.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 /**
  * @brief Provides implementation for basic MPI point-to-point communication.
  *
@@ -129,7 +128,6 @@ protected:
 private:
   logging::Logger _log{"com::MPICommunication"};
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com
 
 #endif // not PRECICE_NO_MPI

--- a/src/com/MPIDirectCommunication.hpp
+++ b/src/com/MPIDirectCommunication.hpp
@@ -32,30 +32,30 @@ public:
    */
   MPIDirectCommunication();
 
-  virtual ~MPIDirectCommunication();
+  ~MPIDirectCommunication() override;
 
   /**
    * @brief Returns the number of processes in the remote communicator.
    *
    * @pre A connection to the remote participant has been setup.
    */
-  virtual size_t getRemoteCommunicatorSize() override;
+  size_t getRemoteCommunicatorSize() override;
 
   /** See precice::com::Communication::acceptConnection().
    * @attention Calls precice::utils::Parallel::splitCommunicator()
    * if local and global communicators are equal.
    */
-  virtual void acceptConnection(std::string const &acceptorName,
+  void acceptConnection(std::string const &acceptorName,
+                        std::string const &requesterName,
+                        std::string const &tag,
+                        int                acceptorRank,
+                        int                rankOffset = 0) override;
+
+  void acceptConnectionAsServer(std::string const &acceptorName,
                                 std::string const &requesterName,
                                 std::string const &tag,
                                 int                acceptorRank,
-                                int                rankOffset = 0) override;
-
-  virtual void acceptConnectionAsServer(std::string const &acceptorName,
-                                        std::string const &requesterName,
-                                        std::string const &tag,
-                                        int                acceptorRank,
-                                        int                requesterCommunicatorSize) override
+                                int                requesterCommunicatorSize) override
   {
     PRECICE_ASSERT(false, "Not implemented!");
   }
@@ -64,68 +64,68 @@ public:
    * @attention Calls precice::utils::Parallel::splitCommunicator()
    * if local and global communicators are equal.
    */
-  virtual void requestConnection(std::string const &acceptorName,
-                                 std::string const &requesterName,
-                                 std::string const &tag,
-                                 int                requesterRank,
-                                 int                requesterCommunicatorSize) override;
+  void requestConnection(std::string const &acceptorName,
+                         std::string const &requesterName,
+                         std::string const &tag,
+                         int                requesterRank,
+                         int                requesterCommunicatorSize) override;
 
-  virtual void requestConnectionAsClient(std::string const &  acceptorName,
-                                         std::string const &  requesterName,
-                                         std::string const &  tag,
-                                         std::set<int> const &acceptorRanks,
-                                         int                  requesterRank) override
+  void requestConnectionAsClient(std::string const &  acceptorName,
+                                 std::string const &  requesterName,
+                                 std::string const &  tag,
+                                 std::set<int> const &acceptorRanks,
+                                 int                  requesterRank) override
   {
     PRECICE_ASSERT(false, "Not implemented!");
   }
 
   /// See precice::com::Communication::closeConnection().
-  virtual void closeConnection() override;
+  void closeConnection() override;
 
-  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
+  void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
 
-  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
+  void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
 
-  virtual void reduceSum(int itemToSend, int &itemsToReceive, Rank primaryRank) override;
+  void reduceSum(int itemToSend, int &itemsToReceive, Rank primaryRank) override;
 
-  virtual void reduceSum(int itemToSend, int &itemsToReceive) override;
+  void reduceSum(int itemToSend, int &itemsToReceive) override;
 
-  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
+  void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
 
-  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
+  void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
 
-  virtual void allreduceSum(double itemToSend, double &itemsToReceive, Rank primaryRank) override;
+  void allreduceSum(double itemToSend, double &itemsToReceive, Rank primaryRank) override;
 
-  virtual void allreduceSum(double itemToSend, double &itemsToReceive) override;
+  void allreduceSum(double itemToSend, double &itemsToReceive) override;
 
-  virtual void allreduceSum(int itemToSend, int &itemsToReceive, Rank primaryRank) override;
+  void allreduceSum(int itemToSend, int &itemsToReceive, Rank primaryRank) override;
 
-  virtual void allreduceSum(int itemToSend, int &itemsToReceive) override;
+  void allreduceSum(int itemToSend, int &itemsToReceive) override;
 
-  virtual void broadcast(precice::span<const int> itemsToSend) override;
+  void broadcast(precice::span<const int> itemsToSend) override;
 
-  virtual void broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster) override;
+  void broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster) override;
 
-  virtual void broadcast(int itemToSend) override;
+  void broadcast(int itemToSend) override;
 
-  virtual void broadcast(int &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(int &itemToReceive, Rank rankBroadcaster) override;
 
-  virtual void broadcast(precice::span<const double> itemsToSend) override;
+  void broadcast(precice::span<const double> itemsToSend) override;
 
-  virtual void broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster) override;
+  void broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster) override;
 
-  virtual void broadcast(double itemToSend) override;
+  void broadcast(double itemToSend) override;
 
-  virtual void broadcast(double &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(double &itemToReceive, Rank rankBroadcaster) override;
 
-  virtual void broadcast(bool itemToSend) override;
+  void broadcast(bool itemToSend) override;
 
-  virtual void broadcast(bool &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(bool &itemToReceive, Rank rankBroadcaster) override;
 
 private:
-  virtual MPI_Comm &communicator(Rank rank = 0) override;
+  MPI_Comm &communicator(Rank rank = 0) override;
 
-  virtual Rank rank(int rank) override;
+  Rank rank(int rank) override;
 
   logging::Logger _log{"com::MPIDirectCommunication"};
 
@@ -134,7 +134,7 @@ private:
 
 protected:
   /// Turn the rank adjustment into a noop for direct communication
-  virtual int adjustRank(Rank rank) const override;
+  int adjustRank(Rank rank) const override;
 };
 
 } // namespace com

--- a/src/com/MPIDirectCommunication.hpp
+++ b/src/com/MPIDirectCommunication.hpp
@@ -13,8 +13,7 @@
 #include "utils/Parallel.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 /**
  * @brief Provides connection methods for processes located in one communicator.
  *
@@ -137,7 +136,6 @@ protected:
   int adjustRank(Rank rank) const override;
 };
 
-} // namespace com
-} // namespace precice
+} // namespace precice::com
 
 #endif // not PRECICE_NO_MPI

--- a/src/com/MPIPortsCommunication.hpp
+++ b/src/com/MPIPortsCommunication.hpp
@@ -23,46 +23,46 @@ class MPIPortsCommunication : public MPICommunication {
 public:
   explicit MPIPortsCommunication(std::string addressDirectory = ".");
 
-  virtual ~MPIPortsCommunication();
+  ~MPIPortsCommunication() override;
 
-  virtual size_t getRemoteCommunicatorSize() override;
+  size_t getRemoteCommunicatorSize() override;
 
-  virtual void acceptConnection(std::string const &acceptorName,
+  void acceptConnection(std::string const &acceptorName,
+                        std::string const &requesterName,
+                        std::string const &tag,
+                        int                acceptorRank,
+                        int                rankOffset = 0) override;
+
+  void acceptConnectionAsServer(std::string const &acceptorName,
                                 std::string const &requesterName,
                                 std::string const &tag,
                                 int                acceptorRank,
-                                int                rankOffset = 0) override;
+                                int                requesterCommunicatorSize) override;
 
-  virtual void acceptConnectionAsServer(std::string const &acceptorName,
-                                        std::string const &requesterName,
-                                        std::string const &tag,
-                                        int                acceptorRank,
-                                        int                requesterCommunicatorSize) override;
+  void requestConnection(std::string const &acceptorName,
+                         std::string const &requesterName,
+                         std::string const &tag,
+                         int                requesterRank,
+                         int                requesterCommunicatorSize) override;
 
-  virtual void requestConnection(std::string const &acceptorName,
-                                 std::string const &requesterName,
-                                 std::string const &tag,
-                                 int                requesterRank,
-                                 int                requesterCommunicatorSize) override;
+  void requestConnectionAsClient(std::string const &  acceptorName,
+                                 std::string const &  requesterName,
+                                 std::string const &  tag,
+                                 std::set<int> const &acceptorRanks,
+                                 int                  requesterRank) override;
 
-  virtual void requestConnectionAsClient(std::string const &  acceptorName,
-                                         std::string const &  requesterName,
-                                         std::string const &  tag,
-                                         std::set<int> const &acceptorRanks,
-                                         int                  requesterRank) override;
+  void closeConnection() override;
 
-  virtual void closeConnection() override;
+  void prepareEstablishment(std::string const &acceptorName,
+                            std::string const &requesterName) override;
 
-  virtual void prepareEstablishment(std::string const &acceptorName,
-                                    std::string const &requesterName) override;
-
-  virtual void cleanupEstablishment(std::string const &acceptorName,
-                                    std::string const &requesterName) override;
+  void cleanupEstablishment(std::string const &acceptorName,
+                            std::string const &requesterName) override;
 
 private:
-  virtual MPI_Comm &communicator(Rank rank) override;
+  MPI_Comm &communicator(Rank rank) override;
 
-  virtual Rank rank(int rank) override;
+  Rank rank(int rank) override;
 
   logging::Logger _log{"com::MPIPortsCommunication"};
 

--- a/src/com/MPIPortsCommunication.hpp
+++ b/src/com/MPIPortsCommunication.hpp
@@ -11,8 +11,7 @@
 #include "logging/Logger.hpp"
 #include "precice/impl/Types.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 /**
  * @brief Provides connection methods based on MPI ports (part of MPI 2.0).
  *
@@ -76,7 +75,6 @@ private:
 
   bool _isAcceptor = false;
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com
 
 #endif // not PRECICE_NO_MPI

--- a/src/com/MPIPortsCommunicationFactory.hpp
+++ b/src/com/MPIPortsCommunicationFactory.hpp
@@ -7,8 +7,7 @@
 
 #include <string>
 
-namespace precice {
-namespace com {
+namespace precice::com {
 class MPIPortsCommunicationFactory : public CommunicationFactory {
 public:
   explicit MPIPortsCommunicationFactory(std::string addressDirectory = ".");
@@ -20,7 +19,6 @@ public:
 private:
   std::string _addressDirectory;
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com
 
 #endif // not PRECICE_NO_MPI

--- a/src/com/MPIRequest.hpp
+++ b/src/com/MPIRequest.hpp
@@ -4,8 +4,7 @@
 #include <mpi.h>
 #include "com/Request.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 class MPIRequest : public Request {
 public:
   explicit MPIRequest(MPI_Request request);
@@ -17,7 +16,6 @@ public:
 private:
   MPI_Request _request;
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com
 
 #endif // not PRECICE_NO_MPI

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -11,8 +11,7 @@
 #include "logging/Logger.hpp"
 #include "precice/impl/Types.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 /**
  * @brief Provides connection methods based on MPI ports (part of MPI 2.0).
  *
@@ -111,7 +110,6 @@ private:
 
   bool _isAcceptor = false;
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com
 
 #endif // not PRECICE_NO_MPI

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -37,46 +37,46 @@ class MPISinglePortsCommunication : public MPICommunication {
 public:
   explicit MPISinglePortsCommunication(std::string addressDirectory = ".");
 
-  virtual ~MPISinglePortsCommunication();
+  ~MPISinglePortsCommunication() override;
 
-  virtual size_t getRemoteCommunicatorSize() override;
+  size_t getRemoteCommunicatorSize() override;
 
-  virtual void acceptConnection(std::string const &acceptorName,
+  void acceptConnection(std::string const &acceptorName,
+                        std::string const &requesterName,
+                        std::string const &tag,
+                        int                acceptorRank,
+                        int                rankOffset = 0) override;
+
+  void acceptConnectionAsServer(std::string const &acceptorName,
                                 std::string const &requesterName,
                                 std::string const &tag,
                                 int                acceptorRank,
-                                int                rankOffset = 0) override;
+                                int                requesterCommunicatorSize) override;
 
-  virtual void acceptConnectionAsServer(std::string const &acceptorName,
-                                        std::string const &requesterName,
-                                        std::string const &tag,
-                                        int                acceptorRank,
-                                        int                requesterCommunicatorSize) override;
+  void requestConnection(std::string const &acceptorName,
+                         std::string const &requesterName,
+                         std::string const &tag,
+                         int                requesterRank,
+                         int                requesterCommunicatorSize) override;
 
-  virtual void requestConnection(std::string const &acceptorName,
-                                 std::string const &requesterName,
-                                 std::string const &tag,
-                                 int                requesterRank,
-                                 int                requesterCommunicatorSize) override;
+  void requestConnectionAsClient(std::string const &  acceptorName,
+                                 std::string const &  requesterName,
+                                 std::string const &  tag,
+                                 std::set<int> const &acceptorRanks,
+                                 int                  requesterRank) override;
 
-  virtual void requestConnectionAsClient(std::string const &  acceptorName,
-                                         std::string const &  requesterName,
-                                         std::string const &  tag,
-                                         std::set<int> const &acceptorRanks,
-                                         int                  requesterRank) override;
+  void prepareEstablishment(std::string const &acceptorName,
+                            std::string const &requesterName) override;
 
-  virtual void prepareEstablishment(std::string const &acceptorName,
-                                    std::string const &requesterName) override;
+  void cleanupEstablishment(std::string const &acceptorName,
+                            std::string const &requesterName) override;
 
-  virtual void cleanupEstablishment(std::string const &acceptorName,
-                                    std::string const &requesterName) override;
-
-  virtual void closeConnection() override;
+  void closeConnection() override;
 
 private:
-  virtual MPI_Comm &communicator(Rank rank) override;
+  MPI_Comm &communicator(Rank rank) override;
 
-  virtual Rank rank(int rank) override;
+  Rank rank(int rank) override;
 
   logging::Logger _log{"com::MPISinglePortsCommunication"};
 

--- a/src/com/MPISinglePortsCommunicationFactory.hpp
+++ b/src/com/MPISinglePortsCommunicationFactory.hpp
@@ -7,8 +7,7 @@
 
 #include <string>
 
-namespace precice {
-namespace com {
+namespace precice::com {
 class MPISinglePortsCommunicationFactory : public CommunicationFactory {
 public:
   explicit MPISinglePortsCommunicationFactory(std::string addressDirectory = ".");
@@ -20,7 +19,6 @@ public:
 private:
   std::string _addressDirectory;
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com
 
 #endif // not PRECICE_NO_MPI

--- a/src/com/Request.hpp
+++ b/src/com/Request.hpp
@@ -3,8 +3,7 @@
 #include <vector>
 #include "com/SharedPointer.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 class Request {
 
 public:
@@ -16,5 +15,4 @@ public:
 
   virtual void wait() = 0;
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/SerializedStamples.hpp
+++ b/src/com/SerializedStamples.hpp
@@ -4,8 +4,7 @@
 #include <vector>
 #include "cplscheme/SharedPointer.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 class Communication;
 
 namespace serialize {
@@ -112,5 +111,4 @@ private:
 };
 
 } // namespace serialize
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/SharedPointer.hpp
+++ b/src/com/SharedPointer.hpp
@@ -2,8 +2,7 @@
 
 #include <memory>
 
-namespace precice {
-namespace com {
+namespace precice::com {
 
 class Communication;
 class CommunicationFactory;
@@ -12,5 +11,4 @@ class Request;
 using PtrCommunication        = std::shared_ptr<Communication>;
 using PtrCommunicationFactory = std::shared_ptr<CommunicationFactory>;
 using PtrRequest              = std::shared_ptr<Request>;
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -27,105 +27,105 @@ public:
 
   explicit SocketCommunication(std::string const &addressDirectory);
 
-  virtual ~SocketCommunication();
+  ~SocketCommunication() override;
 
-  virtual size_t getRemoteCommunicatorSize() override;
+  size_t getRemoteCommunicatorSize() override;
 
-  virtual void acceptConnection(std::string const &acceptorName,
+  void acceptConnection(std::string const &acceptorName,
+                        std::string const &requesterName,
+                        std::string const &tag,
+                        int                acceptorRank,
+                        int                rankOffset = 0) override;
+
+  void acceptConnectionAsServer(std::string const &acceptorName,
                                 std::string const &requesterName,
                                 std::string const &tag,
                                 int                acceptorRank,
-                                int                rankOffset = 0) override;
+                                int                requesterCommunicatorSize) override;
 
-  virtual void acceptConnectionAsServer(std::string const &acceptorName,
-                                        std::string const &requesterName,
-                                        std::string const &tag,
-                                        int                acceptorRank,
-                                        int                requesterCommunicatorSize) override;
+  void requestConnection(std::string const &acceptorName,
+                         std::string const &requesterName,
+                         std::string const &tag,
+                         int                requesterRank,
+                         int                requesterCommunicatorSize) override;
 
-  virtual void requestConnection(std::string const &acceptorName,
-                                 std::string const &requesterName,
-                                 std::string const &tag,
-                                 int                requesterRank,
-                                 int                requesterCommunicatorSize) override;
+  void requestConnectionAsClient(std::string const &  acceptorName,
+                                 std::string const &  requesterName,
+                                 std::string const &  tag,
+                                 std::set<int> const &acceptorRanks,
+                                 int                  requesterRank) override;
 
-  virtual void requestConnectionAsClient(std::string const &  acceptorName,
-                                         std::string const &  requesterName,
-                                         std::string const &  tag,
-                                         std::set<int> const &acceptorRanks,
-                                         int                  requesterRank) override;
-
-  virtual void closeConnection() override;
+  void closeConnection() override;
 
   /// Sends a std::string to process with given rank.
-  virtual void send(std::string const &itemToSend, Rank rankReceiver) override;
+  void send(std::string const &itemToSend, Rank rankReceiver) override;
 
   /// Sends an array of integer values.
-  virtual void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of integer values.
-  virtual PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
 
   /// Sends an array of double values.
-  virtual void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an array of double values.
-  virtual PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
 
   /// Sends a double to process with given rank.
-  virtual void send(double itemToSend, Rank rankReceiver) override;
+  void send(double itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a double to process with given rank.
-  virtual PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
 
   /// Sends an int to process with given rank.
-  virtual void send(int itemToSend, Rank rankReceiver) override;
+  void send(int itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends an int to process with given rank.
-  virtual PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
 
   /// Sends a bool to process with given rank.
-  virtual void send(bool itemToSend, Rank rankReceiver) override;
+  void send(bool itemToSend, Rank rankReceiver) override;
 
   /// Asynchronously sends a bool to process with given rank.
-  virtual PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
 
   /// Receives a std::string from process with given rank.
-  virtual void receive(std::string &itemToReceive, Rank rankSender) override;
+  void receive(std::string &itemToReceive, Rank rankSender) override;
 
   /// Receives an array of integer values.
-  virtual void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
+  void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
 
   /// Receives an array of double values.
-  virtual void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
+  void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an array of double values.
-  virtual PtrRequest aReceive(precice::span<double> itemsToReceive,
-                              int                   rankSender) override;
+  PtrRequest aReceive(precice::span<double> itemsToReceive,
+                      int                   rankSender) override;
 
   /// Receives a double from process with given rank.
-  virtual void receive(double &itemToReceive, Rank rankSender) override;
+  void receive(double &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a double from process with given rank.
-  virtual PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
 
   /// Receives an int from process with given rank.
-  virtual void receive(int &itemToReceive, Rank rankSender) override;
+  void receive(int &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives an int from process with given rank.
-  virtual PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
 
   /// Receives a bool from process with given rank.
-  virtual void receive(bool &itemToReceive, Rank rankSender) override;
+  void receive(bool &itemToReceive, Rank rankSender) override;
 
   /// Asynchronously receives a bool from process with given rank.
-  virtual PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
 
-  virtual void prepareEstablishment(std::string const &acceptorName,
-                                    std::string const &requesterName) override;
+  void prepareEstablishment(std::string const &acceptorName,
+                            std::string const &requesterName) override;
 
-  virtual void cleanupEstablishment(std::string const &acceptorName,
-                                    std::string const &requesterName) override;
+  void cleanupEstablishment(std::string const &acceptorName,
+                            std::string const &requesterName) override;
 
 private:
   logging::Logger _log{"com::SocketCommunication"};

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -15,8 +15,7 @@
 #include "precice/impl/Types.hpp"
 #include "utils/networking.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 /// Implements Communication by using sockets.
 class SocketCommunication : public Communication {
 public:
@@ -159,5 +158,4 @@ private:
 
   std::string getIpAddress();
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/SocketCommunicationFactory.hpp
+++ b/src/com/SocketCommunicationFactory.hpp
@@ -6,8 +6,7 @@
 
 #include <string>
 
-namespace precice {
-namespace com {
+namespace precice::com {
 class SocketCommunicationFactory : public CommunicationFactory {
 public:
   SocketCommunicationFactory(unsigned short portNumber       = 0,
@@ -27,5 +26,4 @@ private:
   std::string    _networkName;
   std::string    _addressDirectory;
 };
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/SocketSendQueue.hpp
+++ b/src/com/SocketSendQueue.hpp
@@ -8,8 +8,7 @@
 #include <string>
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace com {
+namespace precice::com {
 
 /// This Queue is intended for SocketCommunication to push requests which should be sent onto it.
 /// It ensures that the invocations of asio::aSend are done serially.
@@ -47,5 +46,4 @@ private:
   bool _ready = true;
 };
 
-} // namespace com
-} // namespace precice
+} // namespace precice::com

--- a/src/com/config/CommunicationConfiguration.hpp
+++ b/src/com/config/CommunicationConfiguration.hpp
@@ -18,7 +18,7 @@ namespace com {
  */
 class CommunicationConfiguration {
 public:
-  virtual ~CommunicationConfiguration() {}
+  virtual ~CommunicationConfiguration() = default;
 
   /// Returns a communication object of given type.
   PtrCommunication createCommunication(const xml::XMLTag &tag) const;

--- a/src/com/tests/GenericTestFunctions.hpp
+++ b/src/com/tests/GenericTestFunctions.hpp
@@ -11,9 +11,7 @@
 /// Generic test function that is called from the tests for
 /// MPIPortsCommunication, MPIDirectCommunication and SocketCommunication
 
-namespace precice {
-namespace testing {
-namespace com {
+namespace precice::testing::com {
 
 namespace primaryprimary {
 
@@ -940,6 +938,4 @@ void TestSendReceiveFourProcessesServerClientV2(TestContext const &context)
 
 } // namespace serverclient
 
-} // namespace com
-} // namespace testing
-} // namespace precice
+} // namespace precice::testing::com

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -78,16 +78,16 @@ public:
    * @brief Getter for _sendsInitializedData
    * @returns _sendsInitializedData
    */
-  bool sendsInitializedData() const override final;
+  bool sendsInitializedData() const final;
 
   /**
    * @brief getter for _isInitialized
    * @returns true, if initialize has been called.
    */
-  bool isInitialized() const override final;
+  bool isInitialized() const final;
 
   /// @copydoc cplscheme::CouplingScheme::addComputedTime()
-  bool addComputedTime(double timeToAdd) override final;
+  bool addComputedTime(double timeToAdd) final;
 
   /**
    * @brief Returns true, if data will be exchanged when calling advance().
@@ -98,27 +98,27 @@ public:
    * @param lastSolverTimeStepSize [IN] The size of the last time step
    *        computed by the solver calling willDataBeExchanged().
    */
-  bool willDataBeExchanged(double lastSolverTimeStepSize) const override final;
+  bool willDataBeExchanged(double lastSolverTimeStepSize) const final;
 
   /**
    * @brief getter for _hasDataBeenReceived
    * @returns true, if data has been received in last call of advance().
    */
-  bool hasDataBeenReceived() const override final;
+  bool hasDataBeenReceived() const final;
 
   /**
    * @brief getter for _time
    * @returns the currently computed time of the coupling scheme.
    */
-  double getTime() const override final;
+  double getTime() const final;
 
-  double getTimeWindowStart() const override final;
+  double getTimeWindowStart() const final;
 
   /**
    * @brief getter for _timeWindows
    * @returns the number of currently computed time windows of the coupling scheme.
    */
-  int getTimeWindows() const override final;
+  int getTimeWindows() const final;
 
   /**
    * @brief Function to check whether time window size is defined by coupling scheme.
@@ -129,7 +129,7 @@ public:
    *
    * @returns true, if time window size is available.
    */
-  bool hasTimeWindowSize() const override final;
+  bool hasTimeWindowSize() const final;
 
   /**
    * @brief Returns the time window size, if one is given by the coupling scheme.
@@ -137,7 +137,7 @@ public:
    * An assertion is thrown, if no valid time window size is given. Check with
    * hasTimeWindowSize().
    */
-  double getTimeWindowSize() const override final;
+  double getTimeWindowSize() const final;
 
   /**
    * @brief Returns the maximal size of the next time step to be computed.
@@ -145,25 +145,25 @@ public:
    * If no time window size is prescribed by the coupling scheme, always the
    * maximal double accuracy floating point number value is returned.
    */
-  double getNextTimeStepMaxSize() const override final;
+  double getNextTimeStepMaxSize() const final;
 
   /// Returns true, when the coupled simulation is still ongoing.
-  bool isCouplingOngoing() const override final;
+  bool isCouplingOngoing() const final;
 
   /// Returns true, when the accessor can advance to the next time window.
-  bool isTimeWindowComplete() const override final;
+  bool isTimeWindowComplete() const final;
 
   /// Returns true, if the given action has to be performed by the accessor.
-  bool isActionRequired(Action action) const override final;
+  bool isActionRequired(Action action) const final;
 
   /// Returns true, if the given action has to be performed by the accessor.
-  bool isActionFulfilled(Action action) const override final;
+  bool isActionFulfilled(Action action) const final;
 
   /// Tells the coupling scheme that the accessor has performed the given action.
-  void markActionFulfilled(Action action) override final;
+  void markActionFulfilled(Action action) final;
 
   /// Sets an action required to be performed by the accessor.
-  void requireAction(Action action) override final;
+  void requireAction(Action action) final;
 
   /**
    * @brief Returns coupling state information.
@@ -173,20 +173,20 @@ public:
   std::string printCouplingState() const override;
 
   /// Finalizes the coupling scheme.
-  void finalize() override final;
+  void finalize() final;
 
   /// @copydoc cplscheme::CouplingScheme::initialize()
-  void initialize() override final;
+  void initialize() final;
 
-  void reinitialize() override final;
+  void reinitialize() final;
 
-  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) override final;
+  ChangedMeshes firstSynchronization(const ChangedMeshes &changes) final;
 
-  void firstExchange() override final;
+  void firstExchange() final;
 
-  ChangedMeshes secondSynchronization() override final;
+  ChangedMeshes secondSynchronization() final;
 
-  void secondExchange() override final;
+  void secondExchange() final;
 
   /// Adds a measure to determine the convergence of coupling iterations.
   void addConvergenceMeasure(
@@ -394,13 +394,13 @@ protected:
   bool reachedEndOfTimeWindow() const;
 
   /// @copydoc cplscheme::CouplingScheme::requiresSubsteps()
-  bool requiresSubsteps() const override final;
+  bool requiresSubsteps() const final;
 
   /// @copydoc cplscheme::CouplingScheme::implicitDataToReceive()
   ImplicitData implicitDataToReceive() const override;
 
   /// @copydoc cplscheme::CouplingScheme::localParticipant()
-  std::string localParticipant() const override final;
+  std::string localParticipant() const final;
 
 private:
   /// Coupling mode used by coupling scheme.

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -57,12 +57,12 @@ public:
   void determineInitialDataExchange() override;
 
   /// returns list of all coupling partners
-  std::vector<std::string> getCouplingPartners() const override final;
+  std::vector<std::string> getCouplingPartners() const final;
 
   /**
    * @returns true, if coupling scheme has any sendData
    */
-  bool hasAnySendData() override final;
+  bool hasAnySendData() final;
 
   /**
    * @returns true, if coupling scheme has sendData with given DataID
@@ -89,7 +89,7 @@ protected:
   m2n::PtrM2N getM2N() const;
 
   /// @copydoc cplscheme::BaseCouplingScheme::initializeReceiveDataStorage()
-  void initializeReceiveDataStorage() override final;
+  void initializeReceiveDataStorage() final;
 
 private:
   mutable logging::Logger _log{"cplscheme::BiCouplingScheme"};

--- a/src/cplscheme/BiCouplingScheme.hpp
+++ b/src/cplscheme/BiCouplingScheme.hpp
@@ -12,8 +12,7 @@
 #include "precice/impl/Types.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace cplscheme {
+namespace precice::cplscheme {
 class CouplingData;
 
 /**
@@ -110,5 +109,4 @@ private:
   std::string _secondParticipant = "unknown";
 };
 
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -57,7 +57,7 @@ namespace cplscheme {
 class CompositionalCouplingScheme final : public CouplingScheme {
 public:
   /// Destructor, empty.
-  virtual ~CompositionalCouplingScheme() {}
+  virtual ~CompositionalCouplingScheme() = default;
 
   /**
    * @brief Adds another coupling scheme in parallel to this scheme.

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -9,8 +9,7 @@
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace cplscheme {
+namespace precice::cplscheme {
 
 /**
  * @brief Acts as one coupling scheme, but consists of several composed ones.
@@ -249,5 +248,4 @@ private:
   void checkCompatibleTimeWindowSizes(const CouplingScheme &impl, const CouplingScheme &expl) const;
 };
 
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme

--- a/src/cplscheme/CompositionalCouplingScheme.hpp
+++ b/src/cplscheme/CompositionalCouplingScheme.hpp
@@ -57,7 +57,7 @@ namespace cplscheme {
 class CompositionalCouplingScheme final : public CouplingScheme {
 public:
   /// Destructor, empty.
-  virtual ~CompositionalCouplingScheme() = default;
+  ~CompositionalCouplingScheme() override = default;
 
   /**
    * @brief Adds another coupling scheme in parallel to this scheme.
@@ -75,18 +75,18 @@ public:
    * @brief Initializes the coupling scheme and establishes a communication
    *        connection to the coupling partner.
    */
-  void initialize() final override;
+  void initialize() final;
 
-  void reinitialize() override final;
+  void reinitialize() final;
 
   /// Returns true, if any of the composed coupling schemes sendsInitializedData for this participant
-  bool sendsInitializedData() const override final;
+  bool sendsInitializedData() const final;
 
   /// Returns true, if initialize has been called.
-  bool isInitialized() const final override;
+  bool isInitialized() const final;
 
   /// @copydoc cplscheme::CouplingScheme::addComputedTime()
-  bool addComputedTime(double timeToAdd) final override;
+  bool addComputedTime(double timeToAdd) final;
 
   /// Exchanges data and updates the state of the coupling scheme.
   //void advance() final override;
@@ -100,13 +100,13 @@ public:
   void secondExchange() override;
 
   /// Finalizes the coupling and disconnects communication.
-  void finalize() final override;
+  void finalize() final;
 
   /// Returns list of all coupling partners
-  std::vector<std::string> getCouplingPartners() const final override;
+  std::vector<std::string> getCouplingPartners() const final;
 
   /// @copydoc cplscheme::CouplingScheme::localParticipant()
-  std::string localParticipant() const override final;
+  std::string localParticipant() const final;
 
   /**
    * @brief Returns true, if data will be exchanged when calling advance().
@@ -117,35 +117,35 @@ public:
    * @param lastSolverTimeStepSize [IN] The size of the last time step
    *        computed by the solver calling willDataBeExchanged().
    */
-  bool willDataBeExchanged(double lastSolverTimeStepSize) const final override;
+  bool willDataBeExchanged(double lastSolverTimeStepSize) const final;
 
   /**
    * @brief checks all coupling schemes this coupling scheme is composed of.
    * @returns true, if data has been exchanged in last call of advance().
    */
-  bool hasDataBeenReceived() const final override;
+  bool hasDataBeenReceived() const final;
 
   /**
    * @brief Returns the currently computed time of the coupling scheme.
    *
    * This time is the minimum time of any coupling scheme in the composition.
    */
-  double getTime() const final override;
+  double getTime() const final;
 
-  double getTimeWindowStart() const override final;
+  double getTimeWindowStart() const final;
 
   /**
    * @brief Returns the currently computed time windows of the coupling scheme.
    *
    * The time window is the minimum time window in any coupling scheme in the composition.
    */
-  int getTimeWindows() const final override;
+  int getTimeWindows() const final;
 
   /**
    * @brief Returns true, if time window size is given by any of the coupling schemes in this compositional coupling scheme.
    *
    */
-  bool hasTimeWindowSize() const final override;
+  bool hasTimeWindowSize() const final;
 
   /**
    * @brief Returns the time window size, if one is given by the coupling scheme.
@@ -154,7 +154,7 @@ public:
    * hasTimeWindowSize().
    *
    */
-  double getTimeWindowSize() const final override;
+  double getTimeWindowSize() const final;
 
   /**
    * @brief Returns the maximal size of the next time step to be computed.
@@ -164,40 +164,40 @@ public:
    *
    * This is the minimum of all max sizes of the composed coupling schemes.
    */
-  double getNextTimeStepMaxSize() const final override;
+  double getNextTimeStepMaxSize() const final;
 
   /**
    * @brief Returns true, when the coupled simulation is still ongoing.
    *
    * As long as one composed coupling scheme is still ongoing, returns true.
    */
-  bool isCouplingOngoing() const final override;
+  bool isCouplingOngoing() const final;
 
   /**
    * @brief Returns true, when the accessor can advance to the next time window.
    *
    * Only true, if all composed coupling schemes have completed the time window.
    */
-  bool isTimeWindowComplete() const final override;
+  bool isTimeWindowComplete() const final;
 
   /**
    * @brief Returns true, if the given action has to be performed by the accessor.
    *
    * True, if any of the composed coupling schemes requires the action.
    */
-  bool isActionRequired(Action action) const final override;
+  bool isActionRequired(Action action) const final;
 
   /// Returns true, if the given action has been performed by the accessor.
-  bool isActionFulfilled(Action action) const final override;
+  bool isActionFulfilled(Action action) const final;
 
   /// Tells the coupling scheme that the accessor has performed the given action.
-  void markActionFulfilled(Action action) final override;
+  void markActionFulfilled(Action action) final;
 
   /// Sets an action required to be performed by the accessor.
-  void requireAction(Action action) final override;
+  void requireAction(Action action) final;
 
   /// Returns a string representation of the current coupling state.
-  std::string printCouplingState() const final override;
+  std::string printCouplingState() const final;
 
   /// True if one cplscheme is an implicit scheme
   bool isImplicitCouplingScheme() const final;
@@ -206,10 +206,10 @@ public:
   bool hasConverged() const final;
 
   /// @copydoc cplscheme::CouplingScheme::requiresSubsteps()
-  bool requiresSubsteps() const override final;
+  bool requiresSubsteps() const final;
 
   /// @copydoc cplscheme::CouplingScheme::implicitDataToReceive()
-  ImplicitData implicitDataToReceive() const override final;
+  ImplicitData implicitDataToReceive() const final;
 
 private:
   mutable logging::Logger _log{"cplscheme::CompositionalCouplingScheme"};

--- a/src/cplscheme/Constants.hpp
+++ b/src/cplscheme/Constants.hpp
@@ -2,15 +2,11 @@
 
 #include <string>
 
-namespace precice {
-namespace cplscheme {
-namespace constants {
+namespace precice::cplscheme::constants {
 
 enum TimesteppingMethod {
   FIXED_TIME_WINDOW_SIZE,
   FIRST_PARTICIPANT_SETS_TIME_WINDOW_SIZE
 };
 
-} // namespace constants
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::constants

--- a/src/cplscheme/CouplingData.hpp
+++ b/src/cplscheme/CouplingData.hpp
@@ -7,8 +7,7 @@
 #include "time/Storage.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace cplscheme {
+namespace precice::cplscheme {
 
 class CouplingData {
 public:
@@ -140,5 +139,4 @@ private:
   Direction _direction;
 };
 
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -8,8 +8,7 @@
 #include "cplscheme/ImplicitData.hpp"
 #include "precice/impl/Types.hpp"
 
-namespace precice {
-namespace cplscheme {
+namespace precice::cplscheme {
 
 /**
  * @brief Interface for all coupling schemes.
@@ -238,5 +237,4 @@ public:
   virtual ImplicitData implicitDataToReceive() const = 0;
 };
 
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme

--- a/src/cplscheme/CouplingScheme.hpp
+++ b/src/cplscheme/CouplingScheme.hpp
@@ -70,7 +70,7 @@ public:
 
   CouplingScheme &operator=(CouplingScheme &&) = delete;
 
-  virtual ~CouplingScheme() {}
+  virtual ~CouplingScheme() = default;
 
   /**
    * @brief Initializes the coupling scheme and establishes a communication

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -63,9 +63,9 @@ public:
 
   void determineInitialDataExchange() override;
 
-  std::vector<std::string> getCouplingPartners() const override final;
+  std::vector<std::string> getCouplingPartners() const final;
 
-  bool hasAnySendData() override final;
+  bool hasAnySendData() final;
 
 private:
   /**
@@ -91,21 +91,21 @@ private:
 
   logging::Logger _log{"cplscheme::MultiCouplingScheme"};
 
-  void exchangeFirstData() override final;
+  void exchangeFirstData() final;
 
-  void exchangeSecondData() override final;
+  void exchangeSecondData() final;
 
   bool sendsInitializedDataTo(const std::string &to) const;
 
   bool receivesInitializedDataFrom(const std::string &from) const;
 
-  DataMap &getAccelerationData() override final;
+  DataMap &getAccelerationData() final;
 
   /// @copydoc cplscheme::BaseCouplingScheme::initializeReceiveDataStorage()
-  void initializeReceiveDataStorage() override final;
+  void initializeReceiveDataStorage() final;
 
   /// @copydoc cplscheme::BaseCouplingScheme::exchangeInitialData()
-  void exchangeInitialData() override final;
+  void exchangeInitialData() final;
 
   /// name of the controller participant
   std::string _controller;

--- a/src/cplscheme/MultiCouplingScheme.hpp
+++ b/src/cplscheme/MultiCouplingScheme.hpp
@@ -10,8 +10,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "utils/Helpers.hpp"
 
-namespace precice {
-namespace cplscheme {
+namespace precice::cplscheme {
 class CouplingData;
 struct ExchangeData;
 
@@ -114,5 +113,4 @@ private:
   bool _isController;
 };
 
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme

--- a/src/cplscheme/ParallelCouplingScheme.hpp
+++ b/src/cplscheme/ParallelCouplingScheme.hpp
@@ -65,13 +65,13 @@ private:
   logging::Logger _log{"cplscheme::ParallelCouplingScheme"};
 
   /// @copydoc cplscheme::BaseCouplingScheme::exchangeInitialData()
-  void exchangeInitialData() override final;
+  void exchangeInitialData() final;
 
-  void exchangeFirstData() override final;
+  void exchangeFirstData() final;
 
-  void exchangeSecondData() override final;
+  void exchangeSecondData() final;
 
-  DataMap &getAccelerationData() override final;
+  DataMap &getAccelerationData() final;
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/SerialCouplingScheme.hpp
+++ b/src/cplscheme/SerialCouplingScheme.hpp
@@ -62,7 +62,7 @@ public:
       constants::TimesteppingMethod dtMethod,
       CouplingMode                  cplMode);
 
-  ImplicitData implicitDataToReceive() const override final;
+  ImplicitData implicitDataToReceive() const final;
 
 private:
   logging::Logger _log{"cplschemes::SerialCouplingSchemes"};
@@ -80,13 +80,13 @@ private:
   void receiveAndSetTimeWindowSize();
 
   /// @copydoc cplscheme::BaseCouplingScheme::exchangeInitialData()
-  void exchangeInitialData() override final;
+  void exchangeInitialData() final;
 
-  void exchangeFirstData() override final;
+  void exchangeFirstData() final;
 
-  void exchangeSecondData() override final;
+  void exchangeSecondData() final;
 
-  DataMap &getAccelerationData() override final;
+  DataMap &getAccelerationData() final;
 };
 
 } // namespace cplscheme

--- a/src/cplscheme/SharedPointer.hpp
+++ b/src/cplscheme/SharedPointer.hpp
@@ -3,8 +3,7 @@
 #include <map>
 #include <memory>
 
-namespace precice {
-namespace cplscheme {
+namespace precice::cplscheme {
 
 class CouplingScheme;
 class CouplingSchemeConfiguration;
@@ -15,5 +14,4 @@ using PtrCouplingSchemeConfiguration = std::shared_ptr<CouplingSchemeConfigurati
 using PtrCouplingData                = std::shared_ptr<CouplingData>;
 using DataMap                        = std::map<int, PtrCouplingData>; /// Map that links DataID to CouplingData
 
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -19,12 +19,10 @@
 #include "precice/impl/Types.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace cplscheme {
+namespace precice::cplscheme {
 class CompositionalCouplingScheme;
 class BiCouplingScheme;
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme
 
 // Forward declaration to friend the boost test struct
 namespace CplSchemeTests {
@@ -37,8 +35,8 @@ struct testParseConfigurationWithRelaxation;
 } // namespace CplSchemeTests
 
 // ----------------------------------------------------------- CLASS DEFINITION
-namespace precice {
-namespace cplscheme {
+
+namespace precice::cplscheme {
 class MultiCouplingScheme;
 
 /// Configuration for coupling schemes.
@@ -321,5 +319,4 @@ private:
    */
   void checkIterationLimits() const;
 };
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -61,7 +61,7 @@ public:
   void setRemeshing(bool allowed);
 
   /// Destructor, empty.
-  virtual ~CouplingSchemeConfiguration() = default;
+  ~CouplingSchemeConfiguration() override = default;
 
   /// Check, if a coupling scheme is configured for a participant.
   bool hasCouplingScheme(const std::string &participantName) const;
@@ -73,10 +73,10 @@ public:
   const std::string &getDataToExchange(int index) const;
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
   /// Callback method required when using xml::XMLTag.
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
   /// Adds a manually configured coupling scheme for a participant.
   void addCouplingScheme(const PtrCouplingScheme &cplScheme, const std::string &participantName);

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -61,7 +61,7 @@ public:
   void setRemeshing(bool allowed);
 
   /// Destructor, empty.
-  virtual ~CouplingSchemeConfiguration() {}
+  virtual ~CouplingSchemeConfiguration() = default;
 
   /// Check, if a coupling scheme is configured for a participant.
   bool hasCouplingScheme(const std::string &participantName) const;

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
@@ -35,7 +35,7 @@ class AbsoluteConvergenceMeasure : public ConvergenceMeasure {
 public:
   explicit AbsoluteConvergenceMeasure(double convergenceLimit);
 
-  virtual ~AbsoluteConvergenceMeasure(){};
+  virtual ~AbsoluteConvergenceMeasure() = default;
 
   virtual void newMeasurementSeries()
   {

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
@@ -35,29 +35,29 @@ class AbsoluteConvergenceMeasure : public ConvergenceMeasure {
 public:
   explicit AbsoluteConvergenceMeasure(double convergenceLimit);
 
-  virtual ~AbsoluteConvergenceMeasure() = default;
+  ~AbsoluteConvergenceMeasure() override = default;
 
-  virtual void newMeasurementSeries()
+  void newMeasurementSeries() override
   {
     _isConvergence = false;
   }
 
-  virtual void measure(
+  void measure(
       const Eigen::VectorXd &oldValues,
-      const Eigen::VectorXd &newValues)
+      const Eigen::VectorXd &newValues) override
   {
     PRECICE_ASSERT(oldValues.size() == newValues.size());
     _normDiff      = utils::IntraComm::l2norm(newValues - oldValues);
     _isConvergence = _normDiff <= _convergenceLimit;
   }
 
-  virtual bool isConvergence() const
+  bool isConvergence() const override
   {
     return _isConvergence;
   }
 
   /// Adds current convergence information to output stream.
-  virtual std::string printState(const std::string &dataName)
+  std::string printState(const std::string &dataName) override
   {
     std::ostringstream os;
     os << "absolute convergence measure: ";
@@ -72,12 +72,12 @@ public:
     return os.str();
   }
 
-  virtual double getNormResidual()
+  double getNormResidual() override
   {
     return _normDiff;
   }
 
-  virtual std::string getAbbreviation() const
+  std::string getAbbreviation() const override
   {
     return "Abs";
   }

--- a/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteConvergenceMeasure.hpp
@@ -9,17 +9,11 @@
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace cplscheme {
-namespace tests {
+namespace precice::cplscheme::tests {
 class AbsoluteConvergenceMeasureTest;
 }
-} // namespace cplscheme
-} // namespace precice
 
-namespace precice {
-namespace cplscheme {
-namespace impl {
+namespace precice::cplscheme::impl {
 
 /**
  * @brief Measures the convergence from an old data set to a new one.
@@ -91,6 +85,4 @@ private:
 
   bool _isConvergence = false;
 };
-} // namespace impl
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/impl/AbsoluteOrRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteOrRelativeConvergenceMeasure.hpp
@@ -54,7 +54,7 @@ public:
    */
   AbsoluteOrRelativeConvergenceMeasure(double absLimit, double relLimit);
 
-  virtual ~AbsoluteOrRelativeConvergenceMeasure(){};
+  virtual ~AbsoluteOrRelativeConvergenceMeasure() = default;
 
   virtual void newMeasurementSeries()
   {

--- a/src/cplscheme/impl/AbsoluteOrRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteOrRelativeConvergenceMeasure.hpp
@@ -14,19 +14,13 @@
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace cplscheme {
-namespace tests {
+namespace precice::cplscheme::tests {
 class AbsoluteOrRelativeConvergenceMeasureTest;
 }
-} // namespace cplscheme
-} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace cplscheme {
-namespace impl {
+namespace precice::cplscheme::impl {
 
 /**
  * @brief Measures the convergence from an old data set to a new one.
@@ -131,6 +125,4 @@ private:
 
   bool _isConvergence = false;
 };
-} // namespace impl
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/impl/AbsoluteOrRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/AbsoluteOrRelativeConvergenceMeasure.hpp
@@ -54,16 +54,16 @@ public:
    */
   AbsoluteOrRelativeConvergenceMeasure(double absLimit, double relLimit);
 
-  virtual ~AbsoluteOrRelativeConvergenceMeasure() = default;
+  ~AbsoluteOrRelativeConvergenceMeasure() override = default;
 
-  virtual void newMeasurementSeries()
+  void newMeasurementSeries() override
   {
     _isConvergence = false;
   }
 
-  virtual void measure(
+  void measure(
       const Eigen::VectorXd &oldValues,
-      const Eigen::VectorXd &newValues)
+      const Eigen::VectorXd &newValues) override
   {
     PRECICE_ASSERT(oldValues.size() == newValues.size());
     _normDiff      = utils::IntraComm::l2norm(newValues - oldValues);
@@ -71,7 +71,7 @@ public:
     _isConvergence = (_normDiff <= _norm * _convergenceLimitPercent) or (_normDiff <= _convergenceLimit);
   }
 
-  virtual bool isConvergence() const
+  bool isConvergence() const override
   {
     return _isConvergence;
   }
@@ -79,7 +79,7 @@ public:
   /**
    * @brief Adds current convergence information to output stream.
    */
-  virtual std::string printState(const std::string &dataName)
+  std::string printState(const std::string &dataName) override
   {
     std::ostringstream os;
     os << "absolute convergence measure: ";
@@ -113,7 +113,7 @@ public:
       return _normDiff / _norm;
   }
 
-  virtual std::string getAbbreviation() const
+  std::string getAbbreviation() const override
   {
     return "AbsOrRel";
   }

--- a/src/cplscheme/impl/ConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ConvergenceMeasure.hpp
@@ -22,7 +22,7 @@ namespace impl {
 class ConvergenceMeasure {
 public:
   /// Destructor, empty.
-  virtual ~ConvergenceMeasure() {}
+  virtual ~ConvergenceMeasure() = default;
 
   /// To be called when a new meas. series (iteration process) starts.
   virtual void newMeasurementSeries() = 0;

--- a/src/cplscheme/impl/ConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ConvergenceMeasure.hpp
@@ -2,9 +2,7 @@
 
 #include <Eigen/Core>
 
-namespace precice {
-namespace cplscheme {
-namespace impl {
+namespace precice::cplscheme::impl {
 
 /**
  * @brief Interface for measures checking the convergence of a series of datasets.
@@ -55,6 +53,4 @@ public:
     return "";
   }
 };
-} // namespace impl
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -50,16 +50,16 @@ public:
     */
   RelativeConvergenceMeasure(double convergenceLimitPercent);
 
-  virtual ~RelativeConvergenceMeasure() = default;
+  ~RelativeConvergenceMeasure() override = default;
 
-  virtual void newMeasurementSeries()
+  void newMeasurementSeries() override
   {
     _isConvergence = false;
   }
 
-  virtual void measure(
+  void measure(
       const Eigen::VectorXd &oldValues,
-      const Eigen::VectorXd &newValues)
+      const Eigen::VectorXd &newValues) override
   {
     PRECICE_ASSERT(oldValues.size() == newValues.size());
     /*
@@ -74,7 +74,7 @@ public:
     _isConvergence = _normDiff <= _norm * _convergenceLimitPercent;
   }
 
-  virtual bool isConvergence() const
+  bool isConvergence() const override
   {
     return _isConvergence;
   }
@@ -82,7 +82,7 @@ public:
   /**
     * @brief Adds current convergence information to output stream.
     */
-  virtual std::string printState(const std::string &dataName)
+  std::string printState(const std::string &dataName) override
   {
     std::ostringstream os;
     os << "relative convergence measure: ";
@@ -98,7 +98,7 @@ public:
     return os.str();
   }
 
-  virtual double getNormResidual()
+  double getNormResidual() override
   {
     if (math::equals(_norm, 0.))
       return std::numeric_limits<double>::infinity();
@@ -106,7 +106,7 @@ public:
       return _normDiff / _norm;
   }
 
-  virtual std::string getAbbreviation() const
+  std::string getAbbreviation() const override
   {
     return "Rel";
   }

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -14,19 +14,13 @@
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace cplscheme {
-namespace tests {
+namespace precice::cplscheme::tests {
 class RelativeConvergenceMeasureTest;
 }
-} // namespace cplscheme
-} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace cplscheme {
-namespace impl {
+namespace precice::cplscheme::impl {
 
 /**
  * @brief Measures the convergence from an old data set to a new one.
@@ -122,6 +116,4 @@ private:
 
   bool _isConvergence = false;
 };
-} // namespace impl
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/RelativeConvergenceMeasure.hpp
@@ -50,7 +50,7 @@ public:
     */
   RelativeConvergenceMeasure(double convergenceLimitPercent);
 
-  virtual ~RelativeConvergenceMeasure(){};
+  virtual ~RelativeConvergenceMeasure() = default;
 
   virtual void newMeasurementSeries()
   {

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
@@ -38,18 +38,18 @@ public:
     */
   explicit ResidualRelativeConvergenceMeasure(double convergenceLimitPercent);
 
-  virtual ~ResidualRelativeConvergenceMeasure() = default;
+  ~ResidualRelativeConvergenceMeasure() override = default;
 
-  virtual void newMeasurementSeries()
+  void newMeasurementSeries() override
   {
     _isConvergence     = false;
     _isFirstIteration  = true;
     _normFirstResidual = std::numeric_limits<double>::max();
   }
 
-  virtual void measure(
+  void measure(
       const Eigen::VectorXd &oldValues,
-      const Eigen::VectorXd &newValues)
+      const Eigen::VectorXd &newValues) override
   {
     PRECICE_ASSERT(oldValues.size() == newValues.size());
     _normDiff = utils::IntraComm::l2norm(newValues - oldValues);
@@ -60,13 +60,13 @@ public:
     _isConvergence = _normDiff < _normFirstResidual * _convergenceLimitPercent;
   }
 
-  virtual bool isConvergence() const
+  bool isConvergence() const override
   {
     return _isConvergence;
   }
 
   /// Adds current convergence information to output stream.
-  virtual std::string printState(const std::string &dataName)
+  std::string printState(const std::string &dataName) override
   {
     std::ostringstream os;
     os << "residual relative convergence measure: ";
@@ -82,7 +82,7 @@ public:
     return os.str();
   }
 
-  virtual double getNormResidual()
+  double getNormResidual() override
   {
     if (math::equals(_normFirstResidual, 0.))
       return std::numeric_limits<double>::infinity();
@@ -90,7 +90,7 @@ public:
       return _normDiff / _normFirstResidual;
   }
 
-  virtual std::string getAbbreviation() const
+  std::string getAbbreviation() const override
   {
     return "Drop";
   }

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
@@ -38,7 +38,7 @@ public:
     */
   explicit ResidualRelativeConvergenceMeasure(double convergenceLimitPercent);
 
-  virtual ~ResidualRelativeConvergenceMeasure(){};
+  virtual ~ResidualRelativeConvergenceMeasure() = default;
 
   virtual void newMeasurementSeries()
   {

--- a/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
+++ b/src/cplscheme/impl/ResidualRelativeConvergenceMeasure.hpp
@@ -12,9 +12,7 @@
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace cplscheme {
-namespace impl {
+namespace precice::cplscheme::impl {
 
 /**
  * @brief Measures the convergence from an old data set to a new one.
@@ -108,6 +106,4 @@ private:
 
   bool _isConvergence = false;
 };
-} // namespace impl
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/impl/SharedPointer.hpp
+++ b/src/cplscheme/impl/SharedPointer.hpp
@@ -2,14 +2,10 @@
 
 #include <memory>
 
-namespace precice {
-namespace cplscheme {
-namespace impl {
+namespace precice::cplscheme::impl {
 
 class ConvergenceMeasure;
 class ParallelMatrixOperations;
 
 using PtrConvergenceMeasure = std::shared_ptr<ConvergenceMeasure>;
-} // namespace impl
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::impl

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -34,14 +34,14 @@ public:
   /**
    * @brief
    */
-  void initialize() override final;
+  void initialize() final;
 
-  void reinitialize() override final{};
+  void reinitialize() final{};
 
   /**
    * @brief Not implemented.
    */
-  bool isInitialized() const override final
+  bool isInitialized() const final
   {
     PRECICE_ASSERT(false);
     return false;
@@ -50,13 +50,13 @@ public:
   /**
    * @brief Not implemented.
    */
-  bool sendsInitializedData() const override final
+  bool sendsInitializedData() const final
   {
     PRECICE_ASSERT(false);
     return false;
   }
 
-  bool addComputedTime(double timeToAdd) override final;
+  bool addComputedTime(double timeToAdd) final;
 
   /**
    * @brief
@@ -74,18 +74,18 @@ public:
   /**
    * @brief
    */
-  void finalize() override final;
+  void finalize() final;
 
   /*
    * @brief Not implemented.
    */
-  std::vector<std::string> getCouplingPartners() const override final
+  std::vector<std::string> getCouplingPartners() const final
   {
     PRECICE_ASSERT(false);
     return std::vector<std::string>();
   }
 
-  std::string localParticipant() const override final
+  std::string localParticipant() const final
   {
     PRECICE_ASSERT(false);
     return "unknown";
@@ -94,7 +94,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  bool willDataBeExchanged(double lastSolverTimeStepSize) const override final
+  bool willDataBeExchanged(double lastSolverTimeStepSize) const final
   {
     PRECICE_ASSERT(false);
     return false;
@@ -103,7 +103,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  bool hasDataBeenReceived() const override final
+  bool hasDataBeenReceived() const final
   {
     PRECICE_ASSERT(false);
     return false;
@@ -112,19 +112,19 @@ public:
   /**
    * @brief Not implemented.
    */
-  double getTime() const override final;
+  double getTime() const final;
 
-  double getTimeWindowStart() const override final;
+  double getTimeWindowStart() const final;
 
   /**
    * @brief Not implemented.
    */
-  int getTimeWindows() const override final
+  int getTimeWindows() const final
   {
     return _timeWindows;
   }
 
-  bool hasTimeWindowSize() const override final
+  bool hasTimeWindowSize() const final
   {
     return true;
   }
@@ -132,7 +132,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  double getTimeWindowSize() const override final
+  double getTimeWindowSize() const final
   {
     return 1.0;
   }
@@ -140,7 +140,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  double getNextTimeStepMaxSize() const override final
+  double getNextTimeStepMaxSize() const final
   {
     PRECICE_ASSERT(false);
     return 0;
@@ -149,12 +149,12 @@ public:
   /**
    * @brief Not implemented.
    */
-  bool isCouplingOngoing() const override final;
+  bool isCouplingOngoing() const final;
 
   /**
    * @brief Not implemented.
    */
-  bool isTimeWindowComplete() const override final
+  bool isTimeWindowComplete() const final
   {
     PRECICE_ASSERT(false);
     return false;
@@ -163,9 +163,9 @@ public:
   /**
    * @brief Not implemented.
    */
-  bool isActionRequired(Action action) const override final;
+  bool isActionRequired(Action action) const final;
 
-  bool isActionFulfilled(Action action) const override final
+  bool isActionFulfilled(Action action) const final
   {
     return true;
   }
@@ -173,7 +173,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  void markActionFulfilled(Action action) override final
+  void markActionFulfilled(Action action) final
   {
     PRECICE_ASSERT(false);
   }
@@ -190,7 +190,7 @@ public:
   /**
    * @brief Not implemented.
    */
-  void requireAction(Action action) override final
+  void requireAction(Action action) final
   {
     PRECICE_ASSERT(false);
   }
@@ -198,7 +198,7 @@ public:
   /**
    * @brief Empty.
    */
-  std::string printCouplingState() const override final
+  std::string printCouplingState() const final
   {
     return std::string();
   }
@@ -210,12 +210,12 @@ public:
 
   bool hasConverged() const override;
 
-  bool requiresSubsteps() const override final
+  bool requiresSubsteps() const final
   {
     return true;
   }
 
-  ImplicitData implicitDataToReceive() const override final
+  ImplicitData implicitDataToReceive() const final
   {
     return {};
   }

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -6,9 +6,7 @@
 #include "logging/Logger.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace cplscheme {
-namespace tests {
+namespace precice::cplscheme::tests {
 
 /**
  * @brief Used to test CompositionalCouplingScheme.
@@ -245,6 +243,4 @@ private:
   bool _hasConverged = false;
 };
 
-} // namespace tests
-} // namespace cplscheme
-} // namespace precice
+} // namespace precice::cplscheme::tests

--- a/src/io/Export.hpp
+++ b/src/io/Export.hpp
@@ -4,14 +4,11 @@
 #include <string_view>
 #include <vector>
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Mesh;
 }
-} // namespace precice
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /// Abstract base class of all classes exporting container data structures.
 class Export {
@@ -84,5 +81,4 @@ protected:
   void recordExport(std::string filename, double time);
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/ExportCSV.hpp
+++ b/src/io/ExportCSV.hpp
@@ -18,9 +18,9 @@ public:
       int               rank,
       int               size);
 
-  void doExport(int index, double time) final override;
+  void doExport(int index, double time) final;
 
-  void exportSeries() const final override;
+  void exportSeries() const final;
 
 private:
   mutable logging::Logger _log{"io::ExportCSV"};

--- a/src/io/ExportCSV.hpp
+++ b/src/io/ExportCSV.hpp
@@ -4,8 +4,7 @@
 #include "io/Export.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 class ExportCSV : public Export {
 public:
@@ -26,5 +25,4 @@ private:
   mutable logging::Logger _log{"io::ExportCSV"};
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/ExportContext.hpp
+++ b/src/io/ExportContext.hpp
@@ -4,8 +4,7 @@
 #include <string>
 #include "io/SharedPointer.hpp"
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 struct ExportContext {
   // @brief Exporters performing the actual export.
@@ -27,7 +26,6 @@ struct ExportContext {
   std::string type;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io
 
 #endif /* PRECICE_IO_EXPORTCONTEXT_HPP_ */

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -6,14 +6,11 @@
 #include "io/Export.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Mesh;
 }
-} // namespace precice
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /// Writes polygonal, or triangle meshes to vtk files.
 class ExportVTK : public Export {
@@ -73,5 +70,4 @@ private:
       const mesh::Mesh &mesh);
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/ExportVTK.hpp
+++ b/src/io/ExportVTK.hpp
@@ -28,9 +28,9 @@ public:
       int               size);
 
   /// Perform writing to VTK file
-  void doExport(int index, double time) final override;
+  void doExport(int index, double time) final;
 
-  void exportSeries() const final override;
+  void exportSeries() const final;
 
   static void initializeWriting(
       std::ofstream &filestream);

--- a/src/io/ExportVTP.hpp
+++ b/src/io/ExportVTP.hpp
@@ -7,16 +7,13 @@
 #include "io/ExportXML.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Mesh;
 class Edge;
 class Triangle;
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /** Exporter for VTP and PVTP.
  *
@@ -48,5 +45,4 @@ private:
   void exportConnectivity(std::ostream &outFile, const mesh::Mesh &mesh) const override;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/ExportVTU.hpp
+++ b/src/io/ExportVTU.hpp
@@ -7,16 +7,13 @@
 #include "io/ExportXML.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Mesh;
 class Edge;
 class Triangle;
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /** Exporter for VTU and PVTU.
  *
@@ -48,5 +45,4 @@ private:
   void exportConnectivity(std::ostream &outFile, const mesh::Mesh &mesh) const override;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -32,9 +32,9 @@ public:
       int               rank,
       int               size);
 
-  void doExport(int index, double time) final override;
+  void doExport(int index, double time) final;
 
-  void exportSeries() const final override;
+  void exportSeries() const final;
 
   static void writeVertex(
       const Eigen::VectorXd &position,

--- a/src/io/ExportXML.hpp
+++ b/src/io/ExportXML.hpp
@@ -8,17 +8,14 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Mesh;
 class Edge;
 class Triangle;
 class Tetrahedron;
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /// Common class to generate the VTK XML-based formats.
 class ExportXML : public Export {
@@ -104,5 +101,4 @@ private:
   std::string serialPieceFilename(int index) const;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/SharedPointer.hpp
+++ b/src/io/SharedPointer.hpp
@@ -2,8 +2,7 @@
 
 #include <memory>
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 class Export;
 class ExportConfiguration;
@@ -11,5 +10,4 @@ class ExportConfiguration;
 using PtrExport              = std::shared_ptr<Export>;
 using PtrExportConfiguration = std::shared_ptr<ExportConfiguration>;
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/TXTReader.hpp
+++ b/src/io/TXTReader.hpp
@@ -7,8 +7,7 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /**
  * @brief File reader for matrix/vector in Matlab V7 ASCII format.
@@ -38,5 +37,4 @@ private:
   std::ifstream _file;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/TXTTableWriter.hpp
+++ b/src/io/TXTTableWriter.hpp
@@ -6,8 +6,7 @@
 #include <vector>
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /**
  * @brief File writer for table-data in text-format.
@@ -100,8 +99,8 @@ private:
   std::ofstream _outputStream;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io
+
 //Required in order to print the vector types via the fmt interface
 template <>
 struct fmt::formatter<precice::io::TXTTableWriter::DataType> : formatter<string_view> {

--- a/src/io/TXTWriter.hpp
+++ b/src/io/TXTWriter.hpp
@@ -5,8 +5,7 @@
 #include <string>
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /**
  * @brief File writer for matrix in Matlab V7 ASCII format.
@@ -31,5 +30,4 @@ private:
   std::ofstream _file;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -6,8 +6,7 @@
 #include "logging/Logger.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace io {
+namespace precice::io {
 
 /**
  * @brief Configuration class for exports.
@@ -54,5 +53,4 @@ private:
   std::list<ExportContext> _contexts;
 };
 
-} // namespace io
-} // namespace precice
+} // namespace precice::io

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -24,10 +24,10 @@ public:
     return _contexts;
   }
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
   /// Callback from automatic configuration. Not utilitzed here.
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) {}
+  void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override {}
 
   void resetExports()
   {

--- a/src/logging/config/LogConfiguration.hpp
+++ b/src/logging/config/LogConfiguration.hpp
@@ -11,9 +11,9 @@ class LogConfiguration : public xml::XMLTag::Listener {
 public:
   LogConfiguration(xml::XMLTag &parent);
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag) override;
 
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
+  void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag) override;
 
 private:
   precice::logging::Logger _log{"logging::config::LogConfiguration"};

--- a/src/m2n/BoundM2N.hpp
+++ b/src/m2n/BoundM2N.hpp
@@ -4,8 +4,7 @@
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 
 /// An M2N between participants with a configured direction
 class BoundM2N {
@@ -42,5 +41,4 @@ private:
   void waitForSecondaryRanks();
 };
 
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/DistributedComFactory.hpp
+++ b/src/m2n/DistributedComFactory.hpp
@@ -4,8 +4,7 @@
 
 #include <memory>
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 class DistributedComFactory {
 
 public:
@@ -16,5 +15,4 @@ public:
   virtual DistributedCommunication::SharedPointer newDistributedCommunication(
       mesh::PtrMesh mesh) = 0;
 };
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/DistributedComFactory.hpp
+++ b/src/m2n/DistributedComFactory.hpp
@@ -11,7 +11,7 @@ class DistributedComFactory {
 public:
   using SharedPointer = std::shared_ptr<DistributedComFactory>;
 
-  virtual ~DistributedComFactory(){};
+  virtual ~DistributedComFactory() = default;
 
   virtual DistributedCommunication::SharedPointer newDistributedCommunication(
       mesh::PtrMesh mesh) = 0;

--- a/src/m2n/DistributedCommunication.hpp
+++ b/src/m2n/DistributedCommunication.hpp
@@ -40,7 +40,7 @@ public:
   }
 
   /// Destructor, empty.
-  virtual ~DistributedCommunication() {}
+  virtual ~DistributedCommunication() = default;
 
   /// Returns true, if a connection to a remote participant has been setup.
   virtual bool isConnected() const = 0;

--- a/src/m2n/DistributedCommunication.hpp
+++ b/src/m2n/DistributedCommunication.hpp
@@ -6,8 +6,7 @@
 #include "mesh/SharedPointer.hpp"
 #include "precice/span.hpp"
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 
 /**
  * @brief Interface for all distributed solver to solver communication classes.
@@ -146,5 +145,4 @@ protected:
   mesh::PtrMesh _mesh;
 };
 
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/GatherScatterComFactory.hpp
+++ b/src/m2n/GatherScatterComFactory.hpp
@@ -5,8 +5,7 @@
 #include "m2n/DistributedCommunication.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 class GatherScatterComFactory : public DistributedComFactory {
 public:
   GatherScatterComFactory(com::PtrCommunication intraComm);
@@ -18,5 +17,4 @@ private:
   /// communication between the primary processes
   com::PtrCommunication _intraComm;
 };
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/GatherScatterComFactory.hpp
+++ b/src/m2n/GatherScatterComFactory.hpp
@@ -12,7 +12,7 @@ public:
   GatherScatterComFactory(com::PtrCommunication intraComm);
 
   DistributedCommunication::SharedPointer newDistributedCommunication(
-      mesh::PtrMesh mesh);
+      mesh::PtrMesh mesh) override;
 
 private:
   /// communication between the primary processes

--- a/src/m2n/GatherScatterCommunication.hpp
+++ b/src/m2n/GatherScatterCommunication.hpp
@@ -8,8 +8,7 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 
 /**
  * @brief Implements DistributedCommunication by using a gathering/scattering methodology.
@@ -118,5 +117,4 @@ private:
   bool _isConnected;
 };
 
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/PointToPointComFactory.hpp
+++ b/src/m2n/PointToPointComFactory.hpp
@@ -5,8 +5,7 @@
 #include "m2n/DistributedCommunication.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 
 class PointToPointComFactory : public DistributedComFactory {
 
@@ -21,5 +20,4 @@ private:
   com::PtrCommunicationFactory _comFactory;
 };
 
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/PointToPointComFactory.hpp
+++ b/src/m2n/PointToPointComFactory.hpp
@@ -14,7 +14,7 @@ public:
   explicit PointToPointComFactory(com::PtrCommunicationFactory comFactory);
 
   DistributedCommunication::SharedPointer newDistributedCommunication(
-      mesh::PtrMesh mesh);
+      mesh::PtrMesh mesh) override;
 
 private:
   /// communication factory for 1:M communications

--- a/src/m2n/SharedPointer.hpp
+++ b/src/m2n/SharedPointer.hpp
@@ -2,12 +2,10 @@
 
 #include <memory>
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 
 class M2N;
 
 using PtrM2N = std::shared_ptr<M2N>;
 
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -10,8 +10,7 @@
 #include <string>
 #include <vector>
 
-namespace precice {
-namespace m2n {
+namespace precice::m2n {
 
 /// Configuration for communication channels between solvers.
 class M2NConfiguration : public xml::XMLTag::Listener {
@@ -68,5 +67,4 @@ private:
       const std::string &connector);
 };
 
-} // namespace m2n
-} // namespace precice
+} // namespace precice::m2n

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -29,7 +29,7 @@ public:
 public:
   explicit M2NConfiguration(xml::XMLTag &parent);
 
-  virtual ~M2NConfiguration() = default;
+  ~M2NConfiguration() override = default;
 
   /**
     * @brief Returns the communication object for the given user names.
@@ -49,9 +49,9 @@ public:
 
   bool isM2NConfigured(const std::string &acceptor, const std::string &connector);
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) {}
+  void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override {}
 
 private:
   logging::Logger _log{"m2n::M2NConfiguration"};

--- a/src/m2n/config/M2NConfiguration.hpp
+++ b/src/m2n/config/M2NConfiguration.hpp
@@ -29,7 +29,7 @@ public:
 public:
   explicit M2NConfiguration(xml::XMLTag &parent);
 
-  virtual ~M2NConfiguration() {}
+  virtual ~M2NConfiguration() = default;
 
   /**
     * @brief Returns the communication object for the given user names.

--- a/src/mapping/AxialGeoMultiscaleMapping.hpp
+++ b/src/mapping/AxialGeoMultiscaleMapping.hpp
@@ -4,8 +4,7 @@
 #include "logging/Logger.hpp"
 #include "mapping/Mapping.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /// Geometric multiscale mapping in axial direction
 class AxialGeoMultiscaleMapping : public Mapping {
@@ -72,5 +71,4 @@ private:
   std::vector<double> _vertexDistances;
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/AxialGeoMultiscaleMapping.hpp
+++ b/src/mapping/AxialGeoMultiscaleMapping.hpp
@@ -47,7 +47,7 @@ public:
   void tagMeshSecondRound() override;
 
   /// Returns name of the mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 protected:
   /// @copydoc Mapping::mapConservative

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -5,8 +5,7 @@
 #include "mapping/Mapping.hpp"
 #include "mapping/Polation.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * @brief Base class for interpolation based mappings, where mapping is done using a geometry-based linear combination of input values.
@@ -35,5 +34,4 @@ protected:
   std::vector<Polation> _interpolations;
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/BarycentricBaseMapping.hpp
+++ b/src/mapping/BarycentricBaseMapping.hpp
@@ -17,10 +17,10 @@ public:
   BarycentricBaseMapping(Constraint constraint, int dimensions);
 
   /// Removes a computed mapping.
-  void clear() final override;
+  void clear() final;
 
-  void tagMeshFirstRound() final override;
-  void tagMeshSecondRound() final override;
+  void tagMeshFirstRound() final;
+  void tagMeshSecondRound() final;
 
 private:
   logging::Logger _log{"mapping::BarycentricBaseMapping"};

--- a/src/mapping/LinearCellInterpolationMapping.hpp
+++ b/src/mapping/LinearCellInterpolationMapping.hpp
@@ -16,10 +16,10 @@ public:
   LinearCellInterpolationMapping(Constraint constraint, int dimensions);
 
   /// Computes the projections and interpolation relations.
-  void computeMapping() final override;
+  void computeMapping() final;
 
   /// name of the lci mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 private:
   logging::Logger _log{"mapping::LinearCellInterpolationMappingMapping"};

--- a/src/mapping/LinearCellInterpolationMapping.hpp
+++ b/src/mapping/LinearCellInterpolationMapping.hpp
@@ -3,8 +3,7 @@
 #include "logging/Logger.hpp"
 #include "mapping/BarycentricBaseMapping.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * @brief Mapping using orthogonal projection to nearest triangle/edge/vertex and
@@ -25,5 +24,4 @@ private:
   logging::Logger _log{"mapping::LinearCellInterpolationMappingMapping"};
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/Mapping.hpp
+++ b/src/mapping/Mapping.hpp
@@ -6,8 +6,7 @@
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * @brief Abstract base class for mapping of data from one mesh to another.
@@ -274,5 +273,4 @@ bool operator<(Mapping::MeshRequirement lhs, Mapping::MeshRequirement rhs);
 */
 std::ostream &operator<<(std::ostream &out, Mapping::MeshRequirement val);
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/NearestNeighborBaseMapping.hpp
+++ b/src/mapping/NearestNeighborBaseMapping.hpp
@@ -5,8 +5,7 @@
 #include "logging/Logger.hpp"
 #include "mapping/Mapping.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /// Mapping using nearest neighboring vertices and (eventually) their local gradient values.
 /// Base class for Nearest Neighbor Mapping and Nearest Neighbor Gradient
@@ -53,5 +52,4 @@ protected:
   std::vector<int> _vertexIndices;
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/NearestNeighborBaseMapping.hpp
+++ b/src/mapping/NearestNeighborBaseMapping.hpp
@@ -22,10 +22,10 @@ public:
                              std::string mappingNameShort);
 
   /// Computes the mapping coefficients from the in- and output mesh.
-  void computeMapping() final override;
+  void computeMapping() final;
 
   /// Removes a computed mapping.
-  void clear() final override;
+  void clear() final;
 
   /**
    * Matches the offsets needed for the gradient mapping
@@ -33,8 +33,8 @@ public:
    */
   virtual void onMappingComputed(mesh::PtrMesh origins, mesh::PtrMesh searchSpace);
 
-  void tagMeshFirstRound() final override;
-  void tagMeshSecondRound() final override;
+  void tagMeshFirstRound() final;
+  void tagMeshSecondRound() final;
 
 protected:
   /// NearestNeighborMapping or NearestNeighborGradientMapping

--- a/src/mapping/NearestNeighborGradientMapping.hpp
+++ b/src/mapping/NearestNeighborGradientMapping.hpp
@@ -20,17 +20,17 @@ public:
   NearestNeighborGradientMapping(Constraint constraint, int dimensions);
 
   /// Calculates the offsets needed for the gradient mappings after calculating the matched vertices
-  void onMappingComputed(mesh::PtrMesh origins, mesh::PtrMesh searchSpace) final override;
+  void onMappingComputed(mesh::PtrMesh origins, mesh::PtrMesh searchSpace) final;
 
   /// name of the nng mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 protected:
   /// @copydoc Mapping::mapConservative
-  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final;
 
   /// @copydoc Mapping::mapConsistent
-  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final;
 };
 
 } // namespace mapping

--- a/src/mapping/NearestNeighborGradientMapping.hpp
+++ b/src/mapping/NearestNeighborGradientMapping.hpp
@@ -5,8 +5,7 @@
 #include "logging/Logger.hpp"
 #include "mapping/NearestNeighborBaseMapping.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /// Mapping using nearest neighboring vertices and their local gradient values.
 class NearestNeighborGradientMapping : public NearestNeighborBaseMapping {
@@ -33,5 +32,4 @@ protected:
   void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final;
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/NearestNeighborMapping.hpp
+++ b/src/mapping/NearestNeighborMapping.hpp
@@ -20,14 +20,14 @@ public:
   NearestNeighborMapping(Constraint constraint, int dimensions);
 
   /// name of the nn mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 protected:
   /// @copydoc Mapping::mapConservative
-  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final;
 
   /// @copydoc Mapping::mapConsistent
-  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final;
 };
 
 } // namespace mapping

--- a/src/mapping/NearestNeighborMapping.hpp
+++ b/src/mapping/NearestNeighborMapping.hpp
@@ -5,8 +5,7 @@
 #include "logging/Logger.hpp"
 #include "mapping/NearestNeighborBaseMapping.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /// Mapping using nearest neighboring vertices.
 class NearestNeighborMapping : public NearestNeighborBaseMapping {
@@ -30,5 +29,4 @@ protected:
   void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final;
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -17,10 +17,10 @@ public:
   NearestProjectionMapping(Constraint constraint, int dimensions);
 
   /// Computes the projections and interpolation relations.
-  void computeMapping() final override;
+  void computeMapping() final;
 
   /// name of the np mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 private:
   logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};

--- a/src/mapping/NearestProjectionMapping.hpp
+++ b/src/mapping/NearestProjectionMapping.hpp
@@ -4,8 +4,7 @@
 #include "mapping/BarycentricBaseMapping.hpp"
 #include "mapping/Polation.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * @brief Mapping using orthogonal projection to nearest triangle/edge/vertex and
@@ -26,5 +25,4 @@ private:
   logging::Logger _log{"mapping::NearestNeighborProjectionMapping"};
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -61,19 +61,19 @@ public:
    * In debug mode, the function also exports the partition centers as a separate mesh for visualization
    * purpose.
    */
-  void computeMapping() final override;
+  void computeMapping() final;
 
   /// Clears a computed mapping by deleting the content of the \p _clusters vector.
-  void clear() final override;
+  void clear() final;
 
   /// tag the vertices required for the mapping
-  void tagMeshFirstRound() final override;
+  void tagMeshFirstRound() final;
 
   /// nothing to do here
-  void tagMeshSecondRound() final override;
+  void tagMeshSecondRound() final;
 
   /// name of the pum mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 private:
   /// logger, as usual
@@ -103,10 +103,10 @@ private:
   Polynomial _polynomial;
 
   /// @copydoc Mapping::mapConservative
-  virtual void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) override;
+  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) override;
 
   /// @copydoc Mapping::mapConsistent
-  virtual void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) override;
+  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) override;
 
   /// export the center vertices of all clusters as a mesh with some additional data on it such as vertex count
   /// only enabled in debug builds and mainly for debugging purpose

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -19,8 +19,7 @@
 
 namespace petsc = precice::utils::petsc;
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 namespace {
 // VecChop was deprecated in PETSc 3.20 and is to be replaced by VecFilter
@@ -997,7 +996,6 @@ PetRadialBasisFctMapping<RADIAL_BASIS_FUNCTION_T>::bgPreallocationMatrixA(mesh::
   return vertexData;
 }
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping
 
 #endif // PRECICE_NO_PETSC

--- a/src/mapping/PetRadialBasisFctMapping.hpp
+++ b/src/mapping/PetRadialBasisFctMapping.hpp
@@ -75,20 +75,20 @@ public:
   ~PetRadialBasisFctMapping() override;
 
   /// Computes the mapping coefficients from the in- and output mesh.
-  void computeMapping() final override;
+  void computeMapping() final;
 
   /// Removes a computed mapping.
-  void clear() final override;
+  void clear() final;
 
   /// name of the rbf mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 private:
   /// @copydoc RadialBasisFctBaseMapping::mapConservative
-  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final;
 
   /// @copydoc RadialBasisFctBaseMapping::mapConsistent
-  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final;
 
   /// Stores col -> value for each row. Used to return the already computed values from the preconditioning
   using VertexData = std::vector<std::vector<std::pair<int, double>>>;

--- a/src/mapping/Polation.hpp
+++ b/src/mapping/Polation.hpp
@@ -8,8 +8,7 @@
 #include "mesh/Triangle.hpp"
 #include "mesh/Vertex.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /// Struct that contains weight and index of a vertex
 struct WeightedElement {
@@ -58,5 +57,4 @@ std::ostream &operator<<(std::ostream &os, const WeightedElement &w);
 /// Make the Polation class printable
 std::ostream &operator<<(std::ostream &os, const Polation &p);
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -37,19 +37,19 @@ public:
       std::array<bool, 3>            deadAxis,
       InitialGuessRequirement        mappingType);
 
-  virtual ~RadialBasisFctBaseMapping() = default;
+  ~RadialBasisFctBaseMapping() override = default;
 
   // Methods, which need to be implemented in a derived class
 
   /// Computes the mapping coefficients from the in- and output mesh.
-  virtual void computeMapping() = 0;
+  void computeMapping() override = 0;
 
   /// Removes a computed mapping.
-  virtual void clear() = 0;
+  void clear() override = 0;
 
-  virtual void tagMeshFirstRound() final;
+  void tagMeshFirstRound() final;
 
-  virtual void tagMeshSecondRound() final;
+  void tagMeshSecondRound() final;
 
 protected:
   /// Radial basis function type used in interpolation.

--- a/src/mapping/RadialBasisFctBaseMapping.hpp
+++ b/src/mapping/RadialBasisFctBaseMapping.hpp
@@ -5,8 +5,7 @@
 #include "mesh/Filter.hpp"
 #include "precice/impl/Types.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * @brief Mapping with radial basis functions.
@@ -184,5 +183,4 @@ void RadialBasisFctBaseMapping<RADIAL_BASIS_FUNCTION_T>::tagMeshSecondRound()
   auto vertices = mesh->index().getVerticesInsideBox(bb);
   std::for_each(vertices.begin(), vertices.end(), [&mesh](size_t v) { mesh->vertex(v).tag(); });
 }
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -12,8 +12,7 @@
 #include "profiling/Event.hpp"
 #include "utils/IntraComm.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * @brief Mapping with radial basis functions.
@@ -411,5 +410,4 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConsistent(const time::Sample 
     outData                            = Eigen::Map<Eigen::VectorXd>(receivedValues.data(), receivedValues.size());
   }
 }
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -47,13 +47,13 @@ public:
       Args... args);
 
   /// Computes the mapping coefficients from the in- and output mesh.
-  void computeMapping() final override;
+  void computeMapping() final;
 
   /// Removes a computed mapping.
-  void clear() final override;
+  void clear() final;
 
   /// name of the rbf mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 private:
   precice::logging::Logger _log{"mapping::RadialBasisFctMapping"};
@@ -62,10 +62,10 @@ private:
   std::unique_ptr<SOLVER_T> _rbfSolver;
 
   /// @copydoc RadialBasisFctBaseMapping::mapConservative
-  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConservative(const time::Sample &inData, Eigen::VectorXd &outData) final;
 
   /// @copydoc RadialBasisFctBaseMapping::mapConsistent
-  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final override;
+  void mapConsistent(const time::Sample &inData, Eigen::VectorXd &outData) final;
 
   /// Treatment of the polynomial
   Polynomial _polynomial;

--- a/src/mapping/RadialBasisFctSolver.hpp
+++ b/src/mapping/RadialBasisFctSolver.hpp
@@ -13,8 +13,7 @@
 #include "precice/impl/Types.hpp"
 #include "profiling/Event.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * This class assembles and solves an RBF system, given an input mesh and an output mesh with relevant vertex IDs.
@@ -469,5 +468,4 @@ Eigen::Index RadialBasisFctSolver<RADIAL_BASIS_FUNCTION_T>::getOutputSize() cons
 {
   return _matrixA.rows();
 }
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/RadialGeoMultiscaleMapping.hpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.hpp
@@ -4,8 +4,7 @@
 #include "logging/Logger.hpp"
 #include "mapping/Mapping.hpp"
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 /// Geometric multiscale mapping in radial direction
 class RadialGeoMultiscaleMapping : public Mapping {
@@ -72,5 +71,4 @@ private:
   std::vector<size_t> _vertexCounter;
 };
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/RadialGeoMultiscaleMapping.hpp
+++ b/src/mapping/RadialGeoMultiscaleMapping.hpp
@@ -46,7 +46,7 @@ public:
   void tagMeshSecondRound() override;
 
   /// Returns name of the mapping
-  std::string getName() const final override;
+  std::string getName() const final;
 
 protected:
   /// @copydoc Mapping::mapConservative

--- a/src/mapping/SharedPointer.hpp
+++ b/src/mapping/SharedPointer.hpp
@@ -2,8 +2,7 @@
 
 #include <memory>
 
-namespace precice {
-namespace mapping {
+namespace precice::mapping {
 
 class Mapping;
 class MappingConfiguration;
@@ -11,5 +10,4 @@ class MappingConfiguration;
 using PtrMapping              = std::shared_ptr<Mapping>;
 using PtrMappingConfiguration = std::shared_ptr<MappingConfiguration>;
 
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -60,18 +60,18 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback(
+  void xmlTagCallback(
       const xml::ConfigurationContext &context,
-      xml::XMLTag &                    callingTag);
+      xml::XMLTag &                    callingTag) override;
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback(
+  void xmlEndTagCallback(
       const xml::ConfigurationContext &context,
-      xml::XMLTag &                    callingTag);
+      xml::XMLTag &                    callingTag) override;
 
   /// Returns all configured mappings.
   const std::vector<ConfiguredMapping> &mappings();

--- a/src/mapping/device/Ginkgo.hpp
+++ b/src/mapping/device/Ginkgo.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace precice {
-namespace device {
+namespace precice::device {
 
 class Ginkgo {
 public:
@@ -16,5 +15,4 @@ private:
   static bool weInitialized;
 };
 
-} // namespace device
-} // namespace precice
+} // namespace precice::device

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -11,9 +11,7 @@
 // required for the squared distance computation
 #include "mapping/RadialBasisFctSolver.hpp"
 
-namespace precice {
-namespace mapping {
-namespace impl {
+namespace precice::mapping::impl {
 
 using Vertices = std::vector<mesh::Vertex>;
 
@@ -495,6 +493,4 @@ inline std::tuple<double, Vertices> createClustering(mesh::PtrMesh inMesh, mesh:
 
   return {clusterRadius, centers};
 }
-} // namespace impl
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping::impl

--- a/src/mapping/impl/SphericalVertexCluster.hpp
+++ b/src/mapping/impl/SphericalVertexCluster.hpp
@@ -11,9 +11,7 @@
 #include "precice/impl/Types.hpp"
 #include "profiling/Event.hpp"
 
-namespace precice {
-
-namespace mapping {
+namespace precice::mapping {
 
 /**
  * The SphericalVertexCluster represents a single partition in the partition of unity mapping.
@@ -302,5 +300,4 @@ void SphericalVertexCluster<RADIAL_BASIS_FUNCTION_T>::clear()
   _rbfSolver.clear();
   _hasComputedMapping = false;
 }
-} // namespace mapping
-} // namespace precice
+} // namespace precice::mapping

--- a/src/math/barycenter.hpp
+++ b/src/math/barycenter.hpp
@@ -4,10 +4,8 @@
 #include <Eigen/Dense>
 #include "math/geometry.hpp"
 
-namespace precice {
-namespace math {
 /// Provides operations to calculate barycentric coordinates for a point's projection onto a primitive.
-namespace barycenter {
+namespace precice::math::barycenter {
 
 /** Takes the end vertices of an edge and a point in 2D or 3D space.
  *  Returns the barycentric coordinates for that point's projection onto the given edge.
@@ -61,6 +59,4 @@ Eigen::Vector4d calcBarycentricCoordsForTetrahedron(
     const Eigen::VectorXd &d,
     const Eigen::VectorXd &u);
 
-} // namespace barycenter
-} // namespace math
-} // namespace precice
+} // namespace precice::math::barycenter

--- a/src/math/constants.hpp
+++ b/src/math/constants.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
-namespace precice {
-namespace math {
+namespace precice::math {
 
 constexpr double PI = 3.1415926535897931;
 
 }
-} // namespace precice

--- a/src/math/differences.hpp
+++ b/src/math/differences.hpp
@@ -3,8 +3,7 @@
 #include <Eigen/Core>
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace math {
+namespace precice::math {
 
 constexpr double NUMERICAL_ZERO_DIFFERENCE = 1.0e-14;
 
@@ -92,5 +91,4 @@ typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type smallerEq
   return A - B <= tolerance;
 }
 
-} // namespace math
-} // namespace precice
+} // namespace precice::math

--- a/src/math/geometry.hpp
+++ b/src/math/geometry.hpp
@@ -5,11 +5,8 @@
 #include "math/differences.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace math {
-
 /// Provides computational geometry operations.
-namespace geometry {
+namespace precice::math::geometry {
 
 enum ResultConstants {
   NO_INTERSECTION,
@@ -228,6 +225,4 @@ struct ConvexityResult {
 
 ConvexityResult isConvexQuad(std::array<Eigen::VectorXd, 4> coords);
 
-} // namespace geometry
-} // namespace math
-} // namespace precice
+} // namespace precice::math::geometry

--- a/src/math/la.hpp
+++ b/src/math/la.hpp
@@ -1,8 +1,7 @@
 #include <Eigen/Core>
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace math {
+namespace precice::math {
 
 /// Sums up the components of subvectors in vector into result.
 /* Assumes vector has size k*size(result), i.e. the components of
@@ -28,5 +27,4 @@ void sumSubvectors(const Eigen::MatrixBase<DerivedA> &vector,
   }
 }
 
-} // namespace math
-} // namespace precice
+} // namespace precice::math

--- a/src/math/math.hpp
+++ b/src/math/math.hpp
@@ -4,8 +4,7 @@
 #include "math/differences.hpp"
 #include "math/la.hpp"
 
-namespace precice {
-namespace math {
+namespace precice::math {
 
 /// Return the sign, one of {-1, 0, 1}
 inline int sign(double number)
@@ -31,5 +30,4 @@ inline constexpr T pow_int(const T x)
     return ((iexp % 2 == 1) ? x * pow_int<iexp / 2>(x * x) : pow_int<iexp / 2>(x * x));
 }
 
-} // namespace math
-} // namespace precice
+} // namespace precice::math

--- a/src/mesh/Data.hpp
+++ b/src/mesh/Data.hpp
@@ -13,16 +13,13 @@
 #include "time/Time.hpp"
 #include "time/Waveform.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Mesh;
 }
-} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /**
  * @brief Describes a set of data values belonging to the vertices of a mesh.
@@ -167,5 +164,4 @@ private:
   time::Sample _sample;
 };
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/Edge.hpp
+++ b/src/mesh/Edge.hpp
@@ -9,8 +9,7 @@
 #include "precice/impl/Types.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /// Linear edge of a mesh, defined by two Vertex objects.
 class Edge {
@@ -95,5 +94,4 @@ inline int Edge::getDimensions() const
 
 std::ostream &operator<<(std::ostream &stream, const Edge &edge);
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -5,8 +5,7 @@
 #include "mesh/Mesh.hpp"
 #include "precice/impl/Types.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /** filters the source Mesh and adds it to the destination Mesh
  * @param[inout] destination the destination mesh to append the filtered Mesh to
@@ -69,5 +68,4 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
   }
 }
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -22,8 +22,7 @@
 #include "utils/ManageUniqueIDs.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /**
  * @brief Container and creator for meshes.
@@ -406,5 +405,4 @@ private:
 
 std::ostream &operator<<(std::ostream &os, const Mesh &q);
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/RangeAccessor.hpp
+++ b/src/mesh/RangeAccessor.hpp
@@ -2,8 +2,7 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 /** random-access iterator over an indexable Source.
  *
  * @tparam Source the underlying container to index into
@@ -63,5 +62,4 @@ private:
   size_t  idx_{0};       ///< the current index to access
 };
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/SharedPointer.hpp
+++ b/src/mesh/SharedPointer.hpp
@@ -2,8 +2,7 @@
 
 #include <memory>
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 class Data;
 class Group;
@@ -17,5 +16,4 @@ using PtrMesh              = std::shared_ptr<Mesh>;
 using PtrDataConfiguration = std::shared_ptr<DataConfiguration>;
 using PtrMeshConfiguration = std::shared_ptr<MeshConfiguration>;
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/Tetrahedron.hpp
+++ b/src/mesh/Tetrahedron.hpp
@@ -10,8 +10,7 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /// Tetrahedron of a mesh, defined by 4 vertices
 class Tetrahedron {
@@ -90,5 +89,4 @@ inline const Vertex &Tetrahedron::vertex(int i) const
 
 std::ostream &operator<<(std::ostream &os, const Tetrahedron &t);
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/Triangle.hpp
+++ b/src/mesh/Triangle.hpp
@@ -12,16 +12,13 @@
 #include "precice/impl/Types.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Vertex;
 }
-} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /// Triangle of a mesh, defined by three vertices.
 class Triangle {
@@ -184,5 +181,4 @@ inline Triangle::const_iterator Triangle::cend() const
 
 std::ostream &operator<<(std::ostream &os, const Triangle &t);
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/Utils.hpp
+++ b/src/mesh/Utils.hpp
@@ -11,8 +11,7 @@ namespace precice::mapping {
 struct Sample;
 }
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /** return a pointer to the shared vertex of 2 edges
  *
@@ -154,5 +153,4 @@ std::optional<std::size_t> locateInvalidVertexID(const Mesh &mesh, const Contain
   return std::nullopt;
 }
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -9,8 +9,7 @@
 #include "precice/impl/Types.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /// Vertex of a mesh.
 class Vertex {
@@ -149,5 +148,4 @@ inline bool Vertex::operator<(const Vertex &rhs) const
 /// Make Vertex printable
 std::ostream &operator<<(std::ostream &os, const Vertex &v);
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -32,13 +32,13 @@ public:
 
   ConfiguredData getRecentlyConfiguredData() const;
 
-  virtual void xmlTagCallback(
+  void xmlTagCallback(
       const xml::ConfigurationContext &context,
-      xml::XMLTag &                    callingTag);
+      xml::XMLTag &                    callingTag) override;
 
-  virtual void xmlEndTagCallback(
+  void xmlEndTagCallback(
       const xml::ConfigurationContext &context,
-      xml::XMLTag &                    callingTag);
+      xml::XMLTag &                    callingTag) override;
 
   /**
    * @brief Adds data manually.

--- a/src/mesh/config/DataConfiguration.hpp
+++ b/src/mesh/config/DataConfiguration.hpp
@@ -8,8 +8,7 @@
 #include "utils/ManageUniqueIDs.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 /// Performs and provides configuration for Data objects from XML files.
 class DataConfiguration : public xml::XMLTag::Listener {
@@ -65,5 +64,4 @@ private:
   int _indexLastConfigured = -1;
 };
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -42,11 +42,11 @@ public:
   /// Returns the configured mesh with given name, or NULL.
   mesh::PtrMesh getMesh(const std::string &meshName) const;
 
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &callingTag) override;
 
-  virtual void xmlEndTagCallback(
+  void xmlEndTagCallback(
       const xml::ConfigurationContext &context,
-      xml::XMLTag &                    callingTag);
+      xml::XMLTag &                    callingTag) override;
 
   const PtrDataConfiguration &getDataConfiguration() const;
 

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -12,16 +12,13 @@
 #include "utils/ManageUniqueIDs.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class DataConfiguration;
 }
-} // namespace precice
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 
 class MeshConfiguration : public xml::XMLTag::Listener {
 public:
@@ -98,5 +95,4 @@ private:
   utils::ManageUniqueIDs _dataIDManager;
 };
 
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh

--- a/src/partition/Partition.hpp
+++ b/src/partition/Partition.hpp
@@ -9,8 +9,7 @@
 
 // ----------------------------------------------------------- CLASS DEFINITION
 
-namespace precice {
-namespace partition {
+namespace precice::partition {
 
 /**
  * @brief Abstract base class for partitions.
@@ -73,5 +72,4 @@ private:
   logging::Logger _log{"partition::Partition"};
 };
 
-} // namespace partition
-} // namespace precice
+} // namespace precice::partition

--- a/src/partition/Partition.hpp
+++ b/src/partition/Partition.hpp
@@ -33,7 +33,7 @@ public:
 
   Partition &operator=(Partition &&) = delete;
 
-  virtual ~Partition() {}
+  virtual ~Partition() = default;
 
   /// Intersections between bounding boxes around each rank are computed
   virtual void compareBoundingBoxes() = 0;

--- a/src/partition/ProvidedPartition.hpp
+++ b/src/partition/ProvidedPartition.hpp
@@ -19,7 +19,7 @@ class ProvidedPartition : public Partition {
 public:
   ProvidedPartition(mesh::PtrMesh mesh);
 
-  virtual ~ProvidedPartition() {}
+  virtual ~ProvidedPartition() = default;
 
   /// The mesh is gathered and sent to another participant (if required)
   void communicate() override;

--- a/src/partition/ProvidedPartition.hpp
+++ b/src/partition/ProvidedPartition.hpp
@@ -5,8 +5,7 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace partition {
+namespace precice::partition {
 
 /**
  * @brief A partition that is provided by the participant.
@@ -35,5 +34,4 @@ private:
   logging::Logger _log{"partition::ProvidedPartition"};
 };
 
-} // namespace partition
-} // namespace precice
+} // namespace precice::partition

--- a/src/partition/ProvidedPartition.hpp
+++ b/src/partition/ProvidedPartition.hpp
@@ -19,7 +19,7 @@ class ProvidedPartition : public Partition {
 public:
   ProvidedPartition(mesh::PtrMesh mesh);
 
-  virtual ~ProvidedPartition() = default;
+  ~ProvidedPartition() override = default;
 
   /// The mesh is gathered and sent to another participant (if required)
   void communicate() override;

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -42,7 +42,7 @@ public:
   /// Constructor
   ReceivedPartition(const mesh::PtrMesh &mesh, GeometricFilter geometricFilter, double safetyFactor, bool allowDirectAccess = false);
 
-  virtual ~ReceivedPartition() = default;
+  ~ReceivedPartition() override = default;
 
   void communicate() override;
 

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -42,7 +42,7 @@ public:
   /// Constructor
   ReceivedPartition(const mesh::PtrMesh &mesh, GeometricFilter geometricFilter, double safetyFactor, bool allowDirectAccess = false);
 
-  virtual ~ReceivedPartition() {}
+  virtual ~ReceivedPartition() = default;
 
   void communicate() override;
 

--- a/src/partition/SharedPointer.hpp
+++ b/src/partition/SharedPointer.hpp
@@ -2,12 +2,10 @@
 
 #include <memory>
 
-namespace precice {
-namespace partition {
+namespace precice::partition {
 
 class Partition;
 
 using PtrPartition = std::shared_ptr<Partition>;
 
-} // namespace partition
-} // namespace precice
+} // namespace precice::partition

--- a/src/partition/tests/ReceivedPartitionTest.cpp
+++ b/src/partition/tests/ReceivedPartitionTest.cpp
@@ -1076,7 +1076,7 @@ void testParallelSetOwnerInformation(mesh::PtrMesh mesh, int dimensions)
   auto                                      participantCom = com::PtrCommunication(new com::SocketCommunication());
   m2n::DistributedComFactory::SharedPointer distrFactory;
 
-  auto m2n = m2n::PtrM2N(new m2n::M2N(participantCom, distrFactory, options.useOnlyPrimaryCom, options.useTwoLevelInit));
+  auto m2n = std::make_shared<m2n::M2N>(participantCom, distrFactory, options.useOnlyPrimaryCom, options.useTwoLevelInit);
 
   mapping::PtrMapping boundingFromMapping = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSISTENT, dimensions));
   mapping::PtrMapping boundingToMapping   = mapping::PtrMapping(new mapping::NearestNeighborMapping(mapping::Mapping::CONSERVATIVE, dimensions));

--- a/src/partition/tests/fixtures.hpp
+++ b/src/partition/tests/fixtures.hpp
@@ -1,7 +1,6 @@
 #include "partition/ReceivedPartition.hpp"
 
-namespace precice {
-namespace partition {
+namespace precice::partition {
 
 /*
  * @brief A fixture that is used to access private functions of the receivedPartition class.
@@ -23,5 +22,4 @@ struct ReceivedPartitionFixture {
   }
 };
 
-} // namespace partition
-} // namespace precice
+} // namespace precice::partition

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -13,8 +13,7 @@
 #include "profiling/config/ProfilingConfiguration.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace config {
+namespace precice::config {
 
 /**
  * @brief Main class for preCICE XML configuration tree.
@@ -146,5 +145,4 @@ private:
   cplscheme::PtrCouplingSchemeConfiguration _couplingSchemeConfiguration;
 };
 
-} // namespace config
-} // namespace precice
+} // namespace precice::config

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -29,7 +29,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~Configuration() = default;
+  ~Configuration() override = default;
 
   /**
    * @brief Returns root xml tag to start the automatic configuration process.
@@ -41,14 +41,14 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
+  void xmlTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag) override;
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag);
+  void xmlEndTagCallback(const xml::ConfigurationContext &context, xml::XMLTag &tag) override;
 
   /// @brief Returns whether experimental features are allowed or not
   bool allowsExperimental() const

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -29,7 +29,7 @@ public:
   /**
    * @brief Destructor, empty.
    */
-  virtual ~Configuration() {}
+  virtual ~Configuration() = default;
 
   /**
    * @brief Returns root xml tag to start the automatic configuration process.

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -36,18 +36,18 @@ public:
    *
    * @return True, if successful.
    */
-  virtual void xmlTagCallback(
+  void xmlTagCallback(
       const xml::ConfigurationContext &context,
-      xml::XMLTag &                    callingTag);
+      xml::XMLTag &                    callingTag) override;
 
   /**
    * @brief Callback function required for use of automatic configuration.
    *
    * @return True, if successful.
    */
-  virtual void xmlEndTagCallback(
+  void xmlEndTagCallback(
       const xml::ConfigurationContext &context,
-      xml::XMLTag &                    callingTag);
+      xml::XMLTag &                    callingTag) override;
 
   /// Returns all configured participants.
   const std::vector<impl::PtrParticipant> &getParticipants() const;

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -16,8 +16,7 @@
 #include "utils/networking.hpp"
 #include "xml/XMLTag.hpp"
 
-namespace precice {
-namespace config {
+namespace precice::config {
 
 /**
  * @brief Performs XML configuration of a participant.
@@ -156,5 +155,4 @@ private:
       const impl::PtrParticipant &                            participant);
 };
 
-} // namespace config
-} // namespace precice
+} // namespace precice::config

--- a/src/precice/config/SharedPointer.hpp
+++ b/src/precice/config/SharedPointer.hpp
@@ -2,12 +2,10 @@
 
 #include <memory>
 
-namespace precice {
-namespace config {
+namespace precice::config {
 
 class ParticipantConfiguration;
 
 using PtrParticipantConfiguration = std::shared_ptr<ParticipantConfiguration>;
 
-} // namespace config
-} // namespace precice
+} // namespace precice::config

--- a/src/precice/impl/MappingContext.hpp
+++ b/src/precice/impl/MappingContext.hpp
@@ -3,8 +3,8 @@
 #include "mapping/Mapping.hpp"
 #include "mapping/SharedPointer.hpp"
 #include "mapping/config/MappingConfiguration.hpp"
-namespace precice {
-namespace impl {
+
+namespace precice::impl {
 
 /// Holds a data mapping and related information.
 struct MappingContext {
@@ -33,5 +33,4 @@ struct MappingContext {
   }
 };
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -9,8 +9,7 @@
 #include "partition/ReceivedPartition.hpp"
 #include "partition/SharedPointer.hpp"
 
-namespace precice {
-namespace impl {
+namespace precice::impl {
 
 /// Stores a mesh and related objects and data.
 struct MeshContext {
@@ -69,5 +68,4 @@ inline void MeshContext::require(mapping::Mapping::MeshRequirement requirement)
   meshRequirement = std::max(meshRequirement, requirement);
 }
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -33,14 +33,11 @@ class Configuration;
 } // namespace precice
 
 // Forward declaration to friend the boost test struct
-namespace Integration {
-namespace Serial {
-namespace Whitebox {
+
+namespace Integration::Serial::Whitebox {
 struct TestConfigurationPeano;
 struct TestConfigurationComsol;
-} // namespace Whitebox
-} // namespace Serial
-} // namespace Integration
+} // namespace Integration::Serial::Whitebox
 
 namespace precice {
 namespace cplscheme {

--- a/src/precice/impl/ParticipantState.hpp
+++ b/src/precice/impl/ParticipantState.hpp
@@ -24,22 +24,17 @@
 #include "utils/IntraComm.hpp"
 #include "utils/ManageUniqueIDs.hpp"
 
-namespace precice {
-namespace impl {
+namespace precice::impl {
 struct MeshContext;
 struct MappingContext;
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl
 
 // Forward declaration to friend the boost test struct
-namespace Integration {
-namespace Serial {
-namespace Whitebox {
+
+namespace Integration::Serial::Whitebox {
 struct TestConfigurationPeano;
 struct TestConfigurationComsol;
-} // namespace Whitebox
-} // namespace Serial
-} // namespace Integration
+} // namespace Integration::Serial::Whitebox
 
 namespace precice {
 namespace utils {

--- a/src/precice/impl/ReadDataContext.hpp
+++ b/src/precice/impl/ReadDataContext.hpp
@@ -6,8 +6,7 @@
 #include "cplscheme/ImplicitData.hpp"
 #include "logging/Logger.hpp"
 
-namespace precice {
-namespace impl {
+namespace precice::impl {
 
 /**
  * @brief Stores one Data object with related mesh. Context stores data to be read from and potentially provides a read mapping. Additionally stores Waveform object associated with _providedData.
@@ -83,5 +82,4 @@ private:
   static logging::Logger _log;
 };
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/precice/impl/SharedPointer.hpp
+++ b/src/precice/impl/SharedPointer.hpp
@@ -2,8 +2,7 @@
 
 #include <memory>
 
-namespace precice {
-namespace impl {
+namespace precice::impl {
 
 class ParticipantState;
 class Coupling;
@@ -17,5 +16,4 @@ using PtrWatchPoint    = std::shared_ptr<WatchPoint>;
 using PtrWatchIntegral = std::shared_ptr<WatchIntegral>;
 using PtrMeshContext   = std::shared_ptr<MeshContext>;
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/precice/impl/WatchIntegral.hpp
+++ b/src/precice/impl/WatchIntegral.hpp
@@ -7,14 +7,11 @@
 #include "logging/Logger.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Vertex;
 }
-} // namespace precice
 
-namespace precice {
-namespace impl {
+namespace precice::impl {
 
 /**
  * @brief Track and output transient integral data on a mesh
@@ -60,5 +57,4 @@ private:
   double calculateSurfaceArea() const;
 };
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/precice/impl/WatchPoint.hpp
+++ b/src/precice/impl/WatchPoint.hpp
@@ -10,14 +10,11 @@
 #include "mapping/Polation.hpp"
 #include "mesh/SharedPointer.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Vertex;
 }
-} // namespace precice
 
-namespace precice {
-namespace impl {
+namespace precice::impl {
 
 /// Observes and exports coordinates of a point on the geometry.
 class WatchPoint {
@@ -77,5 +74,4 @@ private:
       mesh::PtrData &data);
 };
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/precice/impl/WriteDataContext.hpp
+++ b/src/precice/impl/WriteDataContext.hpp
@@ -6,8 +6,7 @@
 #include "logging/Logger.hpp"
 #include "time/Sample.hpp"
 
-namespace precice {
-namespace impl {
+namespace precice::impl {
 
 /**
  * @brief Stores one Data object with related mesh. Context stores data to be written to and potentially provides a write mapping.
@@ -88,5 +87,4 @@ private:
   time::Sample _writeDataBuffer;
 };
 
-} // namespace impl
-} // namespace precice
+} // namespace precice::impl

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -13,8 +13,7 @@
 #include "mesh/Vertex.hpp"
 #include "precice/impl/Types.hpp"
 
-namespace precice {
-namespace query {
+namespace precice::query {
 
 /// Type used for the IDs of matching entities
 using MatchID = int;
@@ -132,5 +131,4 @@ private:
   ProjectionMatch findTriangleProjection(const Eigen::VectorXd &location, int n, ProjectionMatch closestVertex);
 };
 
-} // namespace query
-} // namespace precice
+} // namespace precice::query

--- a/src/query/impl/RTreeAdapter.hpp
+++ b/src/query/impl/RTreeAdapter.hpp
@@ -8,18 +8,14 @@
 #include "mesh/Vertex.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace mesh {
+namespace precice::mesh {
 class Triangle;
-} // namespace mesh
-} // namespace precice
+} // namespace precice::mesh
 
 namespace pm = precice::mesh;
 namespace bg = boost::geometry;
 
-namespace boost {
-namespace geometry {
-namespace traits {
+namespace boost::geometry::traits {
 
 /// Adapts Eigen::VectorXd to boost.geometry
 /*
@@ -180,12 +176,9 @@ struct closure<pm::Triangle> {
 
 // BOOST_CONCEPT_ASSERT( (bg::concepts::Ring<pm::Triangle>));
 
-} // namespace traits
-} // namespace geometry
-} // namespace boost
+} // namespace boost::geometry::traits
 
-namespace precice {
-namespace query {
+namespace precice::query {
 
 /// The RTree box type
 using RTreeBox = boost::geometry::model::box<pm::Vertex::RawCoords>;
@@ -354,5 +347,4 @@ struct RTreeTraits {
 };
 
 } // namespace impl
-} // namespace query
-} // namespace precice
+} // namespace precice::query

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -561,10 +561,10 @@ BOOST_AUTO_TEST_CASE(TetraWorksOnBoundary)
   Index   indexTree(ptr);
 
   std::vector<Eigen::Vector3d> locations;
-  locations.push_back(Eigen::Vector3d(0, 0, 0));
-  locations.push_back(Eigen::Vector3d(1, 0, 0));
-  locations.push_back(Eigen::Vector3d(0, 1, 0));
-  locations.push_back(Eigen::Vector3d(0, 0, 1));
+  locations.emplace_back(0, 0, 0);
+  locations.emplace_back(1, 0, 0);
+  locations.emplace_back(0, 1, 0);
+  locations.emplace_back(0, 0, 1);
 
   // Set containing tetra
   auto &v00 = mesh.createVertex(Eigen::Vector3d(0, 0, 0));

--- a/src/testing/DataContextFixture.hpp
+++ b/src/testing/DataContextFixture.hpp
@@ -3,8 +3,7 @@
 #include "precice/impl/DataContext.hpp"
 #include "precice/impl/MappingContext.hpp"
 
-namespace precice {
-namespace testing {
+namespace precice::testing {
 /*
  * @brief A fixture that is used to access private functions of the DataContext class.
  *
@@ -27,5 +26,4 @@ public:
   bool hasWriteMapping(precice::impl::DataContext &dataContext);
 };
 
-} // namespace testing
-} // namespace precice
+} // namespace precice::testing

--- a/src/testing/ParallelCouplingSchemeFixture.hpp
+++ b/src/testing/ParallelCouplingSchemeFixture.hpp
@@ -2,8 +2,7 @@
 
 #include "cplscheme/ParallelCouplingScheme.hpp"
 
-namespace precice {
-namespace testing {
+namespace precice::testing {
 /*
  * @brief A fixture that is used to access private functions of the ParallelCouplingScheme class.
  *
@@ -24,5 +23,4 @@ struct ParallelCouplingSchemeFixture {
 
   static void moveToNextWindow(cplscheme::ParallelCouplingScheme &cplscheme);
 };
-} // namespace testing
-} // namespace precice
+} // namespace precice::testing

--- a/src/testing/SerialCouplingSchemeFixture.hpp
+++ b/src/testing/SerialCouplingSchemeFixture.hpp
@@ -2,8 +2,7 @@
 
 #include "cplscheme/SerialCouplingScheme.hpp"
 
-namespace precice {
-namespace testing {
+namespace precice::testing {
 /*
  * @brief A fixture that is used to access private functions of the SerialCouplingScheme class.
  *
@@ -25,5 +24,4 @@ struct SerialCouplingSchemeFixture {
   static void moveToNextWindow(cplscheme::SerialCouplingScheme &cplscheme);
 };
 
-} // namespace testing
-} // namespace precice
+} // namespace precice::testing

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -255,15 +255,15 @@ m2n::PtrM2N TestContext::connectPrimaryRanks(const std::string &acceptor, const 
   m2n::DistributedComFactory::SharedPointer distrFactory;
   switch (options.type) {
   case ConnectionType::GatherScatter:
-    distrFactory.reset(new m2n::GatherScatterComFactory(participantCom));
+    distrFactory = std::make_shared<m2n::GatherScatterComFactory>(participantCom);
     break;
   case ConnectionType::PointToPoint:
-    distrFactory.reset(new m2n::PointToPointComFactory(com::PtrCommunicationFactory(new com::SocketCommunicationFactory())));
+    distrFactory = std::make_shared<m2n::PointToPointComFactory>(com::PtrCommunicationFactory(new com::SocketCommunicationFactory()));
     break;
   default:
     throw std::runtime_error{"ConnectionType unknown"};
   };
-  auto m2n = m2n::PtrM2N(new m2n::M2N(participantCom, distrFactory, options.useOnlyPrimaryCom, options.useTwoLevelInit));
+  auto m2n = std::make_shared<m2n::M2N>(participantCom, distrFactory, options.useOnlyPrimaryCom, options.useTwoLevelInit);
 
   if (_names.count(acceptor) == 0) {
     throw std::runtime_error{

--- a/src/testing/TestContext.hpp
+++ b/src/testing/TestContext.hpp
@@ -11,8 +11,7 @@
 #include "precice/impl/Types.hpp"
 #include "utils/Parallel.hpp"
 
-namespace precice {
-namespace testing {
+namespace precice::testing {
 
 /** Represents a count of MPI Ranks
  * @see TestContext()
@@ -318,5 +317,4 @@ private:
   /// @}
 };
 
-} // namespace testing
-} // namespace precice
+} // namespace precice::testing

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -71,9 +71,9 @@ TestSetup getTestSetup()
 
 std::optional<TestSetup> getTestSetupFor(const boost::unit_test::test_unit &tu)
 {
-  auto &list = tu.p_decorators;
-  for (auto iter = list->begin(); iter != list->end(); ++iter) {
-    auto ptr = dynamic_cast<precice::testing::precice_testsetup_fixture *>(iter->get());
+  const auto &list = tu.p_decorators.get();
+  for (const auto &iter : list) {
+    auto ptr = dynamic_cast<precice::testing::precice_testsetup_fixture *>(iter.get());
     if (ptr) {
       return ptr->testSetup;
     }

--- a/src/testing/WaveformFixture.hpp
+++ b/src/testing/WaveformFixture.hpp
@@ -2,8 +2,7 @@
 
 #include "time/Waveform.hpp"
 
-namespace precice {
-namespace testing {
+namespace precice::testing {
 /*
  * @brief A fixture that is used to access private functions of the Waveform class.
  *
@@ -16,5 +15,4 @@ public:
   int valuesSize(time::Waveform &waveform);
 };
 
-} // namespace testing
-} // namespace precice
+} // namespace precice::testing

--- a/src/time/Time.hpp
+++ b/src/time/Time.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-namespace precice {
-namespace time {
+namespace precice::time {
 
 class Time {
 public:
@@ -12,5 +11,4 @@ public:
   static const int MIN_WAVEFORM_DEGREE;
 };
 
-} // namespace time
-} // namespace precice
+} // namespace precice::time

--- a/src/time/TimeGrids.cpp
+++ b/src/time/TimeGrids.cpp
@@ -1,10 +1,9 @@
-#pragma once
-
 #include <Eigen/Core>
 #include <numeric>
 #include <vector>
 
 #include "TimeGrids.hpp"
+#include "math/differences.hpp"
 #include "utils/assertion.hpp"
 
 namespace precice::time {

--- a/src/time/TimeGrids.hpp
+++ b/src/time/TimeGrids.hpp
@@ -10,8 +10,7 @@
 #include "logging/Logger.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace time {
+namespace precice::time {
 
 /**
  * @brief Interface for storing the time grids in the Quasi-Newton and Aitken methods.
@@ -47,5 +46,4 @@ private:
   std::map<int, Eigen::VectorXd> _timeGrids;
 };
 
-} // namespace time
-} // namespace precice
+} // namespace precice::time

--- a/src/utils/Dimensions.hpp
+++ b/src/utils/Dimensions.hpp
@@ -2,8 +2,7 @@
 
 #include <Eigen/Core>
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 const Eigen::VectorXd &delinearize(
     int toDelinearize,
@@ -39,5 +38,4 @@ struct IndexMaps<3> {
   static const int CUBOID_EDGE_VERTICES[12][2];
 };
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/src/utils/EigenHelperFunctions.hpp
+++ b/src/utils/EigenHelperFunctions.hpp
@@ -6,8 +6,7 @@
 #include "utils/algorithm.hpp"
 #include "utils/assertion.hpp"
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 void shiftSetFirst(Eigen::MatrixXd &A, const Eigen::VectorXd &v);
 
@@ -91,5 +90,4 @@ struct ComponentWiseLess {
   }
 };
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/src/utils/EigenIO.hpp
+++ b/src/utils/EigenIO.hpp
@@ -2,9 +2,7 @@
 
 #include <Eigen/Core>
 
-namespace precice {
-namespace utils {
-namespace eigenio {
+namespace precice::utils::eigenio {
 
 inline Eigen::IOFormat wkt()
 {
@@ -21,6 +19,4 @@ inline Eigen::IOFormat debug()
   return wkt();
 }
 
-} // namespace eigenio
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils::eigenio

--- a/src/utils/Helpers.hpp
+++ b/src/utils/Helpers.hpp
@@ -6,8 +6,7 @@
 #include <set>
 #include <vector>
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 /// Returns true, if numerical truncation happens in case of type conversion.
 template <class Out, class In>
@@ -60,5 +59,4 @@ bool contained(
 /// Returns true if machine is big-endian needed for parallel vtk output
 bool isMachineBigEndian();
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/src/utils/MPIResult.hpp
+++ b/src/utils/MPIResult.hpp
@@ -8,8 +8,7 @@
 
 #include "utils/String.hpp"
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 /** Utility class to simplify use of MPI return codes
  *
@@ -46,7 +45,6 @@ struct MPIResult {
   }
 };
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils
 
 #endif

--- a/src/utils/ManageUniqueIDs.hpp
+++ b/src/utils/ManageUniqueIDs.hpp
@@ -3,8 +3,7 @@
 #include <boost/container/flat_set.hpp>
 #include <functional>
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 /// Manages a set of unique IDs.
 class ManageUniqueIDs {
@@ -31,5 +30,4 @@ private:
   int _lowerLimit = 0;
 };
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/src/utils/MultiLock.hpp
+++ b/src/utils/MultiLock.hpp
@@ -4,8 +4,7 @@
 #include <exception>
 #include <map>
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 class MultiLockException : public std::runtime_error {
 public:
@@ -158,5 +157,4 @@ private:
   /// The map that keeps track of the locks and their state.
   map_type _locks;
 };
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/src/utils/MultiLock.hpp
+++ b/src/utils/MultiLock.hpp
@@ -15,7 +15,7 @@ public:
 
 class LockNotFoundException : public MultiLockException {
 public:
-  LockNotFoundException() {}
+  LockNotFoundException() = default;
   const char *what() const noexcept override
   {
     return "The multilock does not contain the requested lock!";

--- a/src/utils/Petsc.hpp
+++ b/src/utils/Petsc.hpp
@@ -43,10 +43,8 @@ private:
 #include "petscmat.h"
 #include "petscvec.h"
 
-namespace precice {
-namespace utils {
 /// PETSc related utilities
-namespace petsc {
+namespace precice::utils::petsc {
 
 enum VIEWERFORMAT { ASCII,
                     BINARY };
@@ -297,8 +295,6 @@ void destroy(ISLocalToGlobalMapping *IS);
 /// Destroys an application ordering, if ao is not null and PetscIsInitialized
 void destroy(AO *ao);
 
-} // namespace petsc
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils::petsc
 
 #endif // PRECICE_NO_PETSC

--- a/src/utils/Statistics.hpp
+++ b/src/utils/Statistics.hpp
@@ -10,9 +10,7 @@
 #include <fmt/ostream.h>
 #include <iosfwd>
 
-namespace precice {
-namespace utils {
-namespace statistics {
+namespace precice::utils::statistics {
 
 /**
  * Accunulates distance measures and provides statistics based on them.
@@ -84,9 +82,7 @@ inline std::ostream &operator<<(std::ostream &out, const DistanceAccumulator &ac
   return out;
 }
 
-} // namespace statistics
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils::statistics
 
 template <>
 struct fmt::formatter<precice::utils::statistics::DistanceAccumulator> : ostream_formatter {

--- a/src/utils/String.hpp
+++ b/src/utils/String.hpp
@@ -7,8 +7,7 @@
 #include <string_view>
 #include <vector>
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 /// Utility class to build a string from C functions with output pointers and static maximum length
 template <int MAX>
@@ -107,5 +106,4 @@ std::vector<StringMatch> computeMatches(std::string_view given, const Container 
 
 bool isKebabStyle(std::string_view sv);
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/src/utils/TypeNames.hpp
+++ b/src/utils/TypeNames.hpp
@@ -9,8 +9,7 @@
 #include <Eigen/Core>
 #include <string>
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 inline std::string getTypeName(const double &var)
 {
@@ -37,5 +36,4 @@ inline std::string getTypeName(Eigen::VectorXd const &var)
   return "vector";
 }
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils

--- a/src/utils/algorithm.hpp
+++ b/src/utils/algorithm.hpp
@@ -9,8 +9,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 /**
    * @brief This function is by and large the same as std::set_intersection().
@@ -224,8 +223,7 @@ std::pair<InputIt, InputIt> find_first_range(InputIt first, InputIt last, Predic
   return {firstMatch, trailing};
 }
 
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils
 
 template <typename Iter>
 struct fmt::formatter<precice::utils::RangePreview<Iter>> : ostream_formatter {

--- a/src/utils/assertion.hpp
+++ b/src/utils/assertion.hpp
@@ -32,8 +32,7 @@
 #include "utils/Parallel.hpp"
 #include "utils/stacktrace.hpp"
 
-namespace precice {
-namespace utils {
+namespace precice::utils {
 
 static constexpr std::string_view ASSERT_FMT =
     "ASSERTION FAILED\n"
@@ -44,7 +43,6 @@ static constexpr std::string_view ASSERT_FMT =
     "Arguments:  {}\n"
     "Stacktrace:\n{}\n";
 }
-} // namespace precice
 
 // Create a wrapper around assert that also aborts if NDEBUG is defined.
 #ifndef NDEBUG

--- a/src/utils/networking.hpp
+++ b/src/utils/networking.hpp
@@ -2,14 +2,9 @@
 
 #include <string>
 
-namespace precice {
-namespace utils {
-namespace networking {
+namespace precice::utils::networking {
 
 /// Returns the name of the canonical loopback interface on this system
 std::string loopbackInterfaceName();
 
-} // namespace networking
-
-} // namespace utils
-} // namespace precice
+} // namespace precice::utils::networking

--- a/src/xml/Printer.hpp
+++ b/src/xml/Printer.hpp
@@ -2,8 +2,7 @@
 
 #include <iosfwd>
 
-namespace precice {
-namespace xml {
+namespace precice::xml {
 
 class XMLTag;
 
@@ -16,5 +15,4 @@ void toDTD(std::ostream &out, const XMLTag &tag);
 /// Prints the XML reference for the given tag.
 void toDocumentation(std::ostream &out, const XMLTag &tag);
 
-} // namespace xml
-} // namespace precice
+} // namespace precice::xml

--- a/src/xml/ValueParser.hpp
+++ b/src/xml/ValueParser.hpp
@@ -4,8 +4,7 @@
 #include <string>
 #include "utils/String.hpp"
 
-namespace precice {
-namespace xml {
+namespace precice::xml {
 
 void readValueSpecific(const std::string &rawValue, double &value);
 
@@ -23,5 +22,4 @@ inline void readValueSpecific(const std::string &rawValue, bool &value)
 
 void readValueSpecific(const std::string &rawValue, Eigen::VectorXd &value);
 
-} // namespace xml
-} // namespace precice
+} // namespace precice::xml

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -14,8 +14,7 @@
 #include "utils/assertion.hpp"
 #include "xml/ValueParser.hpp"
 
-namespace precice {
-namespace xml {
+namespace precice::xml {
 
 template <typename ATTRIBUTE_T>
 class XMLAttribute {
@@ -240,5 +239,4 @@ XMLAttribute<T> makeXMLAttribute(std::string name, T defaultValue)
   return XMLAttribute<T>(std::move(name), std::move(defaultValue));
 }
 
-} // namespace xml
-} // namespace precice
+} // namespace precice::xml

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -11,11 +11,9 @@
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLAttribute.hpp"
 
-namespace precice {
-namespace xml {
+namespace precice::xml {
 class ConfigParser;
 }
-} // namespace precice
 
 namespace precice::xml {
 

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -181,12 +181,12 @@ struct ContextListener : public XMLTag::Listener {
   ConfigurationContext startContext;
   ConfigurationContext endContext;
 
-  void xmlTagCallback(const ConfigurationContext &context, XMLTag &callingTag)
+  void xmlTagCallback(const ConfigurationContext &context, XMLTag &callingTag) override
   {
     startContext = context;
   }
 
-  void xmlEndTagCallback(const ConfigurationContext &context, XMLTag &callingTag)
+  void xmlEndTagCallback(const ConfigurationContext &context, XMLTag &callingTag) override
   {
     endContext = context;
   }

--- a/tests/parallel/distributed-communication/helpers.cpp
+++ b/tests/parallel/distributed-communication/helpers.cpp
@@ -22,15 +22,15 @@ void runTestDistributedCommunication(std::string const &config, TestContext cons
     position[0] = i * 1.0;
     position[1] = 0.0;
     position[2] = 0.0;
-    positions.push_back(position);
+    positions.emplace_back(position);
     datum[0] = i * 1.0;
     datum[1] = i * 1.0;
     datum[2] = 0.0;
-    data.push_back(datum);
+    data.emplace_back(datum);
     datum[0] = i * 2.0 + 1.0;
     datum[1] = i * 2.0 + 1.0;
     datum[2] = 1.0;
-    expectedData.push_back(datum);
+    expectedData.emplace_back(datum);
   }
 
   if (context.isNamed("Fluid")) {

--- a/tests/serial/aitken/WithSubsteps.cpp
+++ b/tests/serial/aitken/WithSubsteps.cpp
@@ -1,5 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
+#include "math/differences.hpp"
 #include "testing/Testing.hpp"
 
 #include <precice/precice.hpp>
@@ -29,7 +30,7 @@ BOOST_AUTO_TEST_CASE(WithSubsteps)
   }
 
   precice::Participant interface(context.name, context.config(), context.rank, context.size);
-  VertexID             vertexIDs[2];
+  precice::VertexID    vertexIDs[2];
 
   // meshes for rank 0 and rank 1, we use matching meshes for both participants
   double positions0[4] = {1.0, 0.0, 1.0, 0.5};
@@ -114,8 +115,8 @@ BOOST_AUTO_TEST_CASE(WithSubsteps)
   for (int i = 0; i < nSubsteps; i++) {
     // scaling with the time window length which is equal to 1
     double localTime = (1.0 * i) / nSubStepsDone + timeCheckpoint;
-    BOOST_TEST(math::equals(savedValues(i, 0), analyticalSolution(localTime)[0], 1e-10));
-    BOOST_TEST(math::equals(savedValues(i, 1), analyticalSolution(localTime)[1], 1e-10));
+    BOOST_TEST(precice::math::equals(savedValues(i, 0), analyticalSolution(localTime)[0], 1e-10));
+    BOOST_TEST(precice::math::equals(savedValues(i, 1), analyticalSolution(localTime)[1], 1e-10));
   }
 }
 

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipantInitData)
   }
   precice.initialize();
 
-  for (int i = 0; i < timestepSizes.size(); i++) {
+  for (double &timestepSize : timestepSizes) {
     double dt = precice.getMaxTimeStepSize();
 
     precice.readData(meshName, readDataName, {&vertexID, 1}, dt, {&actualDataValue, 1});
@@ -64,9 +64,9 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataFirstParticipantInitData)
     precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&expectedDataValue, 1});
 
     if (context.isNamed("SolverOne")) {
-      precice.advance(timestepSizes.at(i));
+      precice.advance(timestepSize);
     } else if (context.isNamed("SolverTwo")) {
-      BOOST_TEST(dt == timestepSizes.at(i));
+      BOOST_TEST(dt == timestepSize);
       precice.advance(dt);
     }
   }

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -44,22 +44,22 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
     writeDataName    = "DataOne";
     writeFunction    = dataOneFunction;
     auto dataTwoName = "DataTwo";
-    readDataPairs.push_back(std::make_pair(dataTwoName, dataTwoFunction));
+    readDataPairs.emplace_back(dataTwoName, dataTwoFunction);
     auto dataThreeName = "DataThree";
-    readDataPairs.push_back(std::make_pair(dataThreeName, dataThreeFunction));
+    readDataPairs.emplace_back(dataThreeName, dataThreeFunction);
   } else if (context.isNamed("SolverTwo")) {
     meshName         = "MeshTwo";
     writeDataName    = "DataTwo";
     writeFunction    = dataTwoFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
   } else {
     BOOST_TEST(context.isNamed("SolverThree"));
     meshName         = "MeshThree";
     writeDataName    = "DataThree";
     writeFunction    = dataThreeFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
   }
 
   double   writeData = 0;

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
@@ -46,22 +46,22 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcyclingNoSubsteps)
     writeDataName    = "DataOne";
     writeFunction    = dataOneFunction;
     auto dataTwoName = "DataTwo";
-    readDataPairs.push_back(std::make_pair(dataTwoName, dataTwoFunction));
+    readDataPairs.emplace_back(dataTwoName, dataTwoFunction);
     auto dataThreeName = "DataThree";
-    readDataPairs.push_back(std::make_pair(dataThreeName, dataThreeFunction));
+    readDataPairs.emplace_back(dataThreeName, dataThreeFunction);
   } else if (context.isNamed("SolverTwo")) {
     meshName         = "MeshTwo";
     writeDataName    = "DataTwo";
     writeFunction    = dataTwoFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
   } else {
     BOOST_TEST(context.isNamed("SolverThree"));
     meshName         = "MeshThree";
     writeDataName    = "DataThree";
     writeFunction    = dataThreeFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
   }
 
   double   writeData = 0;

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSamplingFirst.cpp
@@ -45,22 +45,22 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSamplingFirst)
     writeDataName    = "DataOne";
     writeFunction    = dataOneFunction;
     auto dataTwoName = "DataTwo";
-    readDataPairs.push_back(std::make_pair(dataTwoName, dataTwoFunction));
+    readDataPairs.emplace_back(dataTwoName, dataTwoFunction);
     auto dataThreeName = "DataThree";
-    readDataPairs.push_back(std::make_pair(dataThreeName, dataThreeFunction));
+    readDataPairs.emplace_back(dataThreeName, dataThreeFunction);
   } else if (context.isNamed("SolverTwo")) {
     meshName         = "MeshTwo";
     writeDataName    = "DataTwo";
     writeFunction    = dataTwoFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
   } else {
     BOOST_TEST(context.isNamed("SolverThree"));
     meshName         = "MeshThree";
     writeDataName    = "DataThree";
     writeFunction    = dataThreeFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
   }
 
   double   writeData = 0;

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
@@ -47,16 +47,16 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingDifferentDts)
     writeDataName    = "DataOne";
     writeFunction    = dataOneFunction;
     auto dataTwoName = "DataTwo";
-    readDataPairs.push_back(std::make_pair(dataTwoName, dataTwoFunction));
+    readDataPairs.emplace_back(dataTwoName, dataTwoFunction);
     auto dataThreeName = "DataThree";
-    readDataPairs.push_back(std::make_pair(dataThreeName, dataThreeFunction));
+    readDataPairs.emplace_back(dataThreeName, dataThreeFunction);
     nSubsteps = 4;
   } else if (context.isNamed("SolverTwo")) {
     meshName         = "MeshTwo";
     writeDataName    = "DataTwo";
     writeFunction    = dataTwoFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
     nSubsteps = 3;
   } else {
     BOOST_TEST(context.isNamed("SolverThree"));
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingDifferentDts)
     writeDataName    = "DataThree";
     writeFunction    = dataThreeFunction;
     auto dataOneName = "DataOne";
-    readDataPairs.push_back(std::make_pair(dataOneName, dataOneFunction));
+    readDataPairs.emplace_back(dataOneName, dataOneFunction);
     nSubsteps = 2;
   }
 

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataAitken1.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataAitken1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataAitken2.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataAitken2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataConstantAcceleration1.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataConstantAcceleration1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataConstantAcceleration2.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataConstantAcceleration2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataIQNILSAcceleration1.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataIQNILSAcceleration1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataIQNILSAcceleration2.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataIQNILSAcceleration2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataIQNIMVJAcceleration1.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataIQNIMVJAcceleration1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/parallel-coupling/InitialDataIQNIMVJAcceleration2.cpp
+++ b/tests/serial/time/implicit/parallel-coupling/InitialDataIQNIMVJAcceleration2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataAitken1.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataAitken1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataAitken2.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataAitken2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataConstantAcceleration1.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataConstantAcceleration1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataConstantAcceleration2.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataConstantAcceleration2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataIQNILSAcceleration1.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataIQNILSAcceleration1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataIQNILSAcceleration2.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataIQNILSAcceleration2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataIQNIMVJAcceleration1.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataIQNIMVJAcceleration1.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/InitialDataIQNIMVJAcceleration2.cpp
+++ b/tests/serial/time/implicit/serial-coupling/InitialDataIQNIMVJAcceleration2.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
@@ -1,6 +1,6 @@
 #ifndef PRECICE_NO_MPI
 
-#include <math.h>
+#include <cmath>
 #include <precice/precice.hpp>
 #include <vector>
 #include "testing/Testing.hpp"


### PR DESCRIPTION
## Main changes of this PR

This PR performs a tidy up of the code base by applying some clang tidy rules. I also added the header filter which applies fixes in the codebase.

- **Add modernize-override**
- **Use range for over decorators**
- **Fix non-unity compilation errors**
- **Emit clang-tidy to preCICE src headers**
- **Migrate deprecated headers**
- **Migrate use nullptr**
- **Modernize use default c/dtor**
- **Modernize emplace**
- **Modernize make shared**
- **Add and modernize make unique**
- **Modernize overrride**
- **Modernize emplace in tests**
- **Also check tests and extra headers**
- **Use cmath**
- **Uses loop for timestepsizes**
- **Modernize concat namespaces**


## Motivation and additional information


## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
