### PR TITLE
Fix and cleanup ResidualSumPreConditioner update

### DIFF
--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -29,89 +29,91 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
                                          const Eigen::VectorXd &oldValues,
                                          const Eigen::VectorXd &res)
 {
-  if (not timeWindowComplete) {
-    std::vector<double> norms(_subVectorSizes.size(), 0.0);
-
-    double sum = 0.0;
-
-    int  offset       = 0;
-    bool resetWeights = !_preconditionerUpdateOnThreshold; // if _preconditionerUpdateOnThreshold is true, the weights are reset only if the ratio of the new scaling weight to the previous residual sum has changed significantly
-    for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      Eigen::VectorXd part = Eigen::VectorXd::Zero(_subVectorSizes[k]);
-      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-        part(i) = res(i + offset);
-      }
-      norms[k] = utils::IntraComm::dot(part, part);
-      sum += norms[k];
-      offset += _subVectorSizes[k];
-      norms[k] = std::sqrt(norms[k]);
-    }
-    sum = std::sqrt(sum);
-    PRECICE_WARN_IF(
-        math::equals(sum, 0.0),
-        "All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = {}). "
-        "This indicates that the data values exchanged between two successive iterations did not change. "
-        "The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged "
-        "between the solvers is not identical between iterations. The preconditioner scaling factors were "
-        "not updated in this iteration and the scaling factors determined in the previous iteration were used.",
-        sum);
-
-    for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      if (sum > math::NUMERICAL_ZERO_DIFFERENCE)
-        _residualSum[k] += norms[k] / sum;
-
-      PRECICE_WARN_IF(
-          math::equals(_residualSum[k], 0.0),
-          "A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = {}). "
-          "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
-          "check if the coupling data values of one solver is zero in the first iteration. "
-          "The preconditioner scaling factors were not updated for this iteration and the scaling factors "
-          "determined in the previous iteration were used.",
-          _residualSum[k]);
-    }
-
-    offset = 0;
-
-    if (_firstTimeWindow || (!_preconditionerUpdateOnThreshold)) {
-      resetWeights = true;
-    } else {
-      for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-        double resSum = _residualSum[k];
-        if (math::equals(resSum, 0.0)) {
-          continue; // These will be ignored when resetting the weights
-        }
-        // Check if the ratio of the new scaling weight to the previous residual sum
-        // has changed significantly, either exceeding the threshold of 10.0
-        // or dropping below its inverse.
-        double factor = _previousResidualSum[k] / resSum;
-        if ((factor > 10.0) || (factor < 0.1)) {
-          resetWeights = true;
-          PRECICE_DEBUG("Significant scaling weight change is detected. The pre-scaling weights will be reset.");
-          break;
-        }
-      }
-    }
-
-    if (resetWeights) {
-      for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-        if (not math::equals(_residualSum[k], 0.0)) {
-          for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-            _weights[i + offset]    = 1 / _residualSum[k];
-            _invWeights[i + offset] = _residualSum[k];
-          }
-          PRECICE_DEBUG("preconditioner scaling factor[{}] = {}", k, 1 / _residualSum[k]);
-        }
-        _previousResidualSum[k] = _residualSum[k];
-        offset += _subVectorSizes[k];
-      }
-      _requireNewQR = true;
-    }
-  } else {
+  if (timeWindowComplete) {
     _firstTimeWindow = false;
+    std::fill(_residualSum.begin(), _residualSum.end(), 0.0);
+    return;
+  }
+
+  std::vector<double> norms(_subVectorSizes.size(), 0.0);
+
+  double sum = 0.0;
+
+  int offset = 0;
+  for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+    Eigen::VectorXd part = Eigen::VectorXd::Zero(_subVectorSizes[k]);
+    for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+      part(i) = res(i + offset);
+    }
+    norms[k] = utils::IntraComm::dot(part, part);
+    sum += norms[k];
+    offset += _subVectorSizes[k];
+    norms[k] = std::sqrt(norms[k]);
+  }
+  sum = std::sqrt(sum);
+  PRECICE_WARN_IF(
+      math::equals(sum, 0.0),
+      "All residual sub-vectors in the residual-sum preconditioner are numerically zero ( sum = {}). "
+      "This indicates that the data values exchanged between two successive iterations did not change. "
+      "The simulation may be unstable, e.g. produces NAN values. Please check the data values exchanged "
+      "between the solvers is not identical between iterations. The preconditioner scaling factors were "
+      "not updated in this iteration and the scaling factors determined in the previous iteration were used.",
+      sum);
+
+  for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+    if (sum > math::NUMERICAL_ZERO_DIFFERENCE)
+      _residualSum[k] += norms[k] / sum;
+
+    PRECICE_WARN_IF(
+        math::equals(_residualSum[k], 0.0),
+        "A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = {}). "
+        "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+        "check if the coupling data values of one solver is zero in the first iteration. "
+        "The preconditioner scaling factors were not updated for this iteration and the scaling factors "
+        "determined in the previous iteration were used.",
+        _residualSum[k]);
+  }
+
+  // Determine if weights needs to be reset
+  // if _preconditionerUpdateOnThreshold is true, the weights are reset only if the ratio of the new scaling weight to the previous residual sum has changed significantly
+  bool resetWeights = _firstTimeWindow || !_preconditionerUpdateOnThreshold;
+  if (!resetWeights) {
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      _residualSum[k] = 0.0;
+      double resSum = _residualSum[k];
+      if (math::equals(resSum, 0.0)) {
+        continue; // These will be ignored when resetting the weights
+      }
+      // Check if the ratio of the new scaling weight to the previous residual sum
+      // has changed significantly, either exceeding the threshold of 10.0
+      // or dropping below its inverse.
+      double factor = _previousResidualSum[k] / resSum;
+      if ((factor > 10.0) || (factor < 0.1)) {
+        resetWeights = true;
+        PRECICE_DEBUG("Significant scaling weight change is detected. The pre-scaling weights will be reset.");
+        break;
+      }
     }
   }
+
+  if (!resetWeights) {
+    return;
+  }
+
+  // Reset the weights for non-zero residual sums
+  offset = 0;
+  for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+    double resSum = _residualSum[k];
+    if (not math::equals(resSum, 0.0)) {
+      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+        _weights[i + offset]    = 1 / resSum;
+        _invWeights[i + offset] = resSum;
+      }
+      PRECICE_DEBUG("preconditioner scaling factor[{}] = {}", k, 1 / resSum);
+    }
+    _previousResidualSum[k] = resSum;
+    offset += _subVectorSizes[k];
+  }
+  _requireNewQR = true;
 }
 
 } // namespace precice::acceleration::impl


### PR DESCRIPTION
## Main changes of this PR

This PR fixes a possible division by zero and cleans up the code of the update

## Motivation and additional information

Follow-up of #1493

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
