### PR TITLE
Add missing `resetMesh()` on non-primary rank for `precice.Integration/Remeshing/ParallelExplicit/ChangedMapping/RemeshInput`

### DIFF
--- a/tests/remeshing/parallel-explicit/helper.hpp
+++ b/tests/remeshing/parallel-explicit/helper.hpp
@@ -215,6 +215,8 @@ inline void runResetInput(testing::TestContext &context)
           .initialize()
           .write({1.01, 1.02})
           .advance()
+          .resetMesh()
+          .setVertices({2.0, y, 3.0, y})
           .write({1.11, 1.12})
           .advance()
           .finalize();


### PR DESCRIPTION
## Main changes of this PR

Adds missing API calls in the following tests:

```
precice.Integration/Remeshing/ParallelExplicit/ChangedMapping/RemeshInput
precice.Integration/Remeshing/ParallelExplicit/ChangedMapping/RemeshInput2LI
```

## Motivation and additional information

I became aware of this inconsistency due to a failing test in #2220. The changes implemented here result in passing tests in #2220.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
