### PR TITLE
Handle substeps with remeshing

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -263,9 +263,9 @@ void Mesh::clear()
   _tetrahedra.clear();
   _index.clear();
 
+  clearDataStamples();
   for (mesh::PtrData &data : _data) {
     data->values().resize(0);
-    data->timeStepsStorage().clear();
   }
 }
 
@@ -277,6 +277,13 @@ void Mesh::clearPartitioning()
   _vertexDistribution.clear();
   _vertexOffsets.clear();
   _globalNumberOfVertices = 0;
+}
+
+void Mesh::clearDataStamples()
+{
+  for (mesh::PtrData &data : _data) {
+    data->timeStepsStorage().clear();
+  }
 }
 
 bool Mesh::isPartitionEmpty(Rank rank) const

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -233,6 +233,9 @@ public:
   /// Clears the partitioning information
   void clearPartitioning();
 
+  /// Clears all data stamples
+  void clearDataStamples();
+
   void setVertexDistribution(VertexDistribution vd)
   {
     PRECICE_ASSERT(std::all_of(vd.begin(), vd.end(), [](const auto &p) { return std::is_sorted(p.second.begin(), p.second.end()); }));

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1964,9 +1964,9 @@ ParticipantImpl::MeshChanges ParticipantImpl::getTotalMeshChanges() const
   utils::IntraComm::allreduceSum(localMeshChanges, totalMeshChanges);
 
   // Convert the doubles to int
-  MeshChanges totalMeshChangesI(totalMeshChanges.begin(), totalMeshChanges.end());
-  PRECICE_DEBUG("Mesh changes of participant: {}", totalMeshChangesI);
-  return totalMeshChangesI;
+  MeshChanges totalMeshChangesInt(totalMeshChanges.begin(), totalMeshChanges.end());
+  PRECICE_DEBUG("Mesh changes of participant: {}", totalMeshChangesInt);
+  return totalMeshChangesInt;
 }
 
 void ParticipantImpl::clearStamplesOfChangedMeshes(MeshChanges totalMeshChanges)

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1974,9 +1974,7 @@ void ParticipantImpl::clearStamplesOfChangedMeshes(MeshChanges totalMeshChanges)
   auto meshContexts = _accessor->usedMeshContexts();
   for (std::size_t i = 0; i < totalMeshChanges.size(); ++i) {
     if (totalMeshChanges[i] > 0.0) {
-      for (auto d : meshContexts[i]->mesh->data()) {
-        d->timeStepsStorage().clear();
-      }
+      meshContexts[i]->mesh->clearDataStamples();
     }
   }
 }

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -480,10 +480,16 @@ private:
   /// Discards send (currently write) data of a participant after a given time when another iteration is required
   void trimSendDataAfter(double time);
 
+  /// How many ranks have changed each used mesh
+  using MeshChanges = std::vector<int>;
+
   /** Allreduce of the amount of changed meshes on each rank.
-   * @return the total amount of changed meshes of all ranks on each rank
+   * @return a vector of the size of meshcontexts which contain the amount of ranks that changed each mesh
    */
-  int getTotalMeshChanges() const;
+  MeshChanges getTotalMeshChanges() const;
+
+  /// Clears stample of changed meshes to make them consistent after the reinitialization.
+  void clearStamplesOfChangedMeshes(MeshChanges totalMeshChanges);
 
   /** Exchanges request to remesh with all connecting participants.
    *


### PR DESCRIPTION
## Main changes of this PR

This PR removes all existing stamples of all ranks if at least one rank resets the mesh.
This is required to keep timestamps consistent among all ranks of a solver.

## Motivation and additional information

Related to and tested by #2198

Closes #2233

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
