### PR TITLE
Check consistent configs accross participants

### DIFF
--- a/docs/changelog/2217.md
+++ b/docs/changelog/2217.md
@@ -1,0 +1,1 @@
+- Added a check to ensure coupled participants use configuration files with the same content.

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -218,10 +218,10 @@ struct CompositionalCouplingSchemeFixture : m2n::WhiteboxAccessor {
     BOOST_TEST(not communication->isConnected());
     useOnlyPrimaryCom(communication) = true;
     if (participant0 == localParticipant) {
-      communication->requestPrimaryRankConnection(participant1, participant0);
+      communication->requestPrimaryRankConnection(participant1, participant0, "");
     } else {
       BOOST_TEST(participant1 == localParticipant);
-      communication->acceptPrimaryRankConnection(participant1, participant0);
+      communication->acceptPrimaryRankConnection(participant1, participant0, "");
     }
   }
 };

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -291,10 +291,10 @@ struct ExplicitCouplingSchemeFixture : m2n::WhiteboxAccessor {
     BOOST_TEST(not communication->isConnected());
     useOnlyPrimaryCom(communication) = true;
     if (participant0 == localParticipant) {
-      communication->requestPrimaryRankConnection(participant1, participant0);
+      communication->requestPrimaryRankConnection(participant1, participant0, "");
     } else {
       BOOST_TEST(participant1 == localParticipant);
-      communication->acceptPrimaryRankConnection(participant1, participant0);
+      communication->acceptPrimaryRankConnection(participant1, participant0, "");
     }
   }
 };

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -563,9 +563,9 @@ BOOST_AUTO_TEST_CASE(testConfiguredAbsConvergenceMeasureSynchronized)
   std::vector<int> validIterations = {5, 5, 5};
 
   if (context.isNamed("Participant0")) {
-    m2n->requestPrimaryRankConnection("Participant1", "Participant0");
+    m2n->requestPrimaryRankConnection("Participant1", "Participant0", "");
   } else {
-    m2n->acceptPrimaryRankConnection("Participant1", "Participant0");
+    m2n->acceptPrimaryRankConnection("Participant1", "Participant0", "");
   }
 
   runCoupling(*cplSchemeConfig.getCouplingScheme(context.name),

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -20,14 +20,14 @@ void BoundM2N::prepareEstablishment()
   m2n->prepareEstablishment(localName, remoteName);
 }
 
-void BoundM2N::connectPrimaryRanks()
+void BoundM2N::connectPrimaryRanks(std::string_view configHash)
 {
   std::string fullLocalName = localName;
 
   if (isRequesting) {
-    m2n->requestPrimaryRankConnection(remoteName, fullLocalName);
+    m2n->requestPrimaryRankConnection(remoteName, fullLocalName, configHash);
   } else {
-    m2n->acceptPrimaryRankConnection(fullLocalName, remoteName);
+    m2n->acceptPrimaryRankConnection(fullLocalName, remoteName, configHash);
   }
 }
 

--- a/src/m2n/BoundM2N.hpp
+++ b/src/m2n/BoundM2N.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <string_view>
+
 #include "logging/Logger.hpp"
 #include "m2n/SharedPointer.hpp"
 
@@ -13,7 +15,7 @@ public:
   void prepareEstablishment();
 
   /// Connect the Primary Ranks of the M2N
-  void connectPrimaryRanks();
+  void connectPrimaryRanks(std::string_view configHash);
 
   /// Connect the Secondary ranks of the M2N
   void connectSecondaryRanks();

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -43,18 +43,22 @@ public:
    *
    * @param[in] acceptorName Name of calling participant.
    * @param[in] requesterName Name of remote participant to connect to.
