### PR TITLE
Fix compilation on MinGW

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -1,0 +1,79 @@
+name: Build and Test Windows MinGW
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    paths:
+      - 'cmake/**'
+      - 'examples/**'
+      - 'src/**'
+      - 'tests/**'
+      - 'thirdparty/**'
+      - 'tests/**'
+      - 'tools/profiling/**'
+      - 'CMakeLists.txt'
+      - 'extras/bindings/**'
+      - '.github/workflows/build-and-test-windows.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${ {github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{github.event_name == 'pull_request'}}
+
+jobs:
+  msys2-ucrt64:
+    name: ${{ format('MinGW UCRT {0}', matrix.TYPE) }}
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        TYPE: [Release, Debug]
+    env:
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
+      CMAKE_BUILD_TYPE: ${{ matrix.TYPE }}
+      CMAKE_GENERATOR: Ninja
+      CTEST_OUTPUT_ON_FAILURE: True
+      CXXFLAGS: -Wa,-mbig-obj
+    steps:
+      - name: Install MS-MPI
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri https://github.com/microsoft/Microsoft-MPI/releases/download/v10.1.1/msmpisetup.exe -OutFile msmpisetup.exe
+          Start-Process -FilePath .\msmpisetup.exe -ArgumentList '-unattend' -Wait
+          Remove-Item msmpisetup.exe
+
+          # Add MS-MPI to PATH
+          echo "C:\Program Files\Microsoft MPI\Bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: powershell
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          path-type: inherit
+          install: git mingw-w64-ucrt-x86_64-gcc-libs mingw-w64-ucrt-x86_64-boost-libs mingw-w64-ucrt-x86_64-libxml2 mingw-w64-ucrt-x86_64-python mingw-w64-ucrt-x86_64-python-numpy mingw-w64-ucrt-x86_64-cc mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-msmpi mingw-w64-ucrt-x86_64-ninja mingw-w64-ucrt-x86_64-boost mingw-w64-ucrt-x86_64-eigen3 mingw-w64-ucrt-x86_64-crt mingw-w64-ucrt-x86_64-msmpi
+      - uses: actions/checkout@v3
+      - name: Make build directory
+        run: mkdir -p build
+      - name: Configure
+        working-directory: build
+        run: |
+          cmake -DPRECICE_FEATURE_PETSC_MAPPING=OFF -DPRECICE_FEATURE_PYTHON_ACTIONS=OFF -DCMAKE_CXX_FLAGS_DEBUG=-g1 ..
+      - name: Build
+        working-directory: build
+        run: |
+          cmake --build .
+      - name: Test
+        working-directory: build
+        run: |
+          # Allow each test to run twice to iron out sporadic MPI failures
+          ctest -j --repeat until-pass:2
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: debugdump
+          path: build/


### PR DESCRIPTION
## Main changes of this PR

This PR attempts to fix export issue on mingw

## Motivation and additional information

Based on #2265
Closes #2262
Related to #200 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
