### PR TITLE
Rename develop preset to development

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,7 +30,7 @@
       }
     },
     {
-      "name": "develop",
+      "name": "development",
       "inherits": "base",
       "displayName": "Development",
       "description": "Development config with default settings",
@@ -69,7 +69,7 @@
     },
     {
       "name": "profiling",
-      "inherits": "develop",
+      "inherits": "development",
       "displayName": "Profiling",
       "description": "Profiling configuration",
       "cacheVariables": {

--- a/docs/changelog/2241.md
+++ b/docs/changelog/2241.md
@@ -1,0 +1,1 @@
+- Renamed the `develop` CMake preset to `development`.


### PR DESCRIPTION
## Main changes of this PR

This PR renames the `develop` CMake preset to `development`.

## Motivation and additional information

Currently, the preset is called the same as the develop branch.
It has caused some confusion with the term "develop version of preCICE", where a user build a release with the develop preset instead of building the develop branch.

This could break some CIs.

~User-documentation needs to be updated.~ User-documentation doesn't mention the develop preset.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
