### PR TITLE
Fix `getWindowEndTime()`

### DIFF
--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -940,7 +940,11 @@ double BaseCouplingScheme::getWindowStartTime() const
 
 double BaseCouplingScheme::getWindowEndTime() const
 {
-  return getWindowStartTime() + getTimeWindowSize();
+  if (hasTimeWindowSize()) {
+    return _time.time() + _time.untilWindowEnd(_timeWindowSize);
+  } else {
+    return _time.time() + _time.untilEnd();
+  }
 }
 
 bool BaseCouplingScheme::requiresSubsteps() const

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -398,6 +398,17 @@ protected:
   /// @copydoc cplscheme::CouplingScheme::localParticipant()
   std::string localParticipant() const override final;
 
+protected:
+  /**
+   * @return the end of the time window, defined as timeWindowStart + timeWindowSize
+   */
+  double getWindowEndTime() const;
+
+  /**
+   * @return the start of the time window
+   */
+  double getWindowStartTime() const;
+
 private:
   /// Coupling mode used by coupling scheme.
   CouplingMode _couplingMode = Undefined;
@@ -576,16 +587,6 @@ private:
    * @return true, if any CouplingData in dataMap requires initialization
    */
   bool anyDataRequiresInitialization(DataMap &dataMap) const;
-
-  /**
-   * @return the end of the time window, defined as timeWindowStart + timeWindowSize
-   */
-  double getWindowEndTime() const;
-
-  /**
-   * @return the start of the time window
-   */
-  double getWindowStartTime() const;
 };
 } // namespace cplscheme
 } // namespace precice

--- a/src/cplscheme/MultiCouplingScheme.cpp
+++ b/src/cplscheme/MultiCouplingScheme.cpp
@@ -80,6 +80,7 @@ void MultiCouplingScheme::initializeReceiveDataStorage()
 void MultiCouplingScheme::exchangeInitialData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
