### PR TITLE
Fix check for missing exchange tag in conv measure of multi-coupling schemes

### DIFF
--- a/docs/changelog/2287.md
+++ b/docs/changelog/2287.md
@@ -1,0 +1,1 @@
+- Fixed error in configuration for a convergence measure of a multi coupling scheme using data that was exchanged, but not with the controller.

--- a/src/cplscheme/config/CouplingSchemeConfiguration.hpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.hpp
@@ -276,7 +276,7 @@ private:
       const std::string   &accessor) const;
 
   void checkIfDataIsExchanged(
-      DataID dataID) const;
+      DataID dataID, std::string_view participant) const;
 
   void checkSerialImplicitAccelerationData(
       DataID dataID, const std::string &first, const std::string &second) const;


### PR DESCRIPTION
## Main changes of this PR

This PR fixes the check of conv measures in multi coupling scheme using data that is exchanged, but not with the controller.
The message now mentions which participant requires the data, which is only useful for multi coupling schemes.

## Motivation and additional information

This currently leads to an assertion (Debug) or exception in the configuration.

Closes #2286

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
