### PR TITLE
Improve assertion on incorrect event endings

### DIFF
--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -309,7 +309,7 @@ def groupEvents(events: [dict], initTime: int):
                 if name != "_GLOBAL":
                     assert (
                         stack[-1] == name
-                    ), f"Expected to end event {name} but the currently active event is {stack[-1]}."
+                    ), f"Expected to end event {name} but the currently active event is {stack[-1]}. Note that events need to follow a strict nesting and overlapping starts/stops are not permitted."
                     stack.pop()
         # Handle event data
         elif type == "d":

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -307,7 +307,9 @@ def groupEvents(events: [dict], initTime: int):
                 begin.pop("et")
                 completed.append(begin)
                 if name != "_GLOBAL":
-                    assert stack[-1] == name
+                    assert (
+                        stack[-1] == name
+                    ), f"Expected to end event {name} but the currently active event is {stack[-1]}."
                     stack.pop()
         # Handle event data
         elif type == "d":


### PR DESCRIPTION
## Main changes of this PR

This PR improves the error message for events that are incorrectly generated, namely if an end doesn't match the latest start:

```
AssertionError: Expected to end event map.pet.createMatrices.assembleOutputMatrix but the currently active event is map.pet.postFill.FromA-MeshToB-Mesh.
```

## Motivation and additional information

Currently this triggers an assertion without further information.
This change prints at least the expected and found event name.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