+  PRECICE_ASSERT(math::equals(getTime(), getWindowStartTime()), getTime(), getWindowStartTime());
 
   if (_isController) {
     for (auto &[from, data] : _receiveDataVector) {
@@ -126,6 +127,7 @@ bool MultiCouplingScheme::receivesInitializedDataFrom(const std::string &from) c
 void MultiCouplingScheme::exchangeFirstData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
+  PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
   // @todo implement MultiCouplingScheme for explicit coupling
 
   PRECICE_DEBUG("Computed full length of iteration");
@@ -145,6 +147,7 @@ void MultiCouplingScheme::exchangeFirstData()
 void MultiCouplingScheme::exchangeSecondData()
 {
   PRECICE_ASSERT(isImplicitCouplingScheme(), "MultiCouplingScheme is always Implicit.");
+  PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
   // @todo implement MultiCouplingScheme for explicit coupling
 
   if (not _isController) {

--- a/src/cplscheme/ParallelCouplingScheme.cpp
+++ b/src/cplscheme/ParallelCouplingScheme.cpp
@@ -35,6 +35,7 @@ ParallelCouplingScheme::ParallelCouplingScheme(
 void ParallelCouplingScheme::exchangeInitialData()
 {
   // F: send, receive, S: receive, send
+  PRECICE_ASSERT(math::equals(getTime(), getWindowStartTime()), getTime(), getWindowStartTime());
   if (doesFirstStep()) {
     if (sendsInitializedData()) {
       sendData(getM2N(), getSendData());
@@ -60,6 +61,7 @@ void ParallelCouplingScheme::exchangeInitialData()
 
 void ParallelCouplingScheme::exchangeFirstData()
 {
+  PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
   if (doesFirstStep()) { // first participant
     PRECICE_DEBUG("Sending data...");
     sendData(getM2N(), getSendData());
@@ -72,6 +74,7 @@ void ParallelCouplingScheme::exchangeFirstData()
 
 void ParallelCouplingScheme::exchangeSecondData()
 {
+  PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
   if (isExplicitCouplingScheme()) {
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Receiving data...");

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -121,15 +121,15 @@ void SerialCouplingScheme::exchangeInitialData()
 
 void SerialCouplingScheme::exchangeFirstData()
 {
-  PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
-
   if (isExplicitCouplingScheme()) {
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Sending data...");
       sendTimeWindowSize();
+      PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
       sendData(getM2N(), getSendData());
     } else { // second participant
       PRECICE_DEBUG("Sending data...");
+      PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
       sendData(getM2N(), getSendData());
     }
   } else {
@@ -138,6 +138,7 @@ void SerialCouplingScheme::exchangeFirstData()
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Sending data...");
       sendTimeWindowSize();
+      PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
       sendData(getM2N(), getSendData());
     } else { // second participant
       PRECICE_DEBUG("Perform acceleration (only second participant)...");
@@ -145,6 +146,7 @@ void SerialCouplingScheme::exchangeFirstData()
       PRECICE_DEBUG("Sending convergence...");
       sendConvergence(getM2N());
       PRECICE_DEBUG("Sending data...");
+      PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
       sendData(getM2N(), getSendData());
     }
   }

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -91,6 +91,7 @@ void SerialCouplingScheme::receiveAndSetTimeWindowSize()
 void SerialCouplingScheme::exchangeInitialData()
 {
   // F: send, receive, S: receive, send
+  PRECICE_ASSERT(math::equals(getTime(), getWindowStartTime()), getTime(), getWindowStartTime());
   if (doesFirstStep()) {
     if (receivesInitializedData()) {
       receiveData(getM2N(), getReceiveData());
@@ -119,10 +120,16 @@ void SerialCouplingScheme::exchangeInitialData()
 
 void SerialCouplingScheme::exchangeFirstData()
 {
+  if (doesFirstStep()) {
+    PRECICE_DEBUG("Sending time window size...");
+    sendTimeWindowSize();
+  }
+
+  PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
+
   if (isExplicitCouplingScheme()) {
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Sending data...");
-      sendTimeWindowSize();
       sendData(getM2N(), getSendData());
     } else { // second participant
       PRECICE_DEBUG("Sending data...");
@@ -130,10 +137,8 @@ void SerialCouplingScheme::exchangeFirstData()
     }
   } else {
     PRECICE_ASSERT(isImplicitCouplingScheme());
-
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Sending data...");
-      sendTimeWindowSize();
       sendData(getM2N(), getSendData());
     } else { // second participant
       PRECICE_DEBUG("Perform acceleration (only second participant)...");
@@ -151,6 +156,7 @@ void SerialCouplingScheme::exchangeSecondData()
   if (isExplicitCouplingScheme()) {
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Receiving data...");
+      PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
       receiveData(getM2N(), getReceiveData());
       notifyDataHasBeenReceived();
     }
@@ -162,6 +168,7 @@ void SerialCouplingScheme::exchangeSecondData()
       if (isCouplingOngoing()) {
         receiveAndSetTimeWindowSize();
         PRECICE_DEBUG("Receiving data...");
+        PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
         receiveDataForWindowEnd(getM2N(), getReceiveData());
         notifyDataHasBeenReceived();
       }
@@ -173,6 +180,7 @@ void SerialCouplingScheme::exchangeSecondData()
       PRECICE_DEBUG("Receiving convergence data...");
       receiveConvergence(getM2N());
       PRECICE_DEBUG("Receiving data...");
+      PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
       receiveData(getM2N(), getReceiveData());
       notifyDataHasBeenReceived();
     }
@@ -188,6 +196,7 @@ void SerialCouplingScheme::exchangeSecondData()
       if (isCouplingOngoing() || not hasConverged()) {
         receiveAndSetTimeWindowSize();
         PRECICE_DEBUG("Receiving data...");
+        PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
         if (hasConverged()) {
           receiveDataForWindowEnd(getM2N(), getReceiveData());
         } else {

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -110,9 +110,10 @@ void SerialCouplingScheme::exchangeInitialData()
       receiveData(getM2N(), getReceiveData());
     }
     // similar to SerialCouplingScheme::exchangeSecondData()
-    PRECICE_DEBUG("Receiving data...");
+    PRECICE_DEBUG("Receiving time window size...");
     receiveAndSetTimeWindowSize();
     setTimeWindowSize(getNextTimeWindowSize()); // Needed, because second participant just received _timeWindowSize from first participant, if serial coupling scheme using first participant method.
+    PRECICE_DEBUG("Receiving data...");
     receiveDataForWindowEnd(getM2N(), getReceiveData());
     notifyDataHasBeenReceived();
   }
@@ -153,6 +154,13 @@ void SerialCouplingScheme::exchangeFirstData()
 
 void SerialCouplingScheme::exchangeSecondData()
 {
+  if (not doesFirstStep() && (isCouplingOngoing() || not hasConverged())) {
+    PRECICE_DEBUG("Receiving time window size...");
+    receiveAndSetTimeWindowSize();
+  }
+
+  PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
+
   if (isExplicitCouplingScheme()) {
     if (doesFirstStep()) { // first participant
       PRECICE_DEBUG("Receiving data...");
@@ -166,7 +174,6 @@ void SerialCouplingScheme::exchangeSecondData()
     if (not doesFirstStep()) { // second participant
       // the second participant does not want new data in the last iteration of the last time window
       if (isCouplingOngoing()) {
-        receiveAndSetTimeWindowSize();
         PRECICE_DEBUG("Receiving data...");
         PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
         receiveDataForWindowEnd(getM2N(), getReceiveData());
@@ -194,9 +201,7 @@ void SerialCouplingScheme::exchangeSecondData()
     if (not doesFirstStep()) { // second participant
       // the second participant does not want new data in the last iteration of the last time window
       if (isCouplingOngoing() || not hasConverged()) {
-        receiveAndSetTimeWindowSize();
         PRECICE_DEBUG("Receiving data...");
-        PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
         if (hasConverged()) {
           receiveDataForWindowEnd(getM2N(), getReceiveData());
         } else {

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -113,7 +113,6 @@ void SerialCouplingScheme::exchangeInitialData()
     PRECICE_DEBUG("Receiving data...");
     receiveAndSetTimeWindowSize();
     setTimeWindowSize(getNextTimeWindowSize()); // Needed, because second participant just received _timeWindowSize from first participant, if serial coupling scheme using first participant method.
-    PRECICE_ASSERT(math::equals(getTime(), getWindowEndTime()), getTime(), getWindowEndTime());
     receiveDataForWindowEnd(getM2N(), getReceiveData());
     notifyDataHasBeenReceived();
   }


### PR DESCRIPTION
## Main changes of this PR

Fixes `getWindowEndTime()` if window size would exceed max time.

## Motivation and additional information

Added assertions to clarify expected behavior of `getTime` before `sendData` / `recvData` in the respective coupling schemes.

Preparatory PR for #2203 

## Author's checklist

* [x] merge https://github.com/precice/precice/pull/2214
* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [x] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
