### PR TITLE
Add resetMesh to bindings

### DIFF
--- a/extras/bindings/c/include/precice/preciceC.h
+++ b/extras/bindings/c/include/precice/preciceC.h
@@ -125,6 +125,9 @@ PRECICE_API double precicec_getMaxTimeStepSize();
 /// @copydoc precice::Participant::requiresMeshConnectivityFor()
 PRECICE_API int precicec_requiresMeshConnectivityFor(const char *meshName);
 
+/// @copydoc precice::Participant::resetMesh()
+PRECICE_API void precicec_resetMesh(const char *meshName);
+
 /**
  * @brief Creates a mesh vertex
  *

--- a/extras/bindings/c/src/preciceC.cpp
+++ b/extras/bindings/c/src/preciceC.cpp
@@ -171,6 +171,14 @@ try {
   return -1;
 }
 
+void precicec_resetMesh(const char *meshName)
+try {
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->resetMesh(meshName);
+} catch (::precice::Error &e) {
+  std::abort();
+}
+
 int precicec_setMeshVertex(
     const char *  meshName,
     const double *position)

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -211,6 +211,19 @@ PRECICE_API void precicef_requires_mesh_connectivity_for_(
 
 /**
  * Fortran syntax:
+ * precicef_reset_mesh_(
+ *   CHARACTER meshName(*))
+ *
+ * IN:  mesh, meshNameLength
+ *
+ * @copydoc precice::Participant::resetMesh()
+ */
+PRECICE_API void precicef_reset_mesh_(
+    const char *meshName,
+    int         meshNameLength);
+
+/**
+ * Fortran syntax:
  * precicef_set_vertex(
  *   CHARACTER        meshName(*),
  *   DOUBLE PRECISION coordinates(dim),

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -182,6 +182,16 @@ try {
   std::abort();
 }
 
+void precicef_reset_mesh_(
+    const char *meshName,
+    int         meshNameLength)
+try {
+  PRECICE_CHECK(impl != nullptr, errormsg);
+  impl->resetMesh(precice::impl::strippedStringView(meshName, meshNameLength));
+} catch (::precice::Error &e) {
+  std::abort();
+}
+
 void precicef_set_vertex_(
     const char *  meshName,
     const double *position,


### PR DESCRIPTION
## Main changes of this PR

This PR adds the missing `resetMesh()` API to the C and Fortran bindings

## Motivation and additional information


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
