### PR TITLE
Forbid slashes in event names

### DIFF
--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -1190,7 +1190,7 @@ public:
    *
    * All active sections must be stopped before calling initialize() or advance().
    *
-   * \param[in] sectionName the name of the profiling section to start
+   * \param[in] sectionName the name of the profiling section to start. The name may not contain forward slashes `/`.
    *
    */
   void startProfilingSection(::precice::string_view sectionName);

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1992,6 +1992,9 @@ bool ParticipantImpl::reinitHandshake(bool requestReinit) const
 
 void ParticipantImpl::startProfilingSection(std::string_view sectionName)
 {
+  PRECICE_CHECK(std::find(sectionName.begin(), sectionName.end(), '/') == sectionName.end(),
+                "The provided section name \"{}\" may not contain a forward-slash \"/\"",
+                sectionName);
   _userEvents.emplace_back(sectionName, profiling::Fundamental);
 }
 

--- a/src/profiling/Event.cpp
+++ b/src/profiling/Event.cpp
@@ -10,7 +10,8 @@ Event::Event(std::string_view eventName, Options options)
 {
   auto &er   = EventRegistry::instance();
   auto  name = std::string(eventName);
-  _eid       = er.nameToID(name);
+  PRECICE_ASSERT(eventName.find('/') == std::string_view::npos);
+  _eid = er.nameToID(name);
   if (_synchronize && er.parallel()) {
     _sid = er.nameToID(name + ".sync");
   }

--- a/tests/fundamental/profiling/InvalidName.cpp
+++ b/tests/fundamental/profiling/InvalidName.cpp
@@ -1,0 +1,24 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Fundamental)
+BOOST_AUTO_TEST_SUITE(Profiling)
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank));
+BOOST_AUTO_TEST_CASE(InvalidName)
+{
+  PRECICE_TEST();
+
+  precice::Participant p(context.name, context.config(), context.rank, context.size);
+
+  BOOST_CHECK_THROW(p.startProfilingSection("not/allowed"), ::precice::Error);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Profiling
+BOOST_AUTO_TEST_SUITE_END() // Fundamental
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/fundamental/profiling/InvalidName.xml
+++ b/tests/fundamental/profiling/InvalidName.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataOne" />
+
+  <mesh name="MeshOne" dimensions="3">
+    <use-data name="DataOne" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="DataOne" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="SolverTwo" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -6,6 +6,7 @@ target_sources(testprecice
     tests/fundamental/DifferentConfigs.cpp
     tests/fundamental/initial-data/InterleavedCreation.cpp
     tests/fundamental/initial-data/InterleavedCreationWithGradients.cpp
+    tests/fundamental/profiling/InvalidName.cpp
     tests/fundamental/profiling/NotAllStopped.cpp
     tests/fundamental/profiling/NotStoppedAtFinalize.cpp
     tests/fundamental/profiling/UserProfiling.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR forbids slashes `/` in event names, both as a check in the API and an assertion in the event itself.

## Motivation and additional information

This would break the nesting functionality in the `precice-profiling` scripts.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
