### PR TITLE
Simplify write buffer resize

### DIFF
--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -1,7 +1,5 @@
 #include "WriteDataContext.hpp"
 
-#include "utils/EigenHelperFunctions.hpp"
-
 namespace precice::impl {
 
 logging::Logger WriteDataContext::_log{"impl::WriteDataContext"};

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -95,35 +95,27 @@ void WriteDataContext::resizeBufferTo(int nVertices)
   // Allocate data values
   const SizeType expectedSize = nVertices * getDataDimensions();
   const auto     actualSize   = static_cast<SizeType>(_writeDataBuffer.values.size());
-  // Shrink Buffer
-  if (expectedSize < actualSize) {
-    _writeDataBuffer.values.resize(expectedSize);
-  }
+  const auto     change       = expectedSize - actualSize;
+
+  _writeDataBuffer.values.conservativeResize(expectedSize);
   // Enlarge Buffer
-  if (expectedSize > actualSize) {
-    const auto leftToAllocate = expectedSize - actualSize;
-    utils::append(_writeDataBuffer.values, Eigen::VectorXd(Eigen::VectorXd::Zero(leftToAllocate)));
+  if (change > 0) {
+    _writeDataBuffer.values.tail(change).setZero();
   }
   PRECICE_DEBUG("Data {} now has {} values", getDataName(), _writeDataBuffer.values.size());
 
-  // Allocate gradient data values
-  if (_providedData->hasGradient()) {
-    const SizeType spaceDimensions = getSpatialDimensions();
-
-    const auto actualColumnSize = static_cast<SizeType>(_writeDataBuffer.gradients.cols());
-
-    // Shrink Buffer
-    if (expectedSize < actualColumnSize) {
-      _writeDataBuffer.gradients.resize(spaceDimensions, expectedSize);
-    }
-
-    // Enlarge Buffer
-    if (expectedSize > actualColumnSize) {
-      const auto columnLeftToAllocate = expectedSize - actualColumnSize;
-      utils::append(_writeDataBuffer.gradients, Eigen::MatrixXd(Eigen::MatrixXd::Zero(spaceDimensions, columnLeftToAllocate)));
-    }
-    PRECICE_DEBUG("Gradient Data {} now has {} x {} values", getDataName(), _writeDataBuffer.gradients.rows(), _writeDataBuffer.gradients.cols());
+  if (!_providedData->hasGradient()) {
+    return;
   }
+
+  // Allocate gradient data values
+  _writeDataBuffer.gradients.conservativeResize(getSpatialDimensions(), expectedSize);
+
+  // Enlarge Buffer
+  if (change > 0) {
+    _writeDataBuffer.gradients.rightCols(change).setZero();
+  }
+  PRECICE_DEBUG("Gradient Data {} now has {} x {} values", getDataName(), _writeDataBuffer.gradients.rows(), _writeDataBuffer.gradients.cols());
 }
 
 void WriteDataContext::storeBufferedData(double currentTime)


### PR DESCRIPTION
## Main changes of this PR

This PR uses conservativeResize of Eigen to simplify the write buffer resize.

## Motivation and additional information

Less custom code to maintain

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
