### PR TITLE
Add script to check symbols

### DIFF
--- a/tools/building/README.md
+++ b/tools/building/README.md
@@ -9,3 +9,4 @@ building preCICE often.
   Useful when adding/removing source files.
 - `createChangelog`: Creates a changelog file for the current PR. This is based on the GitHub CLI.
 - `createTest.py`: Automatically creates integration tests
+- `checkSymbols`: Takes the preCICE library and uses `readelf` to check if all cpp functions have a counterpart in C and Fortran

--- a/tools/building/checkSymbols
+++ b/tools/building/checkSymbols
@@ -1,0 +1,100 @@
+#!python3
+
+import argparse
+import subprocess
+import pathlib
+import re
+
+
+def load_precice_symbols(lib: pathlib.Path) -> set[str]:
+    run = subprocess.run(
+        ["readelf", "--dyn-syms", "-CW", lib], check=True, stdout=subprocess.PIPE
+    )
+    lines = run.stdout.decode().splitlines(keepends=False)
+
+    symbols = set()
+    for line in lines:
+        r = re.split(" +", line)
+        if len(r[0]) == 0:
+            r.pop(0)
+        if "FUNC" not in r:
+            continue
+        r = " ".join(r[7:]).strip()
+
+        r = re.sub(r"\(.*\)", "", r)  # remove argument information
+        r = re.sub(r"\[.+\]", "", r)  # remove abi information
+        r = r.removesuffix(" const")
+
+        # we only keep precice non-tooling symbols
+        if "precice" in r and "tooling" not in r:
+            symbols.add(r)
+    return symbols
+
+
+def to_cpp(symbol: str) -> str:
+    parts = symbol.removesuffix("_").split("_")
+
+    res = parts[1]
+    for p in parts[2:]:
+        res += p.capitalize()
+    return res
+
+
+def check_symbols(lib: pathlib.Path):
+    all = load_precice_symbols(lib)
+
+    cppsym = {
+        s.removeprefix("precice::").removeprefix("Participant::")
+        for s in all
+        if "precice::" in s
+    }
+    csym = {s for s in all if "precicec_" in s}
+    fsym = {s for s in all if "precicef_" in s}
+
+    cmap = {to_cpp(s): s for s in csym}
+    fmap = {to_cpp(s): s for s in fsym}
+
+    print(f"CF C++")
+    print(f"-- ---")
+    for cpp in cppsym:
+        cmatch = cmap.get(cpp)
+        if cmatch:
+            cmap.pop(cpp)
+
+        fmatch = fmap.get(cpp)
+        if fmatch:
+            fmap.pop(cpp)
+
+        if cmatch and fmatch:
+            print(f"CF {cpp}")
+        elif cmatch:
+            print(f"C. {cpp}")
+        elif fmatch:
+            print(f".F {cpp}")
+        else:
+            print(f".. {cpp}")
+    print()
+
+    print("C functions without counterpart:")
+    for cpp, c in cmap.items():
+        print(f" {c} expected {cpp}")
+    print()
+
+    print("Fortran functions without counterpart:")
+    for cpp, f in fmap.items():
+        print(f" {f} expected {cpp}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("library", type=pathlib.Path, help="The preCICE library to inspect")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+    check_symbols(args.library)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/building/checkSymbols
+++ b/tools/building/checkSymbols
@@ -21,13 +21,19 @@ def load_precice_symbols(lib: pathlib.Path) -> set[str]:
             continue
         r = " ".join(r[7:]).strip()
 
+        # we only keep precice non-tooling symbols
+        if not (
+            r.startswith("precice::Participant::")
+            or r.startswith("precicec_")
+            or r.startswith("precicef_")
+        ):
+            continue
+
         r = re.sub(r"\(.*\)", "", r)  # remove argument information
         r = re.sub(r"\[.+\]", "", r)  # remove abi information
         r = r.removesuffix(" const")
+        symbols.add(r)
 
-        # we only keep precice non-tooling symbols
-        if "precice" in r and "tooling" not in r:
-            symbols.add(r)
     return symbols
 
 


### PR DESCRIPTION
## Main changes of this PR

Adds the script `checkSymbols` which used `readelf` to extract symbols from the library and then tries to find matching counterparts between the Participant interface and the C, Fortran bindings

## Motivation and additional information

Makes feature parity easier

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
