### PR TITLE
Enable exports in tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,6 +582,7 @@ IF (BUILD_TESTING)
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED Yes
     CXX_EXTENSIONS No
+    ENABLE_EXPORTS Yes
     )
   target_include_directories(testprecice PRIVATE
     ${preCICE_SOURCE_DIR}/src


### PR DESCRIPTION
## Main changes of this PR

This tests enables symbol exports in the testprecice binary.

## Motivation and additional information

This improves stacktraces in `testprecice` which significantly improves the debugging experience.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
