### PR TITLE
Improve profiling merge robustness

### DIFF
--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -407,6 +407,10 @@ def loadProfilingOutputs(filenames):
 
         jsons.append(json)
 
+    if not jsons:
+        print("No files loaded")
+        sys.exit(1)
+
     # Grouping events
     print("Grouping events")
     events = {}

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -65,18 +65,18 @@ def checkPolarsVersion():
         sys.exit(1)
 
 
-def loadRobust(content):
-    try:
-        return json.loads(content)
-    except:
-        print("Damaged input detected")
-        content += "]}"
-        return json.loads(content)
-
-
 def readRobust(filename):
     with open(filename, "r") as openfile:
-        return loadRobust(openfile.read())
+        content = openfile.read()
+    try:
+        return json.loads(content)  # try direct
+    except:
+        warning("File damaged. Attempting to terminate truncated event file.", filename)
+        content += "]}"
+        try:
+            return json.loads(content)  # try terminated
+        except:
+            return {}  # give up
 
 
 def printWide(df):
@@ -380,7 +380,19 @@ def loadProfilingOutputs(filenames):
     for i, fn in enumerate(filenames):
         json = readRobust(fn)
 
-        if "meta" in json:
+        # General checks
+        if not json:
+            warning(
+                "The file is empty or was unable to be load and will be ignored.", fn
+            )
+            continue
+        if "meta" not in json:
+            warning("The file doesn't contain metadata and will be ignored.", fn)
+            continue
+        elif "events" not in json:
+            warning("The file doesn't contain event data and will be ignored.", fn)
+            continue
+        else:
             version = json["meta"].get("file_version")
             if version is None:
                 warning(


### PR DESCRIPTION
## Main changes of this PR

This PR 

- improves robustness of loading broken files and makes error messages more useful
- exits early if no files were loaded at all instead of running into an assertion

Based on https://github.com/precice/precice/pull/2268

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
