### PR TITLE
Prevent write data with api access and remeshing

### DIFF
--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -635,6 +635,11 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     _participants.back()->addAction(std::move(action));
   }
 
+  // Check for unsupported remeshing options
+  for (auto &context : participant->writeDataContexts()) {
+    PRECICE_CHECK(participant->meshContext(context.getMeshName()).provideMesh || !(participant->isDirectAccessAllowed(context.getMeshName()) && _remeshing), "Writing data via API access (configuration <write-data ... mesh=\"{}\") is not (yet) supported with remeshing", context.getMeshName());
+  }
+
   // Add export contexts
   for (io::ExportContext &exportContext : _exportConfig->exportContexts()) {
     auto kind = exportContext.everyIteration ? io::Export::ExportKind::Iterations : io::Export::ExportKind::TimeWindows;

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -269,10 +269,6 @@ void ParticipantImpl::initialize()
   _meshLock.lockAll();
 
   for (auto &context : _accessor->writeDataContexts()) {
-    PRECICE_CHECK(_accessor->meshContext(context.getMeshName()).provideMesh || !(_accessor->isDirectAccessAllowed(context.getMeshName()) && _allowsRemeshing), "Writing data via API access (configuration <write-data ... mesh=\"{}\") is not (yet) supported with remeshing", context.getMeshName());
-  }
-
-  for (auto &context : _accessor->writeDataContexts()) {
     const double startTime = 0.0;
     context.storeBufferedData(startTime);
   }

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -257,6 +257,10 @@ void ParticipantImpl::initialize()
                 "Initial data has to be written to preCICE before calling initialize(). "
                 "After defining your mesh, call requiresInitialData() to check if the participant is required to write initial data using the writeData() function.");
 
+  for (auto &context : _accessor->writeDataContexts()) {
+    PRECICE_CHECK(!_accessor->isDirectAccessAllowed(context.getMeshName()), "Writing data via API access (configuration <write-data ... mesh=\"{}\") is not (yet) supported with remeshing", context.getMeshName());
+  }
+
   // Enforce that all user-created events are stopped to prevent incorrect nesting.
   PRECICE_CHECK(_userEvents.empty(), "There are unstopped user defined events. Please stop them using stopLastProfilingSection() before calling initialize().");
 


### PR DESCRIPTION
## Main changes of this PR

Prevent write data with api access and remeshing

## Motivation and additional information

See https://github.com/precice/precice/issues/2094

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
