### PR TITLE
Improve CMake multi config output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ endif()
 # Setup Options
 #
 
-if(NOT CMAKE_BUILD_TYPE)
-  message(WARNING "You did not specify a CMAKE_BUILD_TYPE.
+if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
+  message(WARNING "You did not specify a CMAKE_BUILD_TYPE in a single configuration build.
 
   We will assume you asked for a Debug build.")
   set(CMAKE_BUILD_TYPE Debug CACHE STRING "The type of this build" FORCE)

--- a/cmake/PrintHelper.cmake
+++ b/cmake/PrintHelper.cmake
@@ -47,11 +47,18 @@ endfunction(print_section)
 function(print_configuration)
   cmake_parse_arguments(PARSE_ARGV 0 PRINT_CONFIG "" "" "ADDITIONAL")
   print_section("CONFIGURATION")
-  string(TOUPPER "${CMAKE_BUILD_TYPE}" _upper_build_type)
   print_variables( VARS
     "CMAKE_VERSION;CMake version"
     "PROJECT_VERSION;Library version to build"
-    "CMAKE_BUILD_TYPE;Build configuration"
+  )
+
+  if (CMAKE_CONFIGURATION_TYPES)
+    print_variables( VARS "CMAKE_CONFIGURATION_TYPES;Build configurations")
+  else()
+    print_variables( VARS "CMAKE_BUILD_TYPE;Build configuration")
+  endif()
+
+  print_variables( VARS
     "BUILD_SHARED_LIBS;Build shared libraries"
     "CMAKE_SYSTEM;Target system"
     "CMAKE_HOST_SYSTEM;Host system"
@@ -63,8 +70,18 @@ function(print_configuration)
     "CMAKE_CXX_COMPILER_ID;CXX compiler ID"
     "CMAKE_CXX_COMPILER_VERSION;CXX compiler version"
     "CMAKE_CXX_FLAGS;CXX compiler flags"
-    "CMAKE_CXX_FLAGS_${_upper_build_type};CXX ${CMAKE_BUILD_TYPE} compiler flags"
     )
+
+  if (CMAKE_CONFIGURATION_TYPES)
+    foreach(type IN LISTS CMAKE_CONFIGURATION_TYPES)
+      string(TOUPPER "${type}" _upper_build_type)
+      print_variables( VARS "CMAKE_CXX_FLAGS_${_upper_build_type};CXX ${type} compiler flags")
+    endforeach()
+  else()
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _upper_build_type)
+    print_variables( VARS "CMAKE_CXX_FLAGS_${_upper_build_type};CXX ${CMAKE_BUILD_TYPE} compiler flags")
+  endif()
+
   if(CMAKE_VERSION VERSION_LESS 3.29)
     print_variables(VARS "CMAKE_LINKER;CXX linker")
   else()


### PR DESCRIPTION
## Main changes of this PR

This PR improves the CMake output when using a multi config generator such as `Ninja Multi Config`.

## Motivation and additional information

This requires additional tweaks to differentiate between single and multi configs.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
