### PR TITLE
General warnings cleanup

### DIFF
--- a/src/action/tests/SummationActionTest.cpp
+++ b/src/action/tests/SummationActionTest.cpp
@@ -218,15 +218,15 @@ BOOST_AUTO_TEST_CASE(SummationThreeDimensionalSubcycling)
 
   // Load and check data from 0.5
 
-  auto &loadedStample1 = sourceData1->stamples().front();
+  auto loadedStample1 = sourceData1->stamples().front();
   BOOST_TEST(loadedStample1.timestamp == 0.5);
   sourceData1->values() = loadedStample1.sample.values;
 
-  auto &loadedStample2 = sourceData2->stamples().front();
+  auto loadedStample2 = sourceData2->stamples().front();
   BOOST_TEST(loadedStample2.timestamp == 0.5);
   sourceData2->values() = loadedStample2.sample.values;
 
-  auto &loadedStample3 = targetData->stamples().front();
+  auto loadedStample3 = targetData->stamples().front();
   BOOST_TEST(loadedStample3.timestamp == 0.5);
   targetData->values() = loadedStample3.sample.values;
 

--- a/src/com/SerializedStamples.cpp
+++ b/src/com/SerializedStamples.cpp
@@ -30,7 +30,7 @@ SerializedStamples SerializedStamples::empty(int nTimeStamps, const cplscheme::C
 
 void SerializedStamples::deserializeInto(precice::span<const double> timeStamps, cplscheme::CouplingData &data)
 {
-  PRECICE_ASSERT(_timeSteps == timeStamps.size());
+  PRECICE_ASSERT(_timeSteps == static_cast<int>(timeStamps.size()));
 
   deserialize(timeStamps, data);
 }
@@ -71,13 +71,13 @@ void SerializedStamples::serializeGradients(const cplscheme::CouplingData &data)
 
 void SerializedStamples::deserialize(precice::span<const double> timeStamps, cplscheme::CouplingData &data) const
 {
-  PRECICE_ASSERT(timeStamps.size() * data.getSize() == _values.size(), timeStamps.size() * data.getSize(), _values.size());
+  PRECICE_ASSERT(static_cast<int>(timeStamps.size()) * data.getSize() == _values.size(), timeStamps.size() * data.getSize(), _values.size());
 
   data.timeStepsStorage().clear(); // @todo needs optimization. Don't need to communicate and serialize / deserialize data at beginning of window, because it is already there.
 
   const auto dataDims = data.getDimensions();
 
-  for (int timeId = 0; timeId < timeStamps.size(); timeId++) {
+  for (int timeId = 0; timeId < static_cast<int>(timeStamps.size()); timeId++) {
     const double time = timeStamps[timeId];
 
     Eigen::VectorXd slice(data.getSize());

--- a/src/com/tests/SerializedStamplesTest.cpp
+++ b/src/com/tests/SerializedStamplesTest.cpp
@@ -22,7 +22,6 @@ BOOST_AUTO_TEST_CASE(SerializeValues)
   PRECICE_TEST();
   std::vector<int> vertexOffsets{4, 8, 8, 10};
 
-  const int meshDimensions = 3;
   const int dataDimensions = 1;
   const int nValues        = 4;
   const int nTimeSteps     = 3;

--- a/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ExplicitCouplingSchemeTest.cpp
@@ -327,7 +327,6 @@ BOOST_AUTO_TEST_CASE(testSimpleExplicitCoupling)
   const double maxTime        = 1.0;
   const int    maxTimeWindows = 10;
   const double timeWindowSize = 0.1;
-  const double timeStepSize   = timeWindowSize; // solver is not subcycling
   std::string  nameParticipant0("Participant0");
   std::string  nameParticipant1("Participant1");
   int          sendDataIndex    = -1;
@@ -704,7 +703,6 @@ BOOST_AUTO_TEST_CASE(testExplicitCouplingWithSubcycling)
   const double maxTime        = 1.0;
   const int    maxTimeWindows = 10;
   const double timeWindowSize = 0.1;
-  const double timeStepSize   = timeWindowSize; // solver is not subcycling
   std::string  nameParticipant0("Participant0");
   std::string  nameParticipant1("Participant1");
   int          sendDataIndex    = -1;

--- a/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/ParallelImplicitCouplingSchemeTest.cpp
@@ -78,8 +78,6 @@ BOOST_AUTO_TEST_CASE(testInitializeData)
 
   xml::XMLTag root = xml::getRootTag();
 
-  int dimensions = 3;
-
   // Create a data configuration, to simplify configuration of data
   mesh::PtrDataConfiguration dataConfig(new mesh::DataConfiguration(root));
   dataConfig->addData("Data0", mesh::Data::typeName::SCALAR);

--- a/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/SerialImplicitCouplingSchemeTest.cpp
@@ -444,8 +444,6 @@ BOOST_AUTO_TEST_CASE(testParseConfigurationWithRelaxation)
   PRECICE_TEST();
   using namespace mesh;
 
-  int dimensions = 3;
-
   std::string path(_pathToTests + "serial-implicit-cplscheme-relax-const-config.xml");
 
   xml::XMLTag                          root = xml::getRootTag();
@@ -475,8 +473,6 @@ BOOST_AUTO_TEST_CASE(testAbsConvergenceMeasureSynchronized)
   auto m2n                  = context.connectPrimaryRanks("Participant0", "Participant1", options);
 
   using namespace mesh;
-
-  int dimensions = 3;
 
   xml::XMLTag root = xml::getRootTag();
   // Create a data configuration, to simplify configuration of data
@@ -536,8 +532,6 @@ BOOST_AUTO_TEST_CASE(testConfiguredAbsConvergenceMeasureSynchronized)
   PRECICE_TEST();
 
   using namespace mesh;
-
-  int dimensions = 3;
 
   std::string configurationPath(
       _pathToTests + "serial-implicit-cplscheme-absolute-config.xml");

--- a/src/mapping/tests/NearestProjectionMappingTest.cpp
+++ b/src/mapping/tests/NearestProjectionMappingTest.cpp
@@ -573,17 +573,6 @@ BOOST_AUTO_TEST_CASE(ScaledConsistentQuery3DFullMesh)
 
 namespace {
 using namespace precice::mesh;
-const Eigen::VectorXd &runNPMapping(mapping::Mapping::Constraint constraint, PtrMesh &inMesh, PtrData &inData, PtrMesh &outMesh, PtrData &outData)
-{
-  BOOST_REQUIRE(inMesh->getDimensions() == outMesh->getDimensions());
-  precice::mapping::NearestProjectionMapping mapping(constraint, inMesh->getDimensions());
-  mapping.setMeshes(inMesh, outMesh);
-  BOOST_REQUIRE(mapping.hasComputedMapping() == false);
-  mapping.computeMapping();
-  BOOST_REQUIRE(mapping.hasComputedMapping() == true);
-  mapping.map(inData->getID(), outData->getID());
-  return outData->values();
-}
 const Eigen::VectorXd &runNPMapping(mapping::Mapping::Constraint constraint, PtrMesh &inMesh, Eigen::VectorXd *inData, PtrMesh &outMesh, Eigen::VectorXd *outData)
 {
   BOOST_REQUIRE(inMesh->getDimensions() == outMesh->getDimensions());

--- a/src/mapping/tests/PartitionOfUnityMappingTest.cpp
+++ b/src/mapping/tests/PartitionOfUnityMappingTest.cpp
@@ -82,8 +82,8 @@ void perform2DTestConsistentMapping(Mapping &mapping)
   mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
-  mesh::Vertex &vertex1   = outMesh->createVertex(Vector2d(3.5, 0.5));
-  mesh::Vertex &vertex2   = outMesh->createVertex(Vector2d(2.5, 0.5));
+  outMesh->createVertex(Vector2d(3.5, 0.5));
+  outMesh->createVertex(Vector2d(2.5, 0.5));
   // vertex will be changed
   outMesh->createVertex(Vector2d(0, 0));
   outMesh->createVertex(Vector2d(5, 1));
@@ -216,8 +216,8 @@ void perform2DTestConsistentMappingVector(Mapping &mapping)
   mesh::PtrData outData   = outMesh->createData("OutData", dataDimensions, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector2d(0, 0));
-  mesh::Vertex &vertex1   = outMesh->createVertex(Vector2d(3.5, 0.5));
-  mesh::Vertex &vertex2   = outMesh->createVertex(Vector2d(2.5, 0.5));
+  outMesh->createVertex(Vector2d(3.5, 0.5));
+  outMesh->createVertex(Vector2d(2.5, 0.5));
   // vertex will be changed
   outMesh->createVertex(Vector2d(0, 0));
   outMesh->createVertex(Vector2d(5, 1));
@@ -389,9 +389,9 @@ void perform2DTestConservativeMapping(Mapping &mapping)
   int           inDataID = inData->getID();
 
   // vertices will be changed
-  mesh::Vertex &vertex  = inMesh->createVertex(Vector2d(1.0, 0.0));
-  mesh::Vertex &vertex1 = inMesh->createVertex(Vector2d(3.5, 0.0));
-  mesh::Vertex &vertex2 = inMesh->createVertex(Vector2d(2.5, 0.5));
+  inMesh->createVertex(Vector2d(1.0, 0.0));
+  inMesh->createVertex(Vector2d(3.5, 0.0));
+  inMesh->createVertex(Vector2d(2.5, 0.5));
 
   inMesh->createVertex(Vector2d(0, 0));
   inMesh->createVertex(Vector2d(5, 1));
@@ -486,8 +486,8 @@ void perform2DTestConservativeMappingVector(Mapping &mapping)
   mesh::PtrData inData   = inMesh->createData("InData", dataDimensions, 0_dataID);
   DataID        inDataID = inData->getID();
   mesh::Vertex &vertex   = inMesh->createVertex(Vector2d(0, 0));
-  mesh::Vertex &vertex1  = inMesh->createVertex(Vector2d(3.5, 0.5));
-  mesh::Vertex &vertex2  = inMesh->createVertex(Vector2d(2.5, 0.5));
+  inMesh->createVertex(Vector2d(3.5, 0.5));
+  inMesh->createVertex(Vector2d(2.5, 0.5));
   // vertex will be changed
   inMesh->createVertex(Vector2d(0, 0));
   inMesh->createVertex(Vector2d(5, 1));
@@ -673,8 +673,8 @@ void perform3DTestConsistentMapping(Mapping &mapping)
   mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector3d(0, 0, 0));
-  mesh::Vertex &vertex1   = outMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
-  mesh::Vertex &vertex2   = outMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
+  outMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
+  outMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
   outMesh->createVertex(Vector3d(0, 0, 0.5));
   outMesh->createVertex(Vector3d(5, 1, 0.5));
   outMesh->allocateDataValues();
@@ -776,8 +776,7 @@ void perform3DTestJustInTimeMappingWithPolynomial(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", dataComponents, 0_dataID);
-  int           inDataID = inData->getID();
+  mesh::PtrData inData = inMesh->createData("InData", dataComponents, 0_dataID);
   inMesh->createVertex(Eigen::Vector3d(0.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(1.0, 0.0, 0.0));
   inMesh->createVertex(Eigen::Vector3d(1.0, 1.0, 0.0));
@@ -944,8 +943,7 @@ void perform2DTestJustInTimeMappingNoPolynomial(Mapping &mapping)
 
   // Create mesh to map from
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
-  mesh::PtrData inData   = inMesh->createData("InData", dataComponents, 0_dataID);
-  int           inDataID = inData->getID();
+  mesh::PtrData inData = inMesh->createData("InData", dataComponents, 0_dataID);
   inMesh->createVertex(Eigen::Vector2d(0.0, 0.0));
   inMesh->createVertex(Eigen::Vector2d(1.0, 0.0));
   inMesh->createVertex(Eigen::Vector2d(1.0, 1.0));
@@ -1149,9 +1147,9 @@ void perform3DTestConsistentMappingVector(Mapping &mapping)
   mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData outData   = outMesh->createData("OutData", dataDimensions, 1_dataID);
   int           outDataID = outData->getID();
-  mesh::Vertex &vertex    = outMesh->createVertex(Vector3d(0, 0, 0));
-  mesh::Vertex &vertex1   = outMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
-  mesh::Vertex &vertex2   = outMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
+  outMesh->createVertex(Vector3d(0, 0, 0));
+  outMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
+  outMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
   outMesh->createVertex(Vector3d(0, 0, 0.5));
   outMesh->createVertex(Vector3d(5, 1, 0.5));
   outMesh->allocateDataValues();
@@ -1206,9 +1204,9 @@ void perform3DTestConservativeMapping(Mapping &mapping)
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", 1, 0_dataID);
   const DataID  inDataID = inData->getID();
-  mesh::Vertex &vertex   = inMesh->createVertex(Vector3d(0, 0, 0));
-  mesh::Vertex &vertex1  = inMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
-  mesh::Vertex &vertex2  = inMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
+  inMesh->createVertex(Vector3d(0, 0, 0));
+  inMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
+  inMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
   inMesh->createVertex(Vector3d(1, 1, 1));
   inMesh->createVertex(Vector3d(5, 1, 0.5));
   inMesh->allocateDataValues();
@@ -1649,9 +1647,9 @@ void perform3DTestConservativeMappingVector(Mapping &mapping)
   mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", dimensions, testing::nextMeshID()));
   mesh::PtrData inData   = inMesh->createData("InData", dataDimension, 0_dataID);
   const DataID  inDataID = inData->getID();
-  mesh::Vertex &vertex   = inMesh->createVertex(Vector3d(0, 0, 0));
-  mesh::Vertex &vertex1  = inMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
-  mesh::Vertex &vertex2  = inMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
+  inMesh->createVertex(Vector3d(0, 0, 0));
+  inMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
+  inMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
   inMesh->createVertex(Vector3d(1, 1, 1));
   inMesh->createVertex(Vector3d(5, 1, 0.5));
   inMesh->allocateDataValues();
@@ -1885,8 +1883,8 @@ BOOST_AUTO_TEST_CASE(TestSingleClusterPartitionOfUnity)
   mesh::PtrData outData   = outMesh->createData("OutData", 1, 1_dataID);
   int           outDataID = outData->getID();
   mesh::Vertex &vertex    = outMesh->createVertex(Vector3d(0, 0, 0));
-  mesh::Vertex &vertex1   = outMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
-  mesh::Vertex &vertex2   = outMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
+  outMesh->createVertex(Vector3d(3.5, 0.5, 0.5));
+  outMesh->createVertex(Vector3d(2.5, 0.5, 1.0));
   outMesh->createVertex(Vector3d(0, 0, 0.5));
   outMesh->createVertex(Vector3d(5, 1, 0.5));
   outMesh->allocateDataValues();

--- a/src/mesh/tests/MeshTest.cpp
+++ b/src/mesh/tests/MeshTest.cpp
@@ -154,10 +154,9 @@ BOOST_AUTO_TEST_CASE(Demonstration)
     BOOST_TEST(mesh.edges().size() == 3);
     BOOST_TEST(!mesh.hasTriangles());
 
-    Triangle *t = nullptr;
     if (dim == 3) {
       // Create triangle
-      t = &mesh.createTriangle(e0, e1, e2);
+      mesh.createTriangle(e0, e1, e2);
 
       BOOST_TEST(mesh.hasTriangles());
     } else {

--- a/src/query/tests/RTreeTests.cpp
+++ b/src/query/tests/RTreeTests.cpp
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(Query3DFullTriangle)
   auto &       tlt = mesh->createTriangle(ell, elt, eld);
   auto &       tlb = mesh->createTriangle(eld, elb, elr);
   auto &       trt = mesh->createTriangle(erl, ert, erd);
-  auto &       trb = mesh->createTriangle(erd, erb, err);
+  mesh->createTriangle(erd, erb, err);
 
   Index indexTree(mesh);
 

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -240,9 +240,9 @@ void TestContext::initializePetsc()
 void TestContext::initializeGinkgo()
 {
   if (!invalid && _setup.ginkgo) {
+#ifndef PRECICE_NO_GINKGO
     int    argc = 0;
     char **argv;
-#ifndef PRECICE_NO_GINKGO
     precice::device::Ginkgo::initialize(&argc, &argv);
 #endif
   }

--- a/tests/parallel/direct-mesh-access/helpers.cpp
+++ b/tests/parallel/direct-mesh-access/helpers.cpp
@@ -33,7 +33,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
 
     // According to the bounding boxes and vertices: the primary rank receives 3 vertices, the secondary rank 2
     const bool expectedSize = (context.isPrimary() && meshSize == 3) ||
-                              (!context.isPrimary() && meshSize == expectedPositionSecondaryRank.size() / dim);
+                              (!context.isPrimary() && meshSize == static_cast<int>(expectedPositionSecondaryRank.size()) / dim);
     BOOST_TEST(expectedSize);
 
     // Allocate memory
@@ -47,7 +47,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
 
     // Check the received vertex IDs (IDs are local?!)
     std::vector<int> expectedIDs;
-    for (std::size_t i = 0; i < meshSize; ++i)
+    for (std::size_t i = 0; i < static_cast<size_t>(meshSize); ++i)
       expectedIDs.emplace_back(i);
     BOOST_TEST(expectedIDs == ids);
 
@@ -63,7 +63,7 @@ void runTestAccessReceivedMesh(const TestContext &       context,
       } else {
         // Corresponds semantically to meshSize - startIndex > 0
         // but meshSize - startIndex > 0 might underflow and the static analysis complained
-        if (meshSize > startIndex) {
+        if (meshSize > static_cast<int>(startIndex)) {
           const int *ids_ptr  = &ids.at(startIndex);
           const auto vertices = meshSize - startIndex;
           interface.writeData(otherMeshName, dataName, {ids_ptr, vertices}, {writeData.data(), vertices});

--- a/tests/parallel/direct-mesh-access/helpers.cpp
+++ b/tests/parallel/direct-mesh-access/helpers.cpp
@@ -71,7 +71,6 @@ void runTestAccessReceivedMesh(const TestContext &       context,
       }
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
     }
   } else {
     // Defines the mesh and reads data

--- a/tests/serial/ImplicitCheckpointing.cpp
+++ b/tests/serial/ImplicitCheckpointing.cpp
@@ -13,13 +13,6 @@ BOOST_AUTO_TEST_CASE(ImplicitCheckpointing)
   PRECICE_TEST();
   /// Test simple implicit coupling with checkpointing. Checks correct tracking of time, see https://github.com/precice/precice/pull/1704.
 
-  double state              = 0.0;
-  double checkpoint         = 0.0;
-  int    iterationCount     = 0;
-  double initialStateChange = 5.0;
-  double stateChange        = initialStateChange;
-  int    computedTimesteps  = 0;
-
   precice::Participant interface(context.name, context.config(), context.rank, context.size);
 
   if (context.isNamed("SolverOne")) {

--- a/tests/serial/SummationActionTwoSources.cpp
+++ b/tests/serial/SummationActionTwoSources.cpp
@@ -58,7 +58,6 @@ BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
       BOOST_TEST(valueD == expectedValueD);
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
     }
 
     interface.finalize();
@@ -97,7 +96,6 @@ BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
       interface.writeData(meshName, dataAID, {&idD, 1}, {&valueD, 1});
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
     }
     interface.finalize();
   } else {
@@ -136,7 +134,6 @@ BOOST_AUTO_TEST_CASE(SummationActionTwoSources)
       interface.writeData(meshName, dataAID, {&idD, 1}, {&valueD, 1});
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
     }
 
     interface.finalize();

--- a/tests/serial/action-timings/ActionTimingsParallelExplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsParallelExplicit.cpp
@@ -66,7 +66,6 @@ BOOST_AUTO_TEST_CASE(ActionTimingsParallelExplicit)
     interface.readData(meshName, readDataName, {&vertexID, 1}, dt, readData);
     interface.writeData(meshName, writeDataName, {&vertexID, 1}, writeData);
     interface.advance(dt);
-    double dt = interface.getMaxTimeStepSize();
     BOOST_TEST(interface.isTimeWindowComplete());
     iteration++;
 

--- a/tests/serial/action-timings/ActionTimingsParallelImplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsParallelImplicit.cpp
@@ -69,7 +69,6 @@ BOOST_AUTO_TEST_CASE(ActionTimingsParallelImplicit)
     if (interface.requiresWritingCheckpoint()) {
     }
     interface.advance(dt);
-    double dt = interface.getMaxTimeStepSize();
     if (interface.requiresReadingCheckpoint()) {
     }
     if (interface.isTimeWindowComplete()) {

--- a/tests/serial/action-timings/ActionTimingsSerialExplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsSerialExplicit.cpp
@@ -66,7 +66,6 @@ BOOST_AUTO_TEST_CASE(ActionTimingsSerialExplicit)
     interface.readData(meshName, readDataName, {&vertexID, 1}, dt, readData);
     interface.writeData(meshName, writeDataName, {&vertexID, 1}, writeData);
     interface.advance(dt);
-    double dt = interface.getMaxTimeStepSize();
     BOOST_TEST(interface.isTimeWindowComplete());
     iteration++;
 

--- a/tests/serial/action-timings/ActionTimingsSerialImplicit.cpp
+++ b/tests/serial/action-timings/ActionTimingsSerialImplicit.cpp
@@ -69,7 +69,6 @@ BOOST_AUTO_TEST_CASE(ActionTimingsSerialImplicit)
     if (interface.requiresWritingCheckpoint()) {
     }
     interface.advance(dt);
-    double dt = interface.getMaxTimeStepSize();
     if (interface.requiresReadingCheckpoint()) {
     }
     if (interface.isTimeWindowComplete()) {

--- a/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessReadWrite.cpp
@@ -54,7 +54,6 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
       BOOST_TEST(precice::testing::equals(expectedData, readData));
       interface.writeData(providedMeshName, writeDataName, ids, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing
@@ -110,7 +109,6 @@ BOOST_AUTO_TEST_CASE(DirectAccessReadWrite)
       BOOST_TEST(precice::testing::equals(expectedData, readData));
       interface.writeData(receivedMeshName, writeDataName, receiveMeshIDs, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing

--- a/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithDataInitialization.cpp
@@ -84,7 +84,6 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
       BOOST_TEST(precice::testing::equals(expectedData, readData));
       interface.writeData(otherMeshID, writeDataID, otherIDs, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing
@@ -161,7 +160,6 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithDataInitialization)
       BOOST_TEST(precice::testing::equals(expectedData, readData));
       interface.writeData(meshName, writeDataName, ids, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing

--- a/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
+++ b/tests/serial/direct-mesh-access/DirectAccessWithWaveform.cpp
@@ -80,7 +80,6 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
       BOOST_TEST(precice::testing::equals(expectedData, readData));
       interface.writeData(otherMeshName, writeDataName, otherIDs, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing
@@ -146,7 +145,6 @@ BOOST_AUTO_TEST_CASE(DirectAccessWithWaveform)
       BOOST_TEST(precice::testing::equals(expectedData, readData));
       interface.writeData(meshID, writeDataID, ids, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing

--- a/tests/serial/direct-mesh-access/ExplicitReadNoFlag.cpp
+++ b/tests/serial/direct-mesh-access/ExplicitReadNoFlag.cpp
@@ -29,7 +29,6 @@ BOOST_AUTO_TEST_CASE(ExplicitReadNoFlag)
 
   if (context.isNamed("SolverOne")) {
     auto otherMeshName = "MeshTwo";
-    auto dataName      = "Velocities";
     BOOST_REQUIRE(couplingInterface.getMeshDimensions(otherMeshName) == 2);
 
     // Check for thwrowing when trying to set the region

--- a/tests/serial/just-in-time-mapping/ExplicitReadPUM.cpp
+++ b/tests/serial/just-in-time-mapping/ExplicitReadPUM.cpp
@@ -59,10 +59,8 @@ BOOST_AUTO_TEST_CASE(ExplicitReadPUM)
 
     couplingInterface.initialize();
 
-    double time = 0;
     while (couplingInterface.isCouplingOngoing()) {
       double dt = couplingInterface.getMaxTimeStepSize();
-      time += dt;
 
       // read data (for reference)
       std::vector<double> readData(meshSize);
@@ -132,7 +130,7 @@ BOOST_AUTO_TEST_CASE(ExplicitReadPUM)
 
     // Quadratic filling for writeData2
     std::generate(writeData2.begin(), writeData2.end(), [n = 0]() mutable {
-      return -100.0 + 0.1 * (n * n++); // Quadratic pattern, n^2 scaled by 0.1
+      return -100.0 + 0.1 * std::pow(n++, 2); // Quadratic pattern, n^2 scaled by 0.1
     });
 
     // vectorData1 with linearly increasing values

--- a/tests/serial/just-in-time-mapping/ExplicitWrite.cpp
+++ b/tests/serial/just-in-time-mapping/ExplicitWrite.cpp
@@ -69,7 +69,6 @@ BOOST_AUTO_TEST_CASE(ExplicitWrite)
       // Check that we catch vertice not within the access region.
       {
         std::vector<double> solverTwoCoord(dim);
-        double              value;
         for (int d = 0; d < dim; ++d) {
           solverTwoCoord[d] = 100 * tmpPositions[d];
         }

--- a/tests/serial/just-in-time-mapping/ImplicitDataInitialization.cpp
+++ b/tests/serial/just-in-time-mapping/ImplicitDataInitialization.cpp
@@ -84,7 +84,6 @@ BOOST_AUTO_TEST_CASE(ImplicitDataInitialization)
       BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
       interface.writeAndMapData(otherMeshID, writeDataID, ownPositions, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing
@@ -161,7 +160,6 @@ BOOST_AUTO_TEST_CASE(ImplicitDataInitialization)
       BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
       interface.writeData(meshName, writeDataName, ids, writeData);
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
       iterations++;
       if (interface.requiresReadingCheckpoint()) {
         // do nothing

--- a/tests/serial/just-in-time-mapping/ImplicitWithWaveform.cpp
+++ b/tests/serial/just-in-time-mapping/ImplicitWithWaveform.cpp
@@ -44,7 +44,6 @@ BOOST_AUTO_TEST_CASE(ImplicitWithWaveform)
     std::vector<int> ownIDs(size, -1);
     interface.setMeshVertices(ownMeshName, positions, ownIDs);
 
-    std::array<double, dim * 2> boundingBox = std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.0, 0.0, 1.0};
     // Define region of interest, where we could obtain direct write access
     // Combined with a mapping: setting the access region is (in serial) optional
     // Hence, we omit this line

--- a/tests/serial/multi-coupling/helpers.cpp
+++ b/tests/serial/multi-coupling/helpers.cpp
@@ -14,7 +14,6 @@ void multiCouplingTwoSolvers(const std::string configFile, const TestContext &co
 
   double valueA = 1.0;
   double valueB = 2.0;
-  double valueC = 3.0;
 
   if (context.isNamed("SolverA")) {
     Participant cplInterface("SolverA", configFile, 0, 1);

--- a/tests/serial/parallel-coupling/helpers.cpp
+++ b/tests/serial/parallel-coupling/helpers.cpp
@@ -13,7 +13,6 @@ void parallelCoupling(const std::string configFile, const TestContext &context)
 
   double valueA = 1.0;
   double valueB = 2.0;
-  double valueC = 3.0;
 
   if (context.isNamed("SolverA")) {
     Participant cplInterface("SolverA", configFile, 0, 1);

--- a/tests/serial/three-solvers/helpers.cpp
+++ b/tests/serial/three-solvers/helpers.cpp
@@ -17,7 +17,6 @@ void runTestThreeSolvers(std::string const &config, std::vector<int> expectedCal
   int callsOfAdvance = 0;
 
   double v0[] = {0, 0};
-  double v1[] = {1, 1};
 
   if (context.isNamed("SolverOne")) {
     precice::Participant precice(context.name, config, 0, 1);

--- a/tests/serial/time/explicit/compositional/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/explicit/compositional/DoNothingWithSubcycling.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
     nSubsteps = 3;
   }
 
-  double   v0[]     = {0, 0, 0};
-  VertexID vertexID = precice.setMeshVertex(meshName, v0);
+  double v0[] = {0, 0, 0};
+  precice.setMeshVertex(meshName, v0);
 
   int totalSolves             = 0;
   int totalCompletedTimesteps = 0;

--- a/tests/serial/time/explicit/parallel-coupling/DoManySmallSteps.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/DoManySmallSteps.cpp
@@ -37,14 +37,10 @@ BOOST_AUTO_TEST_CASE(DoManySmallSteps)
     readDataName  = "DataOne";
   }
 
-  double writeData, readData;
+  double writeData;
 
   double   v0[]     = {0, 0, 0};
   VertexID vertexID = precice.setMeshVertex(meshName, v0);
-
-  int    timestep   = 0;
-  int    timewindow = 0;
-  double time       = 0;
 
   if (precice.requiresInitialData()) {
     writeData = 1; // don't care

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -91,8 +91,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
     precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
 
     precice.advance(currentDt);
-    double maxDt = precice.getMaxTimeStepSize();
-    currentDt    = solverDt > preciceDt ? preciceDt : solverDt;
+    currentDt = solverDt > preciceDt ? preciceDt : solverDt;
     timestep++;
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
@@ -91,8 +91,7 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcyclingNoSubsteps)
     precice.writeData(meshName, writeDataName, {&vertexID, 1}, {&writeData, 1});
 
     precice.advance(currentDt);
-    double maxDt = precice.getMaxTimeStepSize();
-    currentDt    = solverDt > preciceDt ? preciceDt : solverDt;
+    currentDt = solverDt > preciceDt ? preciceDt : solverDt;
     timestep++;
     if (precice.isTimeWindowComplete()) {
       timewindow++;

--- a/tests/serial/time/explicit/parallel-coupling/helpers.cpp
+++ b/tests/serial/time/explicit/parallel-coupling/helpers.cpp
@@ -23,14 +23,10 @@ void subcyclingWithNSteps(TestContext const &context, int nSubsteps, bool useAdv
     readDataName  = "DataOne";
   }
 
-  double writeData, readData;
+  double writeData;
 
   double   v0[]     = {0, 0, 0};
   VertexID vertexID = precice.setMeshVertex(meshName, v0);
-
-  int    timestep   = 0;
-  int    timewindow = 0;
-  double time       = 0;
 
   if (precice.requiresInitialData()) {
     writeData = 1; // don't care

--- a/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -75,7 +75,6 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   double expectedDts[] = {4.0 / 7.0, 4.0 / 7.0, 4.0 / 7.0, 2.0 / 7.0}; // If solver uses timestep size of 4/7, fourth step will be restricted to 2/7 via preCICE steering to fit into the window.
 
   while (precice.isCouplingOngoing()) {
-    double readTime;
     double preciceDt = precice.getMaxTimeStepSize();
     double currentDt = solverDt > preciceDt ? preciceDt : solverDt; // determine actual time step size; must fit into remaining time in window
 

--- a/tests/serial/time/helpers.cpp
+++ b/tests/serial/time/helpers.cpp
@@ -25,7 +25,6 @@ void doManySteps(TestContext const &context)
   double   v0[]     = {0, 0, 0};
   VertexID vertexID = precice.setMeshVertex(meshName, v0);
   precice.initialize();
-  double dt = precice.getMaxTimeStepSize();
 
   while (precice.isCouplingOngoing()) {
     double dt = precice.getMaxTimeStepSize();

--- a/tests/serial/time/implicit/compositional/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/implicit/compositional/DoNothingWithSubcycling.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
     nSubsteps = 3;
   }
 
-  double   v0[]     = {0, 0, 0};
-  VertexID vertexID = precice.setMeshVertex(meshName, v0);
+  double v0[] = {0, 0, 0};
+  precice.setMeshVertex(meshName, v0);
 
   int totalSolves             = 0;
   int totalCompletedTimesteps = 0;

--- a/tests/serial/time/implicit/helpers.cpp
+++ b/tests/serial/time/implicit/helpers.cpp
@@ -12,10 +12,6 @@ void checkinit(const TestContext &context)
 
   Participant precice(context.name, context.config(), 0, 1);
 
-  MeshID meshID;
-  DataID writeDataID;
-  DataID readDataID;
-
   typedef double (*DataFunction)(double);
 
   DataFunction dataOneFunction = [](double t) -> double {
@@ -62,7 +58,6 @@ void checkinit(const TestContext &context)
 
   precice.initialize();
   double maxDt     = precice.getMaxTimeStepSize();
-  double windowDt  = maxDt;
   double dt        = maxDt;
   double currentDt = dt; // Timestep length used by solver
 

--- a/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/DoNothingWithSubcycling.cpp
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(DoNothingWithSubcycling)
     nSubsteps = 3;
   }
 
-  double   v0[]     = {0, 0, 0};
-  VertexID vertexID = precice.setMeshVertex(meshName, v0);
+  double v0[] = {0, 0, 0};
+  precice.setMeshVertex(meshName, v0);
 
   int totalSolves             = 0;
   int totalCompletedTimesteps = 0;

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcycling.cpp
@@ -72,7 +72,6 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcycling)
   int    timewindow      = 0;
   double windowStartTime = 0;
   int    windowStartStep = 0;
-  int    nSamples        = 4;
   int    iterations      = 0;
   double time            = 0;
 

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithSubcyclingNoSubsteps.cpp
@@ -74,7 +74,6 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithSubcyclingNoSubsteps)
   int    timewindow      = 0;
   double windowStartTime = 0;
   int    windowStartStep = 0;
-  int    nSamples        = 4;
   int    iterations      = 0;
   double time            = 0;
 

--- a/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
+++ b/tests/serial/time/implicit/multi-coupling/ReadWriteScalarDataWithWaveformSubcyclingDifferentDts.cpp
@@ -78,7 +78,6 @@ BOOST_AUTO_TEST_CASE(ReadWriteScalarDataWithWaveformSubcyclingDifferentDts)
   int    timewindow      = 0;
   double windowStartTime = 0;
   int    windowStartStep = 0;
-  int    nSamples        = 4;
   int    iterations      = 0;
   double time            = 0;
 

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAcceleration.cpp
@@ -23,10 +23,6 @@ BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAcceleration)
 
   Participant precice(context.name, context.config(), 0, 1);
 
-  MeshID meshID;
-  DataID writeDataID;
-  DataID readDataID;
-
   typedef double (*DataFunction)(double);
 
   DataFunction dataOneFunction = [](double t) -> double {
@@ -61,7 +57,6 @@ BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAcceleration)
   vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps          = 7; // perform subcycling on solvers. 4 steps happen in each window.
-  int    nWindows           = 5; // perform 5 windows.
   int    timestep           = 0;
   double time               = 0;
   int    timestepCheckpoint = timestep;

--- a/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
+++ b/tests/serial/time/implicit/serial-coupling/WaveformSubcyclingWithConstantAccelerationNoInit.cpp
@@ -23,10 +23,6 @@ BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAccelerationNoInit)
 
   Participant precice(context.name, context.config(), 0, 1);
 
-  MeshID meshID;
-  DataID writeDataID;
-  DataID readDataID;
-
   typedef double (*DataFunction)(double);
 
   DataFunction dataOneFunction = [](double t) -> double {
@@ -61,7 +57,6 @@ BOOST_AUTO_TEST_CASE(WaveformSubcyclingWithConstantAccelerationNoInit)
   vertexID = precice.setMeshVertex(meshName, v0);
 
   int    nSubsteps          = 7; // perform subcycling on solvers. 4 steps happen in each window.
-  int    nWindows           = 5; // perform 5 windows.
   int    timestep           = 0;
   double time               = 0;
   int    timestepCheckpoint = timestep;

--- a/tests/serial/watch/WatchIntegralScaleAndNoScaleParallel.cpp
+++ b/tests/serial/watch/WatchIntegralScaleAndNoScaleParallel.cpp
@@ -46,7 +46,6 @@ BOOST_AUTO_TEST_CASE(WatchIntegralScaleAndNoScaleParallel)
       interface.writeData(meshName, dataOneID, ids, values);
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
 
       for (int i = 0; i < nVertices; i++) {
         values[i] += increment;

--- a/tests/serial/watch/WatchIntegralScaleAndNoScaleSerial.cpp
+++ b/tests/serial/watch/WatchIntegralScaleAndNoScaleSerial.cpp
@@ -49,7 +49,6 @@ BOOST_AUTO_TEST_CASE(WatchIntegralScaleAndNoScaleSerial)
       interface.writeData(meshName, dataOneID, ids, values);
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
 
       for (int i = 0; i < nVertices; i++) {
         values[i] += increment;

--- a/tests/serial/watch/WatchPointParallel.cpp
+++ b/tests/serial/watch/WatchPointParallel.cpp
@@ -39,7 +39,6 @@ BOOST_AUTO_TEST_CASE(WatchPointParallel)
       interface.writeData(meshName, dataOneID, {&id, 1}, {&value, 1});
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
 
       value += increment;
     }
@@ -53,7 +52,7 @@ BOOST_AUTO_TEST_CASE(WatchPointParallel)
 
     auto meshTwoID = "MeshTwo";
 
-    int id = interface.setMeshVertex(meshTwoID, coord);
+    interface.setMeshVertex(meshTwoID, coord);
 
     // Initialize the mesh
     interface.initialize();

--- a/tests/serial/watch/WatchPointSerial.cpp
+++ b/tests/serial/watch/WatchPointSerial.cpp
@@ -39,7 +39,6 @@ BOOST_AUTO_TEST_CASE(WatchPointSerial)
       interface.writeData(meshName, dataOneID, {&id, 1}, {&value, 1});
 
       interface.advance(dt);
-      double dt = interface.getMaxTimeStepSize();
 
       value += increment;
     }
@@ -53,7 +52,7 @@ BOOST_AUTO_TEST_CASE(WatchPointSerial)
 
     auto meshTwoID = "MeshTwo";
 
-    int id = interface.setMeshVertex(meshTwoID, coord);
+    interface.setMeshVertex(meshTwoID, coord);
 
     // Initialize the mesh
     interface.initialize();

--- a/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
+++ b/tests/serial/whitebox/TestExplicitWithDataScaling.cpp
@@ -47,7 +47,6 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
       }
       cplInterface.writeData(meshName, velocitiesID, ids, data);
       cplInterface.advance(dt);
-      double dt = cplInterface.getMaxTimeStepSize();
     }
     cplInterface.finalize();
   } else {
@@ -75,7 +74,6 @@ BOOST_AUTO_TEST_CASE(TestExplicitWithDataScaling)
       BOOST_TEST(data == expected, boost::test_tools::per_element());
 
       cplInterface.advance(dt);
-      double dt = cplInterface.getMaxTimeStepSize();
     }
     cplInterface.finalize();
   }


### PR DESCRIPTION
## Main changes of this PR

This PR cleans up warnings, mostly regarding unused variables and sign compares.

## Motivation and additional information

Have a clean release

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