+   * @param[in] configHash Hash of the local config
    */
   void acceptPrimaryRankConnection(const std::string &acceptorName,
-                                   const std::string &requesterName);
+                                   const std::string &requesterName,
+                                   std::string_view   configHash);
 
   /**
    * @brief Connects to another participant, which has to call acceptConnection().
    *
    * @param[in] acceptorName Name of remote participant to connect to.
    * @param[in] requesterName Name of calling participant.
+   * @param[in] configHash Hash of the local config
    */
   void requestPrimaryRankConnection(const std::string &acceptorName,
-                                    const std::string &requesterName);
+                                    const std::string &requesterName,
+                                    std::string_view   configHash);
 
   /**
    * @brief Connects to another participant, which has to call requestConnection().
@@ -251,6 +255,12 @@ private:
 
   // @brief To allow access to _useOnlyPrimaryCom
   friend struct WhiteboxAccessor;
+
+  /// checks the info of the remote participant against the version and config hash of the local participant
+  void checkRemoteInfo(std::string_view localParticipant,
+                       std::string_view remoteParticipant,
+                       std::string_view localConfigHash,
+                       std::string_view remoteInfo);
 };
 
 /// struct giving access _useOnlyPrimaryCom

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -175,7 +175,7 @@ void ParticipantImpl::configure(
       _accessorName,
       _accessorProcessRank,
       _accessorCommunicatorSize};
-  xml::configure(config.getXMLTag(), context, configurationFileName);
+  _configHash = xml::configure(config.getXMLTag(), context, configurationFileName);
   if (_accessorProcessRank == 0) {
     PRECICE_INFO("This is preCICE version {}", PRECICE_VERSION);
     PRECICE_INFO("Revision info: {}", precice::preciceRevision);

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -333,7 +333,7 @@ void ParticipantImpl::setupCommunication()
     } else {
       PRECICE_DEBUG((requesting ? "Awaiting primary connection from {}" : "Establishing primary connection to {}"), bm2n.remoteName);
       bm2n.prepareEstablishment();
-      bm2n.connectPrimaryRanks();
+      bm2n.connectPrimaryRanks(_configHash);
       PRECICE_DEBUG("Established primary connection {} {}", (requesting ? "from " : "to "), bm2n.remoteName);
     }
   }

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -352,6 +352,9 @@ private:
   /// Counts the amount of samples mapped in read mappings executed in the latest advance
   int _executedReadMappings = 0;
 
+  /// The hash of the configuration file used to configure this participant
+  std::string _configHash;
+
   /**
    * @brief Configures the coupling interface from the given xml file.
    *

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -274,10 +274,11 @@ m2n::PtrM2N TestContext::connectPrimaryRanks(const std::string &acceptor, const 
         "Requestor \"" + requestor + "\" not defined in this context."};
   }
 
+  std::string configHash = "NOPE";
   if (isNamed(acceptor)) {
-    m2n->acceptPrimaryRankConnection(acceptor, requestor);
+    m2n->acceptPrimaryRankConnection(acceptor, requestor, configHash);
   } else if (isNamed(requestor)) {
-    m2n->requestPrimaryRankConnection(acceptor, requestor);
+    m2n->requestPrimaryRankConnection(acceptor, requestor, configHash);
   } else {
     throw std::runtime_error{"You try to connect " + acceptor + " and " + requestor + ", but this context is named " + name};
   }

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -12,6 +12,7 @@
 
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
+#include "utils/Hash.hpp"
 #include "utils/String.hpp"
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLTag.hpp"
@@ -159,6 +160,11 @@ void ConfigParser::MessageProxy(int level, std::string_view mess)
   }
 }
 
+std::string ConfigParser::hash() const
+{
+  return _hash;
+}
+
 int ConfigParser::readXmlFile(std::string const &filePath)
 {
   xmlSAXHandler SAXHandler;
@@ -177,6 +183,8 @@ int ConfigParser::readXmlFile(std::string const &filePath)
   PRECICE_CHECK(ifs, "XML parser was unable to open configuration file \"{}\"", filePath);
 
   std::string content{std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>()};
+
+  _hash = utils::preciceHash(content);
 
   xmlParserCtxtPtr ctxt = xmlCreatePushParserCtxt(&SAXHandler, static_cast<void *>(this),
                                                   content.c_str(), content.size(), nullptr);

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -37,6 +37,9 @@ public:
 private:
   static precice::logging::Logger _log;
 
+  /// the hash of the last processed config
+  std::string _hash;
+
   CTagPtrVec m_AllTags;
   CTagPtrVec m_CurrentTags;
 
@@ -51,6 +54,9 @@ public:
 
   /// Reads the xml file
   int readXmlFile(std::string const &filePath);
+
+  /// returns the hash of the processed XML file
+  std::string hash() const;
 
   /**
    * @brief Connects the actual tags of an xml layer with the predefined tags

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -281,7 +281,7 @@ XMLTag getRootTag()
   return XMLTag(listener, "configuration", XMLTag::OCCUR_ONCE);
 }
 
-void configure(
+std::string configure(
     XMLTag &                                  tag,
     const precice::xml::ConfigurationContext &context,
     std::string_view                          configurationFilename)
@@ -295,6 +295,8 @@ void configure(
   precice::xml::ConfigParser p(configurationFilename, context, std::make_shared<XMLTag>(tag));
 
   root.addSubtag(tag);
+
+  return p.hash();
 }
 
 std::string_view XMLTag::getOccurrenceString(XMLTag::Occurrence occurrence)

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -256,7 +256,7 @@ struct NoPListener : public XMLTag::Listener {
 XMLTag getRootTag();
 
 /// Configures the given configuration from file configurationFilename.
-void configure(
+std::string configure(
     XMLTag &                                  tag,
     const precice::xml::ConfigurationContext &context,
     std::string_view                          configurationFilename);

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(AttributeTypeTest)
   rootTag.addSubtag(testcaseTag);
 
   auto hash = configure(rootTag, ConfigurationContext{}, filename);
-  BOOST_TEST(!hash.empty());
+  BOOST_TEST(hash == "60a732f93a3a52eea0b33582a0ce0e92");
 
   BOOST_TEST(cb.boolValue == true);
   BOOST_TEST(cb.doubleValue == 3.1);
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(OccurenceTest)
   rootTag.addSubtag(testcaseTag);
 
   auto hash = configure(rootTag, ConfigurationContext{}, filename);
-  BOOST_TEST(!hash.empty());
+  BOOST_TEST(hash == "b2b2b03b807f5d0d86d77fdb2f07b42f");
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(NamespaceTest)
   rootTag.addSubtag(testcaseTag);
 
   auto hash = configure(rootTag, ConfigurationContext{}, filename);
-  BOOST_TEST(!hash.empty());
+  BOOST_TEST(hash == "758805e1fc385a73b929cc75ade90c8c");
 }
 
 struct ContextListener : public XMLTag::Listener {
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(Context)
   XMLTag               rootTag(cl, "configuration", XMLTag::OCCUR_ONCE);
   ConfigurationContext ccontext{"test", 12, 32};
   auto                 hash = configure(rootTag, ccontext, filename);
-  BOOST_TEST(!hash.empty());
+  BOOST_TEST(hash == "c63ea663514b5150ae9415d7adbb84cb");
   BOOST_TEST(cl.startContext.name == "test");
   BOOST_TEST(cl.startContext.rank == 12);
   BOOST_TEST(cl.startContext.size == 32);

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -103,7 +103,8 @@ BOOST_AUTO_TEST_CASE(AttributeTypeTest)
 
   rootTag.addSubtag(testcaseTag);
 
-  configure(rootTag, ConfigurationContext{}, filename);
+  auto hash = configure(rootTag, ConfigurationContext{}, filename);
+  BOOST_TEST(!hash.empty());
 
   BOOST_TEST(cb.boolValue == true);
   BOOST_TEST(cb.doubleValue == 3.1);
@@ -151,7 +152,8 @@ BOOST_AUTO_TEST_CASE(OccurenceTest)
 
   rootTag.addSubtag(testcaseTag);
 
-  configure(rootTag, ConfigurationContext{}, filename);
+  auto hash = configure(rootTag, ConfigurationContext{}, filename);
+  BOOST_TEST(!hash.empty());
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -174,7 +176,8 @@ BOOST_AUTO_TEST_CASE(NamespaceTest)
 
   rootTag.addSubtag(testcaseTag);
 
-  configure(rootTag, ConfigurationContext{}, filename);
+  auto hash = configure(rootTag, ConfigurationContext{}, filename);
+  BOOST_TEST(!hash.empty());
 }
 
 struct ContextListener : public XMLTag::Listener {
@@ -201,7 +204,8 @@ BOOST_AUTO_TEST_CASE(Context)
   ContextListener      cl;
   XMLTag               rootTag(cl, "configuration", XMLTag::OCCUR_ONCE);
   ConfigurationContext ccontext{"test", 12, 32};
-  configure(rootTag, ccontext, filename);
+  auto                 hash = configure(rootTag, ccontext, filename);
+  BOOST_TEST(!hash.empty());
   BOOST_TEST(cl.startContext.name == "test");
   BOOST_TEST(cl.startContext.rank == 12);
   BOOST_TEST(cl.startContext.size == 32);

--- a/tests/fundamental/DifferentConfigs-A.xml
+++ b/tests/fundamental/DifferentConfigs-A.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataOne" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="SolverTwo" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <mapping:linear-cell-interpolation
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/fundamental/DifferentConfigs-B.xml
+++ b/tests/fundamental/DifferentConfigs-B.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataOne" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="SolverTwo" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <mapping:linear-cell-interpolation
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/fundamental/DifferentConfigs.cpp
+++ b/tests/fundamental/DifferentConfigs.cpp
@@ -1,0 +1,29 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Fundamental)
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank))
+BOOST_AUTO_TEST_CASE(DifferentConfigs)
+{
+  PRECICE_TEST();
+
+  auto config = context.prefix(precice::testing::getTestName());
+  if (context.isNamed("SolverOne")) {
+    config.append("-A.xml");
+  } else {
+    config.append("-B.xml");
+  }
+
+  precice::Participant p(context.name, config, context.rank, context.size);
+
+  BOOST_CHECK_THROW(p.initialize(), ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Fundamental
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3,6 +3,7 @@
 #
 target_sources(testprecice
     PRIVATE
+    tests/fundamental/DifferentConfigs.cpp
     tests/geometric-multiscale/AxialGeoMultiscale.cpp
     tests/geometric-multiscale/RadialGeoMultiscale.cpp
     tests/parallel/CouplingOnLine.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR changes the ConfigParser to create a hash of the configuration file content and adds a cross-checking step when establishing primary connections between Participants.
The filepaths are not checked to allow for creative solutions to running in a containerized or distributed setting.

It reuses the same portable hashing we already use for the creation of communication files in `precice-run`.

## Motivation and additional information

Fixes #899

This problem pops up from time to time and even [our veterans](https://precice.discourse.group/t/adapter-advance-with-multiple-interfaces/2330/4) like waste time with this.

This is an extension of #2202

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [x] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
