### PR TITLE
Fix boost asio and cuda incompatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,7 @@ if (PRECICE_FEATURE_GINKGO_MAPPING)
     target_compile_definitions(preciceCore PUBLIC PRECICE_WITH_CUDA)
     # Required to make nvcc happy
     target_compile_definitions(preciceCore PRIVATE BOOST_PP_VARIADICS=1)
+    target_compile_definitions(preciceCore PRIVATE BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT=1)
     target_sources(preciceCore PRIVATE ${PROJECT_SOURCE_DIR}/src/mapping/device/CudaQRSolver.cuh ${PROJECT_SOURCE_DIR}/src/mapping/device/CudaQRSolver.cu)
     target_link_libraries(preciceCore PRIVATE cusolver cublas)
     message(STATUS "Enabled CUDA support for preCICE via the Ginkgo library.")

--- a/docs/changelog/2218.md
+++ b/docs/changelog/2218.md
@@ -1,0 +1,1 @@
+- Fixed incompatibility between Cuda and more recent boost (asio) versions by using BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT.

--- a/docs/changelog/2218.md
+++ b/docs/changelog/2218.md
@@ -1,1 +1,1 @@
-- Fixed incompatibility between Cuda and more recent boost (asio) versions by using BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT.
+- Fixed incompatibility between Cuda and more recent boost (asio) versions by using BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT if cuda was enabled.


### PR DESCRIPTION
## Main changes of this PR

Using cuda 12.8 and boost 1.83 with gcc13.3, I got a rather cryptic error message 

```bash
/usr/include/boost/asio/execution/any_executor.hpp:366:244:   required from ‘struct boost::asio::execution::detail::supportable_properties<0, void(boost::asio::execution::context_as_t<boost::asio::execution_context&>, boost::asio::execution::detail::blocking::never_t<0>, boost::asio::execution::prefer_only<boost::asio::execution::detail::blocking::possibly_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::tracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::untracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::fork_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::continuation_t<0> >)>::is_valid_target<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0> >’
/usr/include/boost/asio/execution/any_executor.hpp:485:8:   required from ‘struct boost::asio::execution::detail::is_valid_target_executor<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0>, void(boost::asio::execution::context_as_t<boost::asio::execution_context&>, boost::asio::execution::detail::blocking::never_t<0>, boost::asio::execution::prefer_only<boost::asio::execution::detail::blocking::possibly_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::tracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::untracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::fork_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::continuation_t<0> >)>’
/usr/include/boost/asio/any_io_executor.hpp:167:1:   required by substitution of ‘template<class Executor> boost::asio::any_io_executor::any_io_executor(Executor, typename boost::asio::constraint<typename std::conditional<((! std::is_same<OtherAnyExecutor, boost::asio::any_io_executor>::value) && (! std::is_base_of<boost::asio::execution::detail::any_executor_base, Executor>::value)), boost::asio::execution::detail::is_valid_target_executor<Executor, void(boost::asio::execution::context_as_t<boost::asio::execution_context&>, boost::asio::execution::detail::blocking::never_t<0>, boost::asio::execution::prefer_only<boost::asio::execution::detail::blocking::possibly_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::tracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::outstanding_work::untracked_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::fork_t<0> >, boost::asio::execution::prefer_only<boost::asio::execution::detail::relationship::continuation_t<0> >)>, std::integral_constant<bool, false> >::type::value>::type) [with Executor = boost::asio::io_context::basic_executor_type<std::allocator<void>, 0>]’
/usr/include/boost/asio/detail/io_object_impl.hpp:57:115:   required from ‘boost::asio::detail::io_object_impl<IoObjectService, Executor>::io_object_impl(int, int, ExecutionContext&) [with ExecutionContext = boost::asio::io_context; IoObjectService = boost::asio::detail::reactive_socket_service<boost::asio::ip::tcp>; Executor = boost::asio::any_io_executor]’
/usr/include/boost/asio/basic_socket_acceptor.hpp:154:156:   required from ‘boost::asio::basic_socket_acceptor<Protocol, Executor>::basic_socket_acceptor(ExecutionContext&, typename boost::asio::constraint<std::is_convertible<ExecutionContext&, boost::asio::execution_context&>::value>::type) [with ExecutionContext = boost::asio::io_context; Protocol = boost::asio::ip::tcp; Executor = boost::asio::any_io_executor; typename boost::asio::constraint<std::is_convertible<ExecutionContext&, boost::asio::execution_context&>::value>::type = int]’
~/precice/src/com/SocketCommunication.cpp:75:56:   required from here
/usr/include/boost/asio/traits/static_query.hpp:70:112: error: ‘‘indirect_ref’ not supported by dump_decl<declaration error>’ is not a template [-fpermissive]
   70 | struct static_query_trait<T, Property,
```

after some investigation, it boiled down to disabling some more recent behavior in boost astio, (see also the [boost docs](https://www.boost.org/doc/libs/1_87_0/doc/html/boost_asio/using.html)). Could be loosely related to build problems we faced with spack +  ginkgo. At the moment, I don't really see any alternative to this.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
