### PR TITLE
Fix type of param in `writeAndMapData` doc

### DIFF
--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -921,7 +921,7 @@ public:
    * @param[in] coordinates A span to the coordinates of the vertices
    *        The 2D-format is (d0x, d0y, d1x, d1y, ..., dnx, dny)
    *        The 3D-format is (d0x, d0y, d0z, d1x, d1y, d1z, ..., dnx, dny, dnz)
-   * @param[out] values The values containing the write data.
+   * @param[in] values The values containing the write data.
    *
    * @pre The coordinates are within the bounding box previously defined via \ref setMeshAccessRegion(). Using coordinates
    * outside the defined bounding box will throw an error.


### PR DESCRIPTION
## Main changes of this PR

The parameter `values` in the API function `writeAndMapData` should be an input parameter.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I squashed / am about to squash all commits that should be seen as one.

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
