### PR TITLE
Fix symbol visibility on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,11 @@ if(NOT Kokkos_VERSION OR NOT Kokkos_VERSION VERSION_LESS 4.4)
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN YES
   )
+else()
+  set_target_properties(preciceCore PROPERTIES
+    CXX_VISIBILITY_PRESET default
+    VISIBILITY_INLINES_HIDDEN NO
+  )
 endif()
 
 # Setup release override options
@@ -489,14 +494,17 @@ add_library(precice)
 set_target_properties(precice PROPERTIES
   VERSION ${preCICE_VERSION}
   SOVERSION ${preCICE_SOVERSION}
-  CXX_VISIBILITY_PRESET default
-  VISIBILITY_INLINES_HIDDEN NO
   )
 
 if(NOT Kokkos_VERSION OR NOT Kokkos_VERSION VERSION_LESS 4.4)
   set_target_properties(precice PROPERTIES
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN YES
+   )
+else()
+  set_target_properties(precice PROPERTIES
+    CXX_VISIBILITY_PRESET default
+    VISIBILITY_INLINES_HIDDEN NO
    )
 endif()
 
@@ -547,6 +555,11 @@ GENERATE_EXPORT_HEADER(preciceCore
   EXPORT_MACRO_NAME PRECICE_API
   INCLUDE_GUARD_NAME PRECICE_EXPORT
   )
+
+# Workaround for making exports work for the preciceCore object library when building preCICE as a shared library
+if (BUILD_SHARED_LIBS)
+  target_compile_definitions(preciceCore PUBLIC preciceCore_EXPORTS)
+endif()
 
 # Add the export header to the public headers of the preCICE lib
 set_property(TARGET precice APPEND PROPERTY PUBLIC_HEADER


### PR DESCRIPTION
## Main changes of this PR

This PR fixes symbol visibility on Windows

## Motivation and additional information

Part of #2266

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
