### PR TITLE
Add nightly system tests badge in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,10 @@
 # preCICE #
 
 **Project Status**  
-[![preCICE website status](https://img.shields.io/website-up-down-green-red/https/precice.org.svg?label=website)](https://precice.org/)
+[![Build status](https://github.com/precice/precice/workflows/Build%20and%20Test/badge.svg)](https://github.com/precice/precice/actions?query=workflow%3A%22Build+and+Test%22+branch%3Adevelop)
 [![Release](https://img.shields.io/github/release/precice/precice.svg)](https://github.com/precice/precice/releases/latest)
 [![Cite](https://img.shields.io/badge/cite-literature_guide-d45815)](https://precice.org/fundamentals-literature-guide.html)
-[![preCICE distribution](https://img.shields.io/badge/preCICE_Distribution-10.18419%2Fdarus--4167-d45815.svg)](https://doi.org/10.18419/darus-4167)
 [![Software Heritage](https://archive.softwareheritage.org/badge/origin/https://github.com/precice/precice/)](https://archive.softwareheritage.org/browse/origin/?origin_url=https://github.com/precice/precice)
-[![Build status](https://github.com/precice/precice/workflows/Build%20and%20Test/badge.svg)](https://github.com/precice/precice/actions?query=workflow%3A%22Build+and+Test%22+branch%3Adevelop)
-[![System tests](https://img.shields.io/badge/system_tests-trigger_manually-blue)](https://github.com/precice/tutorials/actions/workflows/run_testsuite_manual.yml)
 
 **Project Quality**  
 [![xSDK Policy Compatibility](https://img.shields.io/badge/xSDK-member-brightgreen)](https://github.com/xsdk-project/xsdk-policy-compatibility/blob/master/precice-policy-compatibility.md)
@@ -16,6 +13,11 @@
 [![CodeQL](https://github.com/precice/precice/actions/workflows/codeql.yml/badge.svg)](https://github.com/precice/precice/actions/workflows/codeql.yml)
 [![codecov](https://codecov.io/gh/precice/precice/branch/develop/graph/badge.svg?token=ixXCTXAZMU)](https://codecov.io/gh/precice/precice)
 [![Coverity](https://scan.coverity.com/projects/19312/badge.svg)](https://scan.coverity.com/projects/precice-precice)
+
+**Downstream Components**  
+[![System tests (latest components)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml)
+[![preCICE distribution](https://img.shields.io/badge/preCICE_Distribution-10.18419%2Fdarus--4167-d45815.svg)](https://doi.org/10.18419/darus-4167)
+[![preCICE website status](https://img.shields.io/website-up-down-green-red/https/precice.org.svg?label=website)](https://precice.org/)
 
 **Community**  
 [![Join the forum](https://img.shields.io/badge/discourse-news_and_forum-orange?link=https%3A%2F%2Fprecice.discourse.group%2F)](https://precice.discourse.group/)

--- a/docs/changelog/2229.md
+++ b/docs/changelog/2229.md
@@ -1,0 +1,1 @@
+- Added nightly system tests


### PR DESCRIPTION
## Main changes of this PR

Adds a dynamic badge to the system tests workflow:

[![System tests (latest components)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml)

Clicking on the badge gives you also a manual workflow trigger, with no inputs (just takes the latest components). The fully customizable manual workflow is [this](https://github.com/precice/tutorials/actions/workflows/run_testsuite_manual.yml), which I will rename to be more easily discoverable.

The workflow should run nightly at 4am. It does not modify the commit build status and it is not connected to this repository.

Rendered as:

![Screenshot from 2025-03-18 17-45-15](https://github.com/user-attachments/assets/3026550c-45e4-4335-ab22-9e66df3d7eb4)

## Motivation and additional information

We need a way to easily check the status of these tests, and notifications are a bit tricky to set up (we need either an email account or integration with Matrix).

At the same time, we don't want them to be too intrusive and have failing system tests give the wrong impression for the library itself. Therefore, I added a category "Downstream Components" and moved the related badges there (system tests, distribution, website). I did not use "Ecosystem", as this might not be clear to first-time readers.

Also adds a changelog entry, which was missing in #2052.

## Author's checklist

* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I squashed / am about to squash all commits that should be seen as one.

