### PR TITLE
Add tests for interleaved mesh creation and data writing

### DIFF
--- a/tests/fundamental/initial-data/InterleavedCreation.cpp
+++ b/tests/fundamental/initial-data/InterleavedCreation.cpp
@@ -1,0 +1,47 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Fundamental)
+BOOST_AUTO_TEST_SUITE(InitialData)
+PRECICE_TEST_SETUP("PA"_on(1_rank), "PB"_on(1_rank))
+BOOST_AUTO_TEST_CASE(InterleavedCreation)
+{
+  PRECICE_TEST();
+
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+
+  if (context.isNamed("PA")) {
+    BOOST_TEST(p.requiresInitialData());
+    std::array<double, 1> d1{1}, d2{2}, d3{3}, d4{4};
+    std::array<double, 2> p1{0.0, 0.0}, p2{0.0, 1.0}, p3{1.0, 0.0}, p4{1.0, 1.0};
+    auto                  v1 = p.setMeshVertex("MA", p1);
+    p.writeData("MA", "DA", {&v1, 1}, d1);
+    auto v2 = p.setMeshVertex("MA", p2);
+    p.writeData("MA", "DA", {&v2, 1}, d2);
+    auto v3 = p.setMeshVertex("MA", p3);
+    p.writeData("MA", "DA", {&v3, 1}, d3);
+    auto v4 = p.setMeshVertex("MA", p4);
+    p.writeData("MA", "DA", {&v4, 1}, d4);
+    p.initialize();
+  } else {
+    std::array<precice::VertexID, 4> vids;
+    std::vector<double>              pos{0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0};
+    p.setMeshVertices("MB", pos, vids);
+    p.initialize();
+    std::array<double, 4> data;
+    p.readData("MB", "DA", vids, 0, data);
+    std::vector<double> expected{1.0, 2.0, 3.0, 4.0};
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // InitialData
+BOOST_AUTO_TEST_SUITE_END() // Fundamental
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/fundamental/initial-data/InterleavedCreation.xml
+++ b/tests/fundamental/initial-data/InterleavedCreation.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DA" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+  </mesh>
+
+  <participant name="PA">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="PB" />
+    <write-data name="DA" mesh="MA" />
+    <mapping:nearest-neighbor direction="write" from="MA" to="MB" constraint="consistent" />
+  </participant>
+
+  <participant name="PB">
+    <provide-mesh name="MB" />
+    <read-data name="DA" mesh="MB" />
+  </participant>
+
+  <m2n:sockets acceptor="PA" connector="PB" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="PA" second="PB" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="DA" mesh="MB" from="PA" to="PB" initialize="true" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/fundamental/initial-data/InterleavedCreationWithGradients.cpp
+++ b/tests/fundamental/initial-data/InterleavedCreationWithGradients.cpp
@@ -1,0 +1,53 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Fundamental)
+BOOST_AUTO_TEST_SUITE(InitialData)
+PRECICE_TEST_SETUP("PA"_on(1_rank), "PB"_on(1_rank))
+BOOST_AUTO_TEST_CASE(InterleavedCreationWithGradients)
+{
+  PRECICE_TEST();
+
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+
+  if (context.isNamed("PA")) {
+    BOOST_TEST(p.requiresInitialData());
+    BOOST_TEST(p.requiresGradientDataFor("MA", "DA"));
+    std::array<double, 1> d1{1}, d2{2}, d3{3}, d4{4};
+    std::array<double, 2> g1{1, 1}, g2{2, 2}, g3{3, 3}, g4{4, 4};
+    std::array<double, 2> p1{1.0, 0.0}, p2{2.0, 0.0}, p3{3.0, 0.0}, p4{4.0, 0.0};
+    auto                  v1 = p.setMeshVertex("MA", p1);
+    p.writeData("MA", "DA", {&v1, 1}, d1);
+    p.writeGradientData("MA", "DA", {&v1, 1}, g1);
+    auto v2 = p.setMeshVertex("MA", p2);
+    p.writeData("MA", "DA", {&v2, 1}, d2);
+    p.writeGradientData("MA", "DA", {&v2, 1}, g2);
+    auto v3 = p.setMeshVertex("MA", p3);
+    p.writeData("MA", "DA", {&v3, 1}, d3);
+    p.writeGradientData("MA", "DA", {&v3, 1}, g3);
+    auto v4 = p.setMeshVertex("MA", p4);
+    p.writeData("MA", "DA", {&v4, 1}, d4);
+    p.writeGradientData("MA", "DA", {&v4, 1}, g4);
+    p.initialize();
+  } else {
+    std::array<precice::VertexID, 4> vids;
+    std::vector<double>              pos{1.0, 1.0, 2.0, 1.0, 3.0, 1.0, 4.0, 1.0};
+    p.setMeshVertices("MB", pos, vids);
+    p.initialize();
+    std::array<double, 4> data;
+    p.readData("MB", "DA", vids, 0, data);
+    std::vector<double> expected{2.0, 4.0, 6.0, 8.0};
+    BOOST_TEST(data == expected, boost::test_tools::per_element());
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // InitialData
+BOOST_AUTO_TEST_SUITE_END() // Fundamental
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/fundamental/initial-data/InterleavedCreationWithGradients.xml
+++ b/tests/fundamental/initial-data/InterleavedCreationWithGradients.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration experimental="true">
+  <data:scalar name="DA" />
+
+  <mesh name="MA" dimensions="2">
+    <use-data name="DA" />
+  </mesh>
+
+  <mesh name="MB" dimensions="2">
+    <use-data name="DA" />
+  </mesh>
+
+  <participant name="PA">
+    <provide-mesh name="MA" />
+    <receive-mesh name="MB" from="PB" />
+    <write-data name="DA" mesh="MA" />
+    <mapping:nearest-neighbor-gradient
+      direction="write"
+      from="MA"
+      to="MB"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="PB">
+    <provide-mesh name="MB" />
+    <read-data name="DA" mesh="MB" />
+  </participant>
+
+  <m2n:sockets acceptor="PA" connector="PB" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="PA" second="PB" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="DA" mesh="MB" from="PA" to="PB" initialize="true" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -5,6 +5,7 @@ target_sources(testprecice
     PRIVATE
     tests/fundamental/DifferentConfigs.cpp
     tests/fundamental/initial-data/InterleavedCreation.cpp
+    tests/fundamental/initial-data/InterleavedCreationWithGradients.cpp
     tests/fundamental/profiling/NotAllStopped.cpp
     tests/fundamental/profiling/NotStoppedAtFinalize.cpp
     tests/fundamental/profiling/UserProfiling.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -4,6 +4,7 @@
 target_sources(testprecice
     PRIVATE
     tests/fundamental/DifferentConfigs.cpp
+    tests/fundamental/initial-data/InterleavedCreation.cpp
     tests/fundamental/profiling/NotAllStopped.cpp
     tests/fundamental/profiling/NotStoppedAtFinalize.cpp
     tests/fundamental/profiling/UserProfiling.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds tests for interleaving mesh creation and data writing.

## Motivation and additional information

This is currently untested and thus also the logic of resizing write buffers while maintaining data.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
