### PR TITLE
Extend CMake info

### DIFF
--- a/cmake/PrintHelper.cmake
+++ b/cmake/PrintHelper.cmake
@@ -47,20 +47,37 @@ endfunction(print_section)
 function(print_configuration)
   cmake_parse_arguments(PARSE_ARGV 0 PRINT_CONFIG "" "" "ADDITIONAL")
   print_section("CONFIGURATION")
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" _upper_build_type)
   print_variables( VARS
+    "CMAKE_VERSION;CMake version"
     "PROJECT_VERSION;Library version to build"
     "CMAKE_BUILD_TYPE;Build configuration"
     "BUILD_SHARED_LIBS;Build shared libraries"
     "CMAKE_SYSTEM;Target system"
     "CMAKE_HOST_SYSTEM;Host system"
-    "CMAKE_CXX_LIBRARY_ARCHITECTURE;Library architecture"
-    "CMAKE_CXX_COMPILER;CXX compiler"
-    "CMAKE_CXX_FLAGS;CXX compiler flags"
-    "CMAKE_LINKER;CXX linker"
     "CMAKE_INSTALL_PREFIX;Install prefix"
     "PROJECT_SOURCE_DIR;Source directory"
     "PROJECT_BINARY_DIR;Binary directory"
+    "CMAKE_CXX_LIBRARY_ARCHITECTURE;Library architecture"
+    "CMAKE_CXX_COMPILER;CXX compiler"
+    "CMAKE_CXX_COMPILER_ID;CXX compiler ID"
+    "CMAKE_CXX_COMPILER_VERSION;CXX compiler version"
+    "CMAKE_CXX_FLAGS;CXX compiler flags"
+    "CMAKE_CXX_FLAGS_${_upper_build_type};CXX ${CMAKE_BUILD_TYPE} compiler flags"
     )
+  if(CMAKE_VERSION VERSION_LESS 3.29)
+    print_variables(VARS "CMAKE_LINKER;CXX linker")
+  else()
+    print_variables(VARS
+    "CMAKE_CXX_COMPILER_LINKER;CXX linker"
+    "CMAKE_CXX_COMPILER_LINKER_ID;CXX linker ID"
+    "CMAKE_CXX_COMPILER_LINKER_VERSION;CXX linker version"
+    )
+  endif()
+  print_variables(VARS
+    "CMAKE_SHARED_LINKER_FLAGS;Shared linker flags"
+    "CMAKE_EXE_LINKER_FLAGS;Executable linker flags"
+  )
   if(PRINT_CONFIG_ADDITIONAL)
     print_variables(VARS ${PRINT_CONFIG_ADDITIONAL})
   endif()

--- a/docs/changelog/2282.md
+++ b/docs/changelog/2282.md
@@ -1,0 +1,1 @@
+- Added detailed CMake, compiler and linker information to the CMake configuration log


### PR DESCRIPTION
## Main changes of this PR

This PR extends the printed CMake info to the CMake version, and the include ID (Clang/G++/etc) and version of the compiler and the linker (if available).
It also prints the configuration flags such as `-g` for Debug and the linker flags for shared and exe separately.

## Motivation and additional information

The CMake version can be important to figure out changing policies.

Due to wrappers, the path to a compiler/linker is often not enough.
CMake deduces the ID of compilers and linkers (since v3.29).
So the can just print them in the intro.

This may also be useful for Cuda and HIP compilers.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
