### PR TITLE
Enable running system tests in forks

### DIFF
--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -120,6 +120,7 @@ jobs:
       suites: release_test
       build_args: "PLATFORM:ubuntu_2404,\
         PRECICE_REF:${{ github.event.pull_request.head.sha }},\
+        PRECICE_PR:${{ github.event.number }},\
         PYTHON_BINDINGS_REF:${{ needs.gather-refs.outputs.ref-python-bindings }},\
         CALCULIX_VERSION:2.20,\
         CALCULIX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-calculix-adapter }},\


### PR DESCRIPTION
## Main changes of this PR

Passes the PR (event) number as an additional argument.

The [system tests run](https://github.com/precice/precice/actions/runs/14114462834/job/39541158760) confirms that this already works in this PR, which uses a branch on my fork.

## Motivation and additional information

Follow-up of https://github.com/precice/tutorials/pull/638

This is independent of the release process. It just needs to be merged to `develop`.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
*  I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> I don't think we need one
* [x] I squashed / am about to squash all commits that should be seen as one.
* [x] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

