### PR TITLE
Basic Misusage tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
   rev: 'v4.3.0'
   hooks:
   - id: check-xml
+    exclude: "^src/precice/tests/emptyconfig.xml"
   - id: check-merge-conflict
   - id: mixed-line-ending
     exclude: "^thirdparty"
@@ -32,6 +33,7 @@ repos:
   hooks:
   - id: format-precice-config
     name: format preCICE configs
+    exclude: "^src/precice/tests/emptyconfig.xml"
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.2
   hooks:

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -817,7 +817,7 @@ void ParticipantImpl::setMeshVertices(
   const auto expectedPositionSize = ids.size() * meshDims;
   PRECICE_CHECK(positions.size() == expectedPositionSize,
                 "Input sizes are inconsistent attempting to set vertices on {}D mesh \"{}\". "
-                "You passed {} vertices indices and {} position components, but we expected {} position components ({} x {}).",
+                "You passed {} vertex indices and {} position components, but we expected {} position components ({} x {}).",
                 meshDims, meshName, ids.size(), positions.size(), expectedPositionSize, ids.size(), meshDims);
 
   Event                                   e{fmt::format("setMeshVertices.{}", meshName), profiling::Fundamental};
@@ -870,7 +870,7 @@ void ParticipantImpl::setMeshEdges(
   mesh::PtrMesh &mesh = context.mesh;
   PRECICE_CHECK(vertices.size() % 2 == 0,
                 "Cannot interpret passed vertex IDs attempting to set edges of mesh \"{}\" . "
-                "You passed {} vertices, but we expected an even number.",
+                "You passed {} vertex indices, but we expected an even number.",
                 meshName, vertices.size());
   {
     auto end           = vertices.end();
@@ -944,7 +944,7 @@ void ParticipantImpl::setMeshTriangles(
   mesh::PtrMesh &mesh = context.mesh;
   PRECICE_CHECK(vertices.size() % 3 == 0,
                 "Cannot interpret passed vertex IDs attempting to set triangles of mesh \"{}\" . "
-                "You passed {} vertices, which isn't dividable by 3.",
+                "You passed {} vertex indices, which isn't dividable by 3.",
                 meshName, vertices.size());
   {
     auto end           = vertices.end();
@@ -1037,7 +1037,7 @@ void ParticipantImpl::setMeshQuads(
   mesh::Mesh &mesh = *(context.mesh);
   PRECICE_CHECK(vertices.size() % 4 == 0,
                 "Cannot interpret passed vertex IDs attempting to set quads of mesh \"{}\" . "
-                "You passed {} vertices, which isn't dividable by 4.",
+                "You passed {} vertex indices, which isn't dividable by 4.",
                 meshName, vertices.size());
   {
     auto end           = vertices.end();
@@ -1132,7 +1132,7 @@ void ParticipantImpl::setMeshTetrahedra(
   mesh::PtrMesh &mesh = context.mesh;
   PRECICE_CHECK(vertices.size() % 4 == 0,
                 "Cannot interpret passed vertex IDs attempting to set quads of mesh \"{}\" . "
-                "You passed {} vertices, which isn't dividable by 4.",
+                "You passed {} vertex indices, which isn't dividable by 4.",
                 meshName, vertices.size());
   {
     auto end           = vertices.end();
@@ -1180,7 +1180,7 @@ void ParticipantImpl::writeData(
   const auto expectedDataSize = vertices.size() * dataDims;
   PRECICE_CHECK(expectedDataSize == values.size(),
                 "Input sizes are inconsistent attempting to write {}D data \"{}\" to mesh \"{}\". "
-                "You passed {} vertices and {} data components, but we expected {} data components ({} x {}).",
+                "You passed {} vertex indices and {} data components, but we expected {} data components ({} x {}).",
                 dataDims, dataName, meshName,
                 vertices.size(), values.size(), expectedDataSize, dataDims, vertices.size());
 
@@ -1231,7 +1231,7 @@ void ParticipantImpl::readData(
   const auto expectedDataSize = vertices.size() * dataDims;
   PRECICE_CHECK(expectedDataSize == values.size(),
                 "Input/Output sizes are inconsistent attempting to read {}D data \"{}\" from mesh \"{}\". "
-                "You passed {} vertices and {} data components, but we expected {} data components ({} x {}).",
+                "You passed {} vertex indices and {} data components, but we expected {} data components ({} x {}).",
                 dataDims, dataName, meshName,
                 vertices.size(), values.size(), expectedDataSize, dataDims, vertices.size());
 
@@ -1300,7 +1300,7 @@ void ParticipantImpl::mapAndReadData(
   // Make use of the read data context
   PRECICE_CHECK(nVertices * dataDims == values.size(),
                 "Input sizes are inconsistent attempting to mapAndRead {}D data \"{}\" from mesh \"{}\". "
-                "You passed {} vertices and {} data components, but we expected {} data components ({} x {}).",
+                "You passed {} vertex indices and {} data components, but we expected {} data components ({} x {}).",
                 dataDims, dataName, meshName,
                 nVertices, values.size(), nVertices * dataDims, dataDims, nVertices);
 
@@ -1352,7 +1352,7 @@ void ParticipantImpl::writeAndMapData(
 
   PRECICE_CHECK(nVertices * dataDims == values.size(),
                 "Input sizes are inconsistent attempting to write {}D data \"{}\" to mesh \"{}\". "
-                "You passed {} vertices and {} data components, but we expected {} data components ({} x {}).",
+                "You passed {} vertex indices and {} data components, but we expected {} data components ({} x {}).",
                 dataDims, dataName, meshName,
                 nVertices, values.size(), nVertices * dataDims, dataDims, nVertices);
 
@@ -1399,7 +1399,7 @@ void ParticipantImpl::writeGradientData(
   PRECICE_CHECK(expectedComponents == gradients.size(),
                 "Input sizes are inconsistent attempting to write gradient for data \"{}\" to mesh \"{}\". "
                 "A single gradient/Jacobian for {}D data on a {}D mesh has {} components. "
-                "You passed {} vertices and {} gradient components, but we expected {} gradient components. ",
+                "You passed {} vertex indices and {} gradient components, but we expected {} gradient components. ",
                 dataName, meshName,
                 dataDims, meshDims, gradientComponents,
                 vertices.size(), gradients.size(), expectedComponents);
@@ -1494,7 +1494,7 @@ void ParticipantImpl::getMeshVertexIDsAndCoordinates(
   const auto          meshDims = mesh->getDimensions();
   PRECICE_CHECK(ids.size() == meshSize,
                 "Output size is incorrect attempting to get vertex ids of {}D mesh \"{}\". "
-                "You passed {} vertices indices, but we expected {}. "
+                "You passed {} vertex indices, but we expected {}. "
                 "Use getMeshVertexSize(\"{}\") to receive the required amount of vertices.",
                 meshDims, meshName, ids.size(), meshSize, meshName);
   const auto expectedCoordinatesSize = static_cast<unsigned long>(meshDims * meshSize);

--- a/src/precice/impl/ParticipantState.cpp
+++ b/src/precice/impl/ParticipantState.cpp
@@ -462,7 +462,7 @@ std::string ParticipantState::hintForMeshData(std::string_view mesh, std::string
   }
 
   // Was the data typoed?
-  auto matches = utils::computeMatches(mesh, localData);
+  auto matches = utils::computeMatches(data, localData);
   if (matches.front().distance < 3) {
     return " Did you mean data \"" + matches.front().name + "\"?";
   }

--- a/src/precice/impl/ValidationMacros.hpp
+++ b/src/precice/impl/ValidationMacros.hpp
@@ -54,6 +54,19 @@
                 "Mesh modification is only allowed before calling initialize().",     \
                 name);
 
+/** Implementation of PRECICE_REQUIRE_DATA_READ or PRECICE_REQUIRE_DATA_WRITE
+ *
+ * @attention Do not use this macro directly!
+ */
+#define PRECICE_VALIDATE_MESH_DATA_ACCESS_IMPL(name)                                                           \
+  PRECICE_VALIDATE_MESH_NAME_IMPL(name)                                                                        \
+  PRECICE_CHECK(_accessor->isMeshProvided(name) || _accessor->isDirectAccessAllowed(name),                     \
+                "This participant does not provide Mesh \"{0}\" nor does it enable direct access to it. "      \
+                "To provide the mesh add a provide-mesh tag as follows <provide-mesh name=\"{0}\" />. "        \
+                "To enable direct access to the mesh please add a receive-mesh tag as follows "                \
+                "<receive-mesh name=\"{0}\" from=\"...\" api-access=\"true\" />, or modify an existing one. ", \
+                name);
+
 /** Validates a given meshID
  * This macros creates the "id" in a local scope and provides it to the called implementation.
  */
@@ -133,17 +146,19 @@
 /** Validates a given dataID and checks for read access
  * This macros creates the "id" in a local scope and provides it to the called implementation.
  */
-#define PRECICE_REQUIRE_DATA_READ(mesh, data)  \
-  do {                                         \
-    PRECICE_REQUIRE_DATA_READ_IMPL(mesh, data) \
+#define PRECICE_REQUIRE_DATA_READ(mesh, data)    \
+  do {                                           \
+    PRECICE_VALIDATE_MESH_DATA_ACCESS_IMPL(mesh) \
+    PRECICE_REQUIRE_DATA_READ_IMPL(mesh, data)   \
   } while (false)
 
 /** Validates a given dataID and checks for write access
  * This macros creates the "id" in a local scope and provides it to the called implementation.
  */
-#define PRECICE_REQUIRE_DATA_WRITE(mesh, data)  \
-  do {                                          \
-    PRECICE_REQUIRE_DATA_WRITE_IMPL(mesh, data) \
+#define PRECICE_REQUIRE_DATA_WRITE(mesh, data)   \
+  do {                                           \
+    PRECICE_VALIDATE_MESH_DATA_ACCESS_IMPL(mesh) \
+    PRECICE_REQUIRE_DATA_WRITE_IMPL(mesh, data)  \
   } while (false)
 
 //

--- a/src/precice/tests/UserInputTests.cpp
+++ b/src/precice/tests/UserInputTests.cpp
@@ -1,0 +1,715 @@
+#include "precice/Participant.hpp"
+#include "testing/Testing.hpp"
+
+#include <array>
+#include <limits>
+
+BOOST_AUTO_TEST_SUITE(PreciceTests)
+BOOST_AUTO_TEST_SUITE(UserInput)
+
+BOOST_AUTO_TEST_SUITE(Constructor)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NoSolverName)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("", config, context.rank, context.size),
+                        ::precice::Error,
+                        precice::testing::errorContains("name is an empty string"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongSolverName)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("IDontExist", config, context.rank, context.size),
+                        ::precice::Error,
+                        precice::testing::errorContains("is not defined"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NoConfig)
+{
+  PRECICE_TEST();
+
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", "", context.rank, context.size), ::precice::Error, ::precice::testing::errorContains("unable to open"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(MissingConfig)
+{
+  PRECICE_TEST();
+
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", "this/file/is/missing.xml", context.rank, context.size), ::precice::Error, ::precice::testing::errorContains("unable to open"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongConfigType)
+{
+  PRECICE_TEST();
+
+  auto notaconfig = precice::testing::getPathToSources() + "/precice/tests/notaconfig.txt";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", notaconfig, context.rank, context.size), ::precice::Error, ::precice::testing::errorContains("Start tag expected"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(EmtyConfigFile)
+{
+  PRECICE_TEST();
+
+  auto notaconfig = precice::testing::getPathToSources() + "/precice/tests/emptyconfig.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", notaconfig, context.rank, context.size), ::precice::Error, ::precice::testing::errorContains("Document is empty"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(RankEqualsSize)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", config, context.size, context.size), ::precice::Error, ::precice::testing::errorContains("needs to be smaller than"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(RankLargerThanSize)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", config, context.size + 1, context.size), ::precice::Error, ::precice::testing::errorContains("needs to be smaller than"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NegativeRank)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", config, -3, context.size), ::precice::Error, ::precice::testing::errorContains("non-negative number"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NegativeSize)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", config, context.rank, -3), ::precice::Error, ::precice::testing::errorContains("positive number"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(ZeroSize)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", config, 0, 0), ::precice::Error, ::precice::testing::errorContains("positive number"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NullptrAsCommunicator)
+{
+  PRECICE_TEST();
+
+  auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", config, context.rank, context.size, nullptr), ::precice::Error, ::precice::testing::errorContains("nullptr"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(SetVertex)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NoName)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3> pos{1, 2, 3};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongName)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3> pos{1, 2, 3};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("FaceCenters", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameChanged)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3> pos{1, 2, 3};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("MeshOno", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameMissing)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3> pos{1, 2, 3};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("MeshOn", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameExtra)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3> pos{1, 2, 3};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("MeshOnee", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(EmptyPositions)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverOne", config, context.rank, context.size);
+  std::array<double, 0> pos{};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("MeshOne", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("but found 0"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongDimensionality)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverOne", config, context.rank, context.size);
+  std::array<double, 3> pos{1, 2, 3};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("MeshOne", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("but found 3"));
+}
+
+/// TODO check this
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(InfInPosition)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverOne", config, context.rank, context.size);
+  std::array<double, 2> pos{std::numeric_limits<double>::infinity(), 2};
+  // Currently allowed
+  BOOST_CHECK_NO_THROW(p.setMeshVertex("MeshOne", pos));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NanInPosition)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverOne", config, context.rank, context.size);
+  std::array<double, 2> pos{std::numeric_limits<double>::quiet_NaN(), 2};
+  // Currently allowed
+  BOOST_CHECK_NO_THROW(p.setMeshVertex("MeshOne", pos));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(SetVertices)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NoName)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3>            pos{1, 2, 3};
+  std::array<precice::VertexID, 1> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongName)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3>            pos{1, 2, 3};
+  std::array<precice::VertexID, 1> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("FaceCenters", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameChanged)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3>            pos{1, 2, 3};
+  std::array<precice::VertexID, 1> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("MeshOno", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameMissing)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3>            pos{1, 2, 3};
+  std::array<precice::VertexID, 1> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("MeshOn", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameExtra)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3>            pos{1, 2, 3};
+  std::array<precice::VertexID, 1> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("MeshOnee", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(EmptyPositions)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverOne", config, context.rank, context.size);
+  std::array<double, 0>            pos{};
+  std::array<precice::VertexID, 1> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("MeshOne", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("1 vertex indices and 0 position components"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NotEnoughPositions)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverOne", config, context.rank, context.size);
+  std::array<double, 3>            pos{1, 2, 3};
+  std::array<precice::VertexID, 2> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("MeshOne", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("2 vertex indices and 3 position components"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TooManyPositions)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverOne", config, context.rank, context.size);
+  std::array<double, 7>            pos{1, 2, 3, 4, 5, 6, 7};
+  std::array<precice::VertexID, 3> vids;
+  BOOST_CHECK_EXCEPTION(p.setMeshVertices("MeshOne", pos, vids),
+                        ::precice::Error,
+                        precice::testing::errorContains("3 vertex indices and 7 position components"));
+}
+
+/// TODO check this
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(InfInPosition)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverOne", config, context.rank, context.size);
+  std::array<double, 2>            pos{std::numeric_limits<double>::infinity(), 2};
+  std::array<precice::VertexID, 1> vids;
+  // Currently allowed
+  BOOST_CHECK_NO_THROW(p.setMeshVertices("MeshOne", pos, vids));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NanInPosition)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverOne", config, context.rank, context.size);
+  std::array<double, 2>            pos{std::numeric_limits<double>::quiet_NaN(), 2};
+  std::array<precice::VertexID, 1> vids;
+  // Currently allowed
+  BOOST_CHECK_NO_THROW(p.setMeshVertices("MeshOne", pos, vids));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(WriteData)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongMesh)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("CellCenters", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoMesh)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshToo", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongData)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "Temperature", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available data are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoData)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "DataTwi", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean data"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongMeshAndData)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("CellCenters", "Temperature", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoMeshAndData)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshUne", "DataToo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NoVertices)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  // Call is ignored
+  BOOST_CHECK_NO_THROW(p.writeData("MeshTwo", "DataTwo", vids, data));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(DataTooSmall)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 1> data{1.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("3 vertex indices and 1 data components"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(DataTooLarge)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 4> data{1.0, 2.0, 3.0, 4.0};
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("3 vertex indices and 4 data components"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(RepeatVertex)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+  vids.back() = vids.front(); // last == first
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  // This is currently allowed but is in discussion of being forbidden
+  BOOST_CHECK_NO_THROW(p.writeData("MeshTwo", "DataTwo", vids, data));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongVertexIDSingle)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+  vids[1] = 666;
+
+  std::array<double, 3> data{1.0, 2.0, 3.0};
+  // This is currently allowed but is in discussion of being forbidden
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("invalid Vertex ID at"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongVertexIDRange)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 10>           pos{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  std::array<precice::VertexID, 5> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+  std::fill_n(&vids[1], 3, 666);
+
+  std::array<double, 5> data{1.0, 2.0, 3.0, 4.0, 5.0};
+  // This is currently allowed but is in discussion of being forbidden
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("invalid Vertex ID at"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NaNInData)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{std::numeric_limits<double>::quiet_NaN(), 2.0, 3.0};
+#ifdef NDEBUG
+  BOOST_CHECK_NO_THROW(p.writeData("MeshTwo", "DataTwo", vids, data));
+#else
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("NaN"));
+#endif
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(InfInData)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 6>            pos{1, 2, 3, 4, 5, 6};
+  std::array<precice::VertexID, 3> vids;
+  p.setMeshVertices("MeshTwo", pos, vids);
+
+  std::array<double, 3> data{std::numeric_limits<double>::infinity(), 2.0, 3.0};
+#ifdef NDEBUG
+  BOOST_CHECK_NO_THROW(p.writeData("MeshTwo", "DataTwo", vids, data));
+#else
+  BOOST_CHECK_EXCEPTION(p.writeData("MeshTwo", "DataTwo", vids, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("infinity"));
+#endif
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(NotBeforeInitialize)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(ReadData)
+{
+  PRECICE_TEST();
+
+  auto                             config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant             p("SolverTwo", config, context.rank, context.size);
+  std::array<precice::VertexID, 0> vids;
+  std::array<double, 0>            data;
+  BOOST_CHECK_EXCEPTION(p.readData("MeshTwo", "DataTwo", vids, 0.0, data),
+                        ::precice::Error,
+                        precice::testing::errorContains("cannot be called"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(GetMaxTimeStepSize)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getMaxTimeStepSize(),
+                        ::precice::Error,
+                        precice::testing::errorContains("has to be called before"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(MeshConnectivity)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(UnknownMesh)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.requiresMeshConnectivityFor("CellCenters"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoedMesh)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.requiresMeshConnectivityFor("MoshOne"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(ResetMesh)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NotEnabled)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.resetMesh("MeshOne"),
+                        ::precice::Error,
+                        precice::testing::errorContains("unlock the full API"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/UserInputTests.cpp
+++ b/src/precice/tests/UserInputTests.cpp
@@ -53,16 +53,17 @@ BOOST_AUTO_TEST_CASE(WrongConfigType)
   PRECICE_TEST();
 
   auto notaconfig = precice::testing::getPathToSources() + "/precice/tests/notaconfig.txt";
-  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", notaconfig, context.rank, context.size), ::precice::Error, ::precice::testing::errorContains("Start tag expected"));
+  // The error depends on the libxml2 version
+  BOOST_CHECK_THROW(precice::Participant("SolverOne", notaconfig, context.rank, context.size), ::precice::Error);
 }
 
 PRECICE_TEST_SETUP(1_rank)
-BOOST_AUTO_TEST_CASE(EmtyConfigFile)
+BOOST_AUTO_TEST_CASE(EmptyConfigFile)
 {
   PRECICE_TEST();
 
   auto notaconfig = precice::testing::getPathToSources() + "/precice/tests/emptyconfig.xml";
-  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", notaconfig, context.rank, context.size), ::precice::Error, ::precice::testing::errorContains("Document is empty"));
+  BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", notaconfig, context.rank, context.size), ::precice::Error, ::precice::testing::errorContains(" is empty."));
 }
 
 PRECICE_TEST_SETUP(1_rank)
@@ -117,6 +118,147 @@ BOOST_AUTO_TEST_CASE(NullptrAsCommunicator)
 
   auto config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
   BOOST_CHECK_EXCEPTION(precice::Participant("SolverOne", config, context.rank, context.size, nullptr), ::precice::Error, ::precice::testing::errorContains("nullptr"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(MeshDimenstions)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(NoName)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getMeshDimensions(""),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongName)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getMeshDimensions("FaceCenters"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameChanged)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getMeshDimensions("MeshOno"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameMissing)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getMeshDimensions("MeshOn"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoNameExtra)
+{
+  PRECICE_TEST();
+
+  auto                  config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant  p("SolverTwo", config, context.rank, context.size);
+  std::array<double, 3> pos{1, 2, 3};
+  BOOST_CHECK_EXCEPTION(p.setMeshVertex("MeshOnee", pos),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+BOOST_AUTO_TEST_SUITE(DataDimensions)
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongMesh)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getDataDimensions("CellCenters", "DataTwo"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoMesh)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getDataDimensions("MeshToo", "DataTwo"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongData)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getDataDimensions("MeshTwo", "Temperature"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available data are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoData)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getDataDimensions("MeshTwo", "DataTwi"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean data"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(WrongMeshAndData)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getDataDimensions("CellCenters", "Temperature"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Available meshes are"));
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(TypoMeshAndData)
+{
+  PRECICE_TEST();
+
+  auto                 config = precice::testing::getPathToSources() + "/precice/tests/config-checker.xml";
+  precice::Participant p("SolverTwo", config, context.rank, context.size);
+  BOOST_CHECK_EXCEPTION(p.getDataDimensions("MeshUne", "DataToo"),
+                        ::precice::Error,
+                        precice::testing::errorContains("Did you mean mesh"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/precice/tests/config-checker.xml
+++ b/src/precice/tests/config-checker.xml
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <precice-configuration>
-  <data:scalar name="Data1" />
-  <data:scalar name="Data2" />
+  <data:scalar name="DataOne" />
+  <data:scalar name="DataTwo" />
 
   <mesh name="MeshOne" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
   </mesh>
 
   <mesh name="MeshTwo" dimensions="2">
-    <use-data name="Data1" />
-    <use-data name="Data2" />
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
   </mesh>
 
   <participant name="SolverOne">
     <provide-mesh name="MeshOne" />
-    <write-data name="Data1" mesh="MeshOne" />
-    <read-data name="Data2" mesh="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
   </participant>
 
   <participant name="SolverTwo">
-    <intra-comm:sockets />
     <receive-mesh name="MeshOne" from="SolverOne" safety-factor="0.1" />
     <provide-mesh name="MeshTwo" />
     <mapping:nearest-neighbor
@@ -33,8 +32,8 @@
       from="MeshTwo"
       to="MeshOne"
       constraint="conservative" />
-    <write-data name="Data2" mesh="MeshTwo" />
-    <read-data name="Data1" mesh="MeshTwo" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
   </participant>
 
   <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
@@ -43,12 +42,12 @@
     <participants first="SolverOne" second="SolverTwo" />
     <max-time-windows value="1" />
     <time-window-size value="1.0" />
-    <exchange data="Data1" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
-    <exchange data="Data2" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
     <max-iterations value="100" />
-    <relative-convergence-measure limit="1e-7" data="Data2" mesh="MeshOne" />
+    <relative-convergence-measure limit="1e-7" data="DataTwo" mesh="MeshOne" />
     <acceleration:IQN-ILS>
-      <data name="Data2" mesh="MeshOne" />
+      <data name="DataTwo" mesh="MeshOne" />
       <filter type="QR2" limit="1e-1" />
       <initial-relaxation value="1.0" />
       <max-used-iterations value="10" />

--- a/src/precice/tests/notaconfig.txt
+++ b/src/precice/tests/notaconfig.txt
@@ -1,0 +1,2 @@
+This is a text file.
+It doesn't contain a preCICE-configuration.

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -1,10 +1,12 @@
 #include <algorithm>
 #include <boost/test/framework.hpp>
 #include <boost/test/tree/test_unit.hpp>
+#include <precice/Exceptions.hpp>
 
 #include <cstdlib>
 #include <filesystem>
 #include <limits>
+#include <regex>
 #include <string>
 
 #include "logging/LogMacros.hpp"
@@ -135,6 +137,21 @@ boost::test_tools::predicate_result equals(double a, double b, double tolerance)
 void expectFile(std::string_view name)
 {
   BOOST_TEST(std::filesystem::is_regular_file(name), "File " << name << " is not a regular file or doesn't exist.");
+}
+
+ErrorPredicate errorContains(std::string_view substring)
+{
+  return [substring](const ::precice::Error &e) -> bool {
+    std::string msg(e.what());
+    return msg.find(substring) != std::string::npos;
+  };
+}
+
+ErrorPredicate errorMatches(std::string pattern)
+{
+  return [regex = std::regex(pattern)](const ::precice::Error &e) -> bool {
+    return std::regex_search(e.what(), regex);
+  };
 }
 
 } // namespace precice::testing

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 #include <boost/test/unit_test.hpp>
+#include <functional>
 #include <string>
 #include <type_traits>
 
@@ -166,6 +167,14 @@ void expectFiles(Args... args)
 {
   (expectFile(args), ...);
 }
+
+using ErrorPredicate = std::function<bool(::precice::Error)>;
+
+/// Checks if the message of a given precice::Error contains a substring
+ErrorPredicate errorContains(std::string_view substring);
+
+/// Checks if the message of a given precice::Error matches a regex
+ErrorPredicate errorMatches(std::string regex);
 
 } // namespace precice::testing
 

--- a/src/tests.cmake
+++ b/src/tests.cmake
@@ -77,6 +77,7 @@ target_sources(testprecice
     src/precice/tests/ParallelTests.cpp
     src/precice/tests/SpanTests.cpp
     src/precice/tests/ToolingTests.cpp
+    src/precice/tests/UserInputTests.cpp
     src/precice/tests/VersioningTests.cpp
     src/precice/tests/WatchIntegralTest.cpp
     src/precice/tests/WatchPointTest.cpp

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -184,6 +184,8 @@ int ConfigParser::readXmlFile(std::string const &filePath)
 
   std::string content{std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>()};
 
+  PRECICE_CHECK(!content.empty(), "The configuration file \"{}\" is empty.", filePath);
+
   _hash = utils::preciceHash(content);
 
   xmlParserCtxtPtr ctxt = xmlCreatePushParserCtxt(&SAXHandler, static_cast<void *>(this),


### PR DESCRIPTION
## Main changes of this PR

This PR adds basic misusage tests for preCICE that don't require initialize.

It also includes bugfixes for missing mesh validation before data validation, message inconsistencies and incorrect hints for wrong data.

## Motivation and additional information

Direct mesh access, implicit coupling, jit, and gradients are not covered. 
Make sure the API throws basic errors.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
