### PR TITLE
Refactor hashing into separate file

### DIFF
--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -307,6 +307,8 @@ target_sources(preciceCore
     src/utils/EigenHelperFunctions.cpp
     src/utils/EigenHelperFunctions.hpp
     src/utils/EigenIO.hpp
+    src/utils/Hash.cpp
+    src/utils/Hash.hpp
     src/utils/Helpers.cpp
     src/utils/Helpers.hpp
     src/utils/IntraComm.cpp

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -104,6 +104,7 @@ target_sources(testprecice
     src/utils/tests/AlgorithmTest.cpp
     src/utils/tests/DimensionsTest.cpp
     src/utils/tests/EigenHelperFunctionsTest.cpp
+    src/utils/tests/HashTest.cpp
     src/utils/tests/IntraCommTest.cpp
     src/utils/tests/ManageUniqueIDsTest.cpp
     src/utils/tests/MultiLockTest.cpp

--- a/src/utils/Hash.cpp
+++ b/src/utils/Hash.cpp
@@ -1,0 +1,25 @@
+#include <boost/uuid/name_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include "utils/Hash.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice::utils {
+
+std::string preciceHash(std::string_view s)
+try {
+  boost::uuids::string_generator ns_gen;
+  auto                           ns = ns_gen("af7ce8f2-a9ee-46cb-38ee-71c318aa3580"); // md5 hash of precice.org as namespace
+
+  boost::uuids::name_generator gen{ns};
+  std::string                  hash = boost::uuids::to_string(gen(s.data(), s.size()));
+  hash.erase(std::remove(hash.begin(), hash.end(), '-'), hash.end());
+  return hash;
+
+} catch (const std::runtime_error &e) {
+  PRECICE_UNREACHABLE("preCICE hashing failed", e.what());
+  return "";
+}
+
+} // namespace precice::utils

--- a/src/utils/Hash.hpp
+++ b/src/utils/Hash.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace precice::utils {
+
+/// creates a portable hash of the given input
+std::string preciceHash(std::string_view s);
+
+} // namespace precice::utils

--- a/src/utils/tests/HashTest.cpp
+++ b/src/utils/tests/HashTest.cpp
@@ -1,0 +1,36 @@
+#include "testing/Testing.hpp"
+#include "utils/Hash.hpp"
+
+BOOST_AUTO_TEST_SUITE(UtilsTests)
+BOOST_AUTO_TEST_SUITE(HashTests)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(Empty)
+{
+  PRECICE_TEST();
+  BOOST_TEST(precice::utils::preciceHash("") == "4d572a0ba37b5812b95a6e7b87898eea");
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(Letter)
+{
+  PRECICE_TEST();
+  BOOST_TEST(precice::utils::preciceHash("A") == "28c1219289105e64885266336db22f68");
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(Digit)
+{
+  PRECICE_TEST();
+  BOOST_TEST(precice::utils::preciceHash("1") == "cecd78530a875345828b93a514cb61c1");
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(XMLTags)
+{
+  PRECICE_TEST();
+  BOOST_TEST(precice::utils::preciceHash("<precice-configuration></precice-configuration>") == "ea6c463e64ba52f7b887e18452156fe6");
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Main changes of this PR

This PR refactors the hashing using boost UUID into a separate function and file.
It also adds tests to ensure that it behaves the same accross platforms.

## Motivation and additional information

This make the hashing reusable

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
