### PR TITLE
Add events to JIT API

### DIFF
--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1287,6 +1287,8 @@ void ParticipantImpl::mapAndReadData(
     return;
   }
 
+  Event e{fmt::format("mapAndReadData.{}_{}", meshName, dataName), profiling::Fundamental};
+
   // Note that meshName refers to a remote mesh
   ReadDataContext &dataContext = _accessor->readDataContext(meshName, dataName);
   const auto       dataDims    = dataContext.getDataDimensions();
@@ -1339,6 +1341,8 @@ void ParticipantImpl::writeAndMapData(
   if (coordinates.empty() && values.empty()) {
     return;
   }
+
+  Event e{fmt::format("writeAndMapData.{}_{}", meshName, dataName), profiling::Fundamental};
 
   // Note that meshName refers here typically to a remote mesh
   WriteDataContext &dataContext = _accessor->writeDataContext(meshName, dataName);


### PR DESCRIPTION
## Main changes of this PR

This PR adds events to the JIT API `mapAndWriteData` and `readAndMapData`.

## Motivation and additional information

This makes the cost of calling these functions more transparent to the user and to improve the scoping of internal mapping events.

@davidscn Could you have a look if this sufficiently improves the event scoping?

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
