### PR TITLE
Fix direct access for serial and filtered runs

### DIFF
--- a/docs/changelog/2224.md
+++ b/docs/changelog/2224.md
@@ -1,0 +1,1 @@
+- Fixed direct mesh access (api access) to correctly read and write data in serial runs, where vertices are filtered through the defined mesh access region.

--- a/tests/serial/direct-mesh-access/DirectAccessFiltered.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessFiltered.cpp
@@ -1,0 +1,136 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+// Test case for a direct mesh access by SolverTwo to a mesh defined
+// by SolverOne.
+// Here, SolverOne defines positions {0.5, 0.25, 1.0, 0.75, 1.5, 1.25}
+// SolverTwo defines the access region {0.5, 1.5, 0.5, 1.5}, which filters
+// out the first vertex, reading and writing (should) just happen on the
+// latter two
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank))
+BOOST_AUTO_TEST_CASE(DirectAccessFiltered)
+{
+  PRECICE_TEST();
+
+  // We need to pick from this vector in both solvers
+  std::vector<double> positions({0.5, 0.25, 1.0, 0.75, 1.5, 1.25});
+  if (context.isNamed("SolverOne")) {
+    // Set up Participant
+    precice::Participant interface(context.name, context.config(), context.rank, context.size);
+    constexpr int        dim              = 2;
+    const auto           providedMeshName = "MeshOne";
+    const auto           readDataName     = "Forces";
+    const auto           writeDataName    = "Velocities";
+    BOOST_TEST(interface.getMeshDimensions(providedMeshName) == 2);
+
+    int              meshSize = positions.size() / dim;
+    std::vector<int> ids(meshSize, -1);
+    interface.setMeshVertices(providedMeshName, positions, ids);
+
+    interface.initialize();
+
+    // Some dummy writeData
+    std::vector<double> readData(meshSize * dim, -1);
+    std::vector<double> writeData(meshSize * dim, -1);
+
+    int                 time = 0;
+    std::vector<double> expectedData(meshSize * dim, 0);
+    while (interface.isCouplingOngoing()) {
+      time++;
+      double dt = interface.getMaxTimeStepSize();
+
+      // read
+      interface.readData(providedMeshName, readDataName, ids, dt, readData);
+      // BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
+
+      // expected Data (lags one dt behind due to coupling scheme)
+      std::transform(positions.begin(), positions.end(), expectedData.begin(), [&](double value) {
+        return value * value - value * time;
+      });
+
+      // We manually account for values excluded due to the access region
+      expectedData[2 * dim] = expectedData[2 * dim + 1] = 0;
+
+      // The artificial solve
+      std::transform(positions.begin(), positions.end(), writeData.begin(), [&](double value) {
+        return value * value * time;
+      });
+
+      // write
+      interface.writeData(providedMeshName, writeDataName, ids, writeData);
+      interface.advance(dt);
+    }
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    precice::Participant interface(context.name, context.config(), context.rank, context.size);
+    constexpr int        dim              = 2;
+    const auto           receivedMeshName = "MeshOne";
+    const auto           writeDataName    = "Forces";
+    const auto           readDataName     = "Velocities";
+    BOOST_TEST(interface.getMeshDimensions(receivedMeshName) == 2);
+
+    // This bounding box excludes the first vertex of the other participant
+    std::array<double, dim * 2> boundingBox{{0.5, 1.5, 0.5, 1.5}};
+    // Define region of interest, where we could obtain direct write access
+    interface.setMeshAccessRegion(receivedMeshName, boundingBox);
+
+    interface.initialize();
+    // Get the size of the filtered mesh within the bounding box
+    // (provided by the coupling participant)
+    int receivedMeshSize = interface.getMeshVertexSize(receivedMeshName);
+    BOOST_TEST(receivedMeshSize == 2);
+
+    // Allocate a vector containing the vertices
+    std::vector<double> receivedMesh(receivedMeshSize * dim);
+    std::vector<int>    receiveMeshIDs(receivedMeshSize, -1);
+    interface.getMeshVertexIDsAndCoordinates(receivedMeshName, receiveMeshIDs, receivedMesh);
+
+    // Allocate data to read and write
+    std::vector<double> readData(receivedMeshSize * dim, -1);
+    std::vector<double> writeData(receivedMeshSize * dim, -1);
+
+    // Expected data = positions of the other participant's mesh
+    auto                startIter = positions.begin() + 2;
+    auto                endIter   = positions.begin() + 6;
+    std::vector<double> expectedMesh(startIter, endIter);
+    BOOST_TEST(receivedMesh == expectedMesh, boost::test_tools::per_element());
+
+    int                 time = 0;
+    std::vector<double> expectedData(receivedMeshSize * dim, 0);
+
+    while (interface.isCouplingOngoing()) {
+      time++;
+      double dt = interface.getMaxTimeStepSize();
+
+      // read
+      interface.readData(receivedMeshName, readDataName, receiveMeshIDs, dt, readData);
+      BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
+
+      // (artificial) solve: fill writeData
+      std::transform(expectedMesh.begin(), expectedMesh.end(), writeData.begin(), [&](double value) {
+        return value * value - value * time;
+      });
+
+      interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
+      interface.advance(dt);
+
+      // the expected data lags one behind, so we generate (the same) reference solution as writeData for SolverOne, one dt later
+      std::transform(expectedMesh.begin(), expectedMesh.end(), expectedData.begin(), [&](double value) {
+        return value * value * time;
+      });
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/direct-mesh-access/DirectAccessFiltered.xml
+++ b/tests/serial/direct-mesh-access/DirectAccessFiltered.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Velocities" />
+  <data:vector name="Forces" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="Velocities" mesh="MeshOne" />
+    <read-data name="Forces" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0" api-access="true" />
+    <read-data name="Velocities" mesh="MeshOne" />
+    <write-data name="Forces" mesh="MeshOne" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="3" />
+    <time-window-size value="1.0" />
+    <exchange data="Velocities" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="Forces" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -217,6 +217,7 @@ target_sources(testprecice
     tests/serial/convergence-measures/testConvergenceMeasures2.cpp
     tests/serial/convergence-measures/testConvergenceMeasures3.cpp
     tests/serial/convergence-measures/testConvergenceMeasures4.cpp
+    tests/serial/direct-mesh-access/DirectAccessFiltered.cpp
     tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
     tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
     tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp


### PR DESCRIPTION
## Main changes of this PR

Fixes the direct mesh access (api access) to correctly read and write data in serial runs, where vertices are filtered through the defined mesh access region. We now perform the filtering step in the API (change introduced through the JIT mapping) rather then the received partition.

## Motivation and additional information

Looks like a bug:

SolverOne defines positions {0.5, 0.25, 1.0, 0.75, 1.5, 1.25}
SolverTwo defines the access region {0.5, 1.5, 0.5, 1.5}, which filters out the first vertex, reading and writing (should) just happen on the latter two.

In the test, SolverOne sends data values

0.25  0.0625  1  0.5625  2.25  1.5625

the first vertex is filtered out, `getMeshVertexCoordinatesAndIDs` gives IDs 0 and 1 (and the latter two coordinates, which is correct). However reading data yields 

0.25  0.0625  1  0.5625

but that's the data of the first two points, not the last two points

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
