### PR TITLE
Use shm fabric on intel

### DIFF
--- a/cmake/discover_tests.cmake
+++ b/cmake/discover_tests.cmake
@@ -46,11 +46,15 @@ function(add_test NAME RANKS)
     list(JOIN labels "\;" labels)
   endif()
 
+  list(APPEND test_env OMP_NUM_THREADS=2 OMP_PROC_BIND=false)
   if(RANKS STREQUAL "1")
     add_command(add_test
       "[=[precice.${NAME}]=]"
       ${_TEST_EXECUTABLE} "--run_test=${NAME}" "--log_level=message"
     )
+    if(PRECICE_MPI_VERSION MATCHES "Intel")
+      list(APPEND test_env I_MPI_FABRIC=shm)
+    endif()
   else()
     # --map-by=:OVERSUBSCRIBE works for OpenMPI(4+5) and MPICH, but not for Intel which doesn't need a flag
     set(_oversubscribe_FLAG "--map-by;:OVERSUBSCRIBE")
@@ -71,11 +75,10 @@ function(add_test NAME RANKS)
     )
   endif()
 
-
   add_command(set_tests_properties
     "[=[precice.${NAME}]=]"
     PROPERTIES
-    ENVIRONMENT "OMP_NUM_THREADS=2\;OMP_PROC_BIND=false"
+    ENVIRONMENT "${test_env}"
     TIMEOUT "30"
     WORKING_DIRECTORY "${test_dir}"
     LABELS "${labels}"


### PR DESCRIPTION
## Main changes of this PR

This uses the shared memory fabric with Intel MPI

## Motivation and additional information

This should half the startup time of each test

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
