### PR TITLE
Refactor preconditioners

### DIFF
--- a/src/acceleration/impl/ConstantPreconditioner.cpp
+++ b/src/acceleration/impl/ConstantPreconditioner.cpp
@@ -24,13 +24,12 @@ void ConstantPreconditioner::initialize(std::vector<size_t> &svs)
 
   PRECICE_ASSERT(_factors.size() == _subVectorSizes.size());
 
-  int offset = 0;
   for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+    auto offset = _subVectorOffsets[k];
     for (size_t i = 0; i < _subVectorSizes[k]; i++) {
       _weights[i + offset]    = 1.0 / _factors[k];
       _invWeights[i + offset] = _factors[k];
     }
-    offset += _subVectorSizes[k];
   }
 }
 

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -40,6 +40,10 @@ public:
 
     _subVectorSizes = svs;
 
+    // Compute offsets of each subvector
+    _subVectorOffsets.resize(_subVectorSizes.size(), 0);
+    std::partial_sum(_subVectorSizes.begin(), --_subVectorSizes.end(), ++_subVectorOffsets.begin());
+
     size_t N = std::accumulate(_subVectorSizes.begin(), _subVectorSizes.end(), static_cast<std::size_t>(0));
 
     // cannot do this already in the constructor as the size is unknown at that point
@@ -216,6 +220,9 @@ protected:
 
   /// Sizes of each sub-vector, i.e. each coupling data
   std::vector<size_t> _subVectorSizes;
+
+  /// Offsets of each sub-vector in concatenated data, i.e. each coupling data
+  std::vector<size_t> _subVectorOffsets;
 
   /** @brief maximum number of non-const time windows, i.e., after this number of time windows,
    *  the preconditioner is frozen with the current weights and becomes a constant preconditioner

--- a/src/acceleration/impl/ValuePreconditioner.cpp
+++ b/src/acceleration/impl/ValuePreconditioner.cpp
@@ -17,40 +17,35 @@ void ValuePreconditioner::_update_(bool                   timeWindowComplete,
                                    const Eigen::VectorXd &oldValues,
                                    const Eigen::VectorXd &res)
 {
-  if (timeWindowComplete || _firstTimeWindow) {
-
-    std::vector<double> norms(_subVectorSizes.size(), 0.0);
-
-    int offset = 0;
-    for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      Eigen::VectorXd part = Eigen::VectorXd::Zero(_subVectorSizes[k]);
-      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-        part(i) = oldValues(i + offset);
-      }
-      norms[k] = utils::IntraComm::l2norm(part);
-      offset += _subVectorSizes[k];
-    }
-
-    offset = 0;
-    for (size_t k = 0; k < _subVectorSizes.size(); k++) {
-      if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
-        PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
-                     "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
-                     "check if the coupling data values of one solver is zero in the first iteration. "
-                     "The preconditioner scaling factors were not applied for this iteration.");
-      } else {
-        for (size_t i = 0; i < _subVectorSizes[k]; i++) {
-          PRECICE_ASSERT(norms[k] > 0.0);
-          _weights[i + offset]    = 1.0 / norms[k];
-          _invWeights[i + offset] = norms[k];
-        }
-      }
-      offset += _subVectorSizes[k];
-    }
-
-    _requireNewQR    = true;
-    _firstTimeWindow = false;
+  if (!timeWindowComplete && !_firstTimeWindow) {
+    return;
   }
+
+  std::vector<double> norms(_subVectorSizes.size(), 0.0);
+
+  for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+    Eigen::VectorXd part = oldValues.segment(_subVectorOffsets[k], _subVectorSizes[k]);
+    norms[k]             = utils::IntraComm::l2norm(part);
+  }
+
+  for (size_t k = 0; k < _subVectorSizes.size(); k++) {
+    if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
+      PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
+                   "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+                   "check if the coupling data values of one solver is zero in the first iteration. "
+                   "The preconditioner scaling factors were not applied for this iteration.");
+    } else {
+      for (size_t i = 0; i < _subVectorSizes[k]; i++) {
+        PRECICE_ASSERT(norms[k] > 0.0);
+        auto offset             = _subVectorOffsets[k];
+        _weights[i + offset]    = 1.0 / norms[k];
+        _invWeights[i + offset] = norms[k];
+      }
+    }
+  }
+
+  _requireNewQR    = true;
+  _firstTimeWindow = false;
 }
 
 } // namespace precice::acceleration::impl


### PR DESCRIPTION
## Main changes of this PR

This PR is a quick refactoring of the preconditioners.
The offsets of subvectors are now precomputed, preventing on-the-fly offset computation.
Also, concatenated values and residuals are now sliced with `.segment()` instead on manual copying.
Lastly, reduces nesting with guards where practical.

## Motivation and additional information

Less code in a math-heavy class hierarchy.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
