### PR TITLE
Fix size of initial gradients in zero read `CouplingData` and `_writeDataBuffer`

### DIFF
--- a/docs/changelog/2223.md
+++ b/docs/changelog/2223.md
@@ -1,0 +1,1 @@
+- Fixed bug if gradient mapping is used and substeps are exchanged.

--- a/docs/changelog/2223.md
+++ b/docs/changelog/2223.md
@@ -1,1 +1,1 @@
-- Fixed bug if gradient mapping is used and substeps are exchanged.
+- Fixed bugs due to size of gradients if gradient mapping is used and substeps are exchanged.

--- a/src/cplscheme/CouplingData.cpp
+++ b/src/cplscheme/CouplingData.cpp
@@ -114,7 +114,13 @@ void CouplingData::setGlobalSample(const time::Sample &sample)
 
 void CouplingData::initializeWithZeroAtTime(double time)
 {
-  auto zero = time::Sample(getDimensions(), nVertices());
+  if (!hasGradient()) {
+    auto zero = time::Sample(getDimensions(), nVertices());
+    zero.setZero();
+    _data->setSampleAtTime(time, zero);
+    return;
+  }
+  auto zero = time::Sample(getDimensions(), nVertices(), meshDimensions());
   zero.setZero();
   _data->setSampleAtTime(time, zero);
 }

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -110,17 +110,16 @@ void WriteDataContext::resizeBufferTo(int nVertices)
   if (_providedData->hasGradient()) {
     const SizeType spaceDimensions = getSpatialDimensions();
 
-    const SizeType expectedColumnSize = expectedSize * getDataDimensions();
-    const auto     actualColumnSize   = static_cast<SizeType>(_writeDataBuffer.gradients.cols());
+    const auto actualColumnSize = static_cast<SizeType>(_writeDataBuffer.gradients.cols());
 
     // Shrink Buffer
-    if (expectedColumnSize < actualColumnSize) {
-      _writeDataBuffer.gradients.resize(spaceDimensions, expectedColumnSize);
+    if (expectedSize < actualColumnSize) {
+      _writeDataBuffer.gradients.resize(spaceDimensions, expectedSize);
     }
 
     // Enlarge Buffer
-    if (expectedColumnSize > actualColumnSize) {
-      const auto columnLeftToAllocate = expectedColumnSize - actualColumnSize;
+    if (expectedSize > actualColumnSize) {
+      const auto columnLeftToAllocate = expectedSize - actualColumnSize;
       utils::append(_writeDataBuffer.gradients, Eigen::MatrixXd(Eigen::MatrixXd::Zero(spaceDimensions, columnLeftToAllocate)));
     }
     PRECICE_DEBUG("Gradient Data {} now has {} x {} values", getDataName(), _writeDataBuffer.gradients.rows(), _writeDataBuffer.gradients.cols());


### PR DESCRIPTION
## Main changes of this PR

Ensures that `CouplingData` initialization is done correctly for gradient data. The receive data storage needs to be initialized correctly in order to allow deserialization of data into that storage.

Ensures that `_writeDataBuffer` initially has gradients of correct size.

## Motivation and additional information

Caused failures if substeps="True" for tests with gradients due to wrong shape of initial data in `CouplingData` or `_writeDataBuffer`.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite. (see #2220)
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
