### PR TITLE
Invalidate write data buffer after repartitioning

### DIFF
--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1665,10 +1665,11 @@ void ParticipantImpl::computePartitions()
 
     meshContext->mesh->allocateDataValues();
 
+    // Should be relevant for direct mesh access only
     const auto requiredSize = meshContext->mesh->nVertices();
     for (auto &context : _accessor->writeDataContexts()) {
       if (context.getMeshName() == meshContext->mesh->getName()) {
-        context.resizeBufferTo(requiredSize);
+        context.resizeBufferTo(requiredSize, true);
       }
     }
   }

--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -86,7 +86,7 @@ void WriteDataContext::writeGradientsIntoDataBuffer(::precice::span<const Vertex
   }
 }
 
-void WriteDataContext::resizeBufferTo(int nVertices)
+void WriteDataContext::resizeBufferTo(int nVertices, bool invalidateBufferedData)
 {
   using SizeType = std::remove_cv<decltype(nVertices)>::type;
 
@@ -100,6 +100,9 @@ void WriteDataContext::resizeBufferTo(int nVertices)
   if (change > 0) {
     _writeDataBuffer.values.tail(change).setZero();
   }
+  if (invalidateBufferedData)
+    _writeDataBuffer.values.setConstant(-1);
+
   PRECICE_DEBUG("Data {} now has {} values", getDataName(), _writeDataBuffer.values.size());
 
   if (!_providedData->hasGradient()) {
@@ -113,6 +116,10 @@ void WriteDataContext::resizeBufferTo(int nVertices)
   if (change > 0) {
     _writeDataBuffer.gradients.rightCols(change).setZero();
   }
+
+  if (invalidateBufferedData)
+    _writeDataBuffer.gradients.setConstant(-1);
+
   PRECICE_DEBUG("Gradient Data {} now has {} x {} values", getDataName(), _writeDataBuffer.gradients.rows(), _writeDataBuffer.gradients.cols());
 }
 

--- a/src/precice/impl/WriteDataContext.hpp
+++ b/src/precice/impl/WriteDataContext.hpp
@@ -84,7 +84,7 @@ public:
    */
   void writeGradientsIntoDataBuffer(::precice::span<const VertexID> vertices, ::precice::span<const double> gradients);
 
-  void resizeBufferTo(int size);
+  void resizeBufferTo(int size, bool invalidateBufferedData = false);
 
   /**
    * @brief Store data from _writeDataBuffer in persistent storage


### PR DESCRIPTION
## Main changes of this PR

invalidate the write buffer after repartitioning it.

## Motivation and additional information

The write buffer is closely connected to the mesh. If we change the mesh, the currently buffered data automatically becomes invalid. There is no connection between the currently stored data and the new layout.
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
