### PR TITLE
Fix a dangling reference in python actions

### DIFF
--- a/src/action/PythonAction.cpp
+++ b/src/action/PythonAction.cpp
@@ -95,44 +95,62 @@ void PythonAction::performAction()
     initialize();
   }
 
-  PyObject *dataArgs = PyTuple_New(_numberArguments);
+  if (!_sourceData) {
+    PyObject *dataArgs = PyTuple_New(_numberArguments);
+    for (auto &targetStample : _targetData->stamples()) {
+      PyObject *pythonTime = PyFloat_FromDouble(targetStample.timestamp);
+      PyTuple_SetItem(dataArgs, 0, pythonTime);
 
-  int i = 0;
-  for (auto &targetStample : _targetData->stamples()) { // iterate over _targetData, because it must always exist
-    PRECICE_ASSERT(_targetData);                        // _targetData is mandatory, cannot call setSampleAtTime, if target data is not provided!
+      npy_intp targetDim[]  = {targetStample.sample.values.size()};
+      double * targetValues = const_cast<double *>(targetStample.sample.values.data());
+      _targetValues         = PyArray_SimpleNewFromData(1, targetDim, NPY_DOUBLE, targetValues);
+      PRECICE_CHECK(_targetValues != nullptr, "Creating python target values failed. Please check that the target data name is used by the mesh in action:python.");
+      PyTuple_SetItem(dataArgs, 1, _targetValues);
+
+      PyObject_CallObject(_performAction, dataArgs);
+      PRECICE_CHECK(!PyErr_Occurred(),
+                    "Error occurred during call of function performAction() in python module \"{}\". "
+                    "The error message is: {}",
+                    _moduleName, python_error_as_string());
+    }
+
+    _targetData->setGlobalSample(_targetData->stamples().back().sample);
+    Py_DECREF(dataArgs);
+    return;
+  }
+
+  PyObject *dataArgs       = PyTuple_New(_numberArguments);
+  auto      targetStamples = _targetData->stamples();
+  auto      sourceStamples = _sourceData->stamples();
+  PRECICE_CHECK(targetStamples.size() == sourceStamples.size(), "Cannot perform python actions on different amount of samples in target and source data.");
+
+  for (size_t i = 0; i < targetStamples.size(); ++i) {
+    auto &targetStample = targetStamples[i];
+    auto &sourceStample = sourceStamples[i];
+    PRECICE_CHECK(math::equals(sourceStample.timestamp, targetStample.timestamp), "Trying to perform python action on samples with different timestamps: {} for source data and {} for target data. Time mesh of source data and target data must agree.", sourceStample.timestamp, targetStample.timestamp);
 
     PyObject *pythonTime = PyFloat_FromDouble(targetStample.timestamp);
     PyTuple_SetItem(dataArgs, 0, pythonTime);
 
-    if (_sourceData) {                                     // _sourceData is optional
-      auto &sourceStample   = _sourceData->stamples()[i];  // simultaneously iterate over _targetData->stamples()
-      _sourceData->values() = sourceStample.sample.values; // put data into temporary buffer
-      PRECICE_CHECK(math::equals(sourceStample.timestamp, targetStample.timestamp), "Trying to perform python action on samples with different timestamps: {} for source data and {} for target data. Time mesh of source data and target data must agree.", sourceStample.timestamp, targetStample.timestamp);
-      i++;
-      npy_intp sourceDim[]  = {_sourceData->values().size()};
-      double * sourceValues = _sourceData->values().data();
-      _sourceValues         = PyArray_SimpleNewFromData(1, sourceDim, NPY_DOUBLE, sourceValues);
-      PRECICE_CHECK(_sourceValues != nullptr, "Creating python source values failed. Please check that the source data name is used by the mesh in action:python.");
-      PyTuple_SetItem(dataArgs, 1, _sourceValues);
-    }
+    npy_intp sourceDim[]  = {sourceStample.sample.values.size()};
+    double * sourceValues = const_cast<double *>(sourceStample.sample.values.data());
+    _sourceValues         = PyArray_SimpleNewFromData(1, sourceDim, NPY_DOUBLE, sourceValues);
+    PRECICE_CHECK(_sourceValues != nullptr, "Creating python source values failed. Please check that the source data name is used by the mesh in action:python.");
+    PyTuple_SetItem(dataArgs, 1, _sourceValues);
 
-    _targetData->values() = targetStample.sample.values; // put data into temporary buffer
-    npy_intp targetDim[]  = {_targetData->values().size()};
-    double * targetValues = _targetData->values().data();
-    // PRECICE_ASSERT(_targetValues == NULL);
-    _targetValues = PyArray_SimpleNewFromData(1, targetDim, NPY_DOUBLE, targetValues);
+    npy_intp targetDim[]  = {targetStample.sample.values.size()};
+    double * targetValues = const_cast<double *>(targetStample.sample.values.data());
+    _targetValues         = PyArray_SimpleNewFromData(1, targetDim, NPY_DOUBLE, targetValues);
     PRECICE_CHECK(_targetValues != nullptr, "Creating python target values failed. Please check that the target data name is used by the mesh in action:python.");
-    int argumentIndex = _sourceData ? 2 : 1;
-    PyTuple_SetItem(dataArgs, argumentIndex, _targetValues);
+    PyTuple_SetItem(dataArgs, 2, _targetValues);
 
     PyObject_CallObject(_performAction, dataArgs);
     PRECICE_CHECK(!PyErr_Occurred(),
                   "Error occurred during call of function performAction() in python module \"{}\". "
                   "The error message is: {}",
                   _moduleName, python_error_as_string());
-
-    _targetData->setSampleAtTime(targetStample.timestamp, _targetData->sample());
   }
+  _targetData->setGlobalSample(_targetData->stamples().back().sample);
   Py_DECREF(dataArgs);
 }
 

--- a/src/action/tests/PythonActionTest.cpp
+++ b/src/action/tests/PythonActionTest.cpp
@@ -33,22 +33,20 @@ BOOST_AUTO_TEST_CASE(PerformActionWithGlobalIterationsCounter)
   std::string  path = testing::getPathToSources() + "/action/tests/";
   PythonAction action(PythonAction::WRITE_MAPPING_POST, path, "TestAction", mesh, targetID, sourceID);
 
-  Eigen::VectorXd v(3);
-  v << 0.1, 0.2, 0.3;
-  mesh->data(sourceID)->setSampleAtTime(1, time::Sample{1, v});
-  mesh->data(targetID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->nVertices())});
+  mesh->data(sourceID)->emplaceSampleAtTime(1, {0.1, 0.2, 0.3});
+  mesh->data(targetID)->emplaceSampleAtTime(1, {0.0, 0.0, 0.0});
 
   action.performAction();
 
   Eigen::VectorXd result(3);
   result << 1.1, 1.2, 1.3;
-  BOOST_TEST(testing::equals(mesh->data(targetID)->values(), result));
-  mesh->data(sourceID)->setSampleAtTime(1, time::Sample{1, Eigen::VectorXd::Zero(mesh->nVertices())});
+  BOOST_TEST(testing::equals(mesh->data(targetID)->stamples().back().sample.values, result));
+  mesh->data(sourceID)->emplaceSampleAtTime(1, {0.0, 0.0, 0.0});
 
   action.performAction();
 
   result << 2.0, 2.0, 2.0;
-  BOOST_TEST(testing::equals(mesh->data(targetID)->values(), result));
+  BOOST_TEST(testing::equals(mesh->data(targetID)->stamples().back().sample.values, result));
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Python


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a dangling reference in the python actions when using a source term.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
