### PR TITLE
Retry opening ConnectionInfoFiles

### DIFF
--- a/docs/changelog/2276.md
+++ b/docs/changelog/2276.md
@@ -1,0 +1,1 @@
+- Added one retry in case opening of connection info files fails during communication buildup.

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -62,6 +62,14 @@ std::string ConnectionInfoReader::read() const
   PRECICE_DEBUG("Found connection file \"{}\"", path);
 
   std::ifstream ifs(path);
+
+  if (!ifs) {
+    PRECICE_DEBUG("Opening connection file \"{}\" failed. Retrying", path);
+    std::this_thread::sleep_for(waitdelay);
+    ifs.clear();
+    ifs.open(path);
+  }
+
   PRECICE_CHECK(ifs,
                 "Unable to establish connection as the connection file \"{}\" couldn't be opened.",
                 path);
@@ -115,7 +123,15 @@ void ConnectionInfoWriter::write(std::string_view info) const
   PRECICE_DEBUG("Writing temporary connection file \"{}\"", tmp.generic_string());
   fs::create_directories(tmp.parent_path());
   {
-    std::ofstream ofs(tmp.string());
+    std::ofstream ofs(tmp);
+
+    if (!ofs) {
+      PRECICE_DEBUG("Opening temporary connection file \"{}\" failed. Retrying", tmp.generic_string());
+      std::this_thread::sleep_for(std::chrono::milliseconds{1});
+      ofs.clear();
+      ofs.open(tmp);
+    }
+
     PRECICE_CHECK(ofs, "Unable to establish connection as the temporary connection file \"{}\" couldn't be opened.", tmp.generic_string());
     fmt::print(ofs,
                "{}\nAcceptor: {}, Requester: {}, Tag: {}, Rank: {}",


### PR DESCRIPTION
## Main changes of this PR

This PR adds a retry in case the opening of a connection info file fails.

## Motivation and additional information

This became a problem on Windows #2266

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
