### PR TITLE
Declare precicef_set_mesh_triangles_

### DIFF
--- a/docs/changelog/2293.md
+++ b/docs/changelog/2293.md
@@ -1,0 +1,1 @@
+- Fixed incorrect declaration for Fortran `precicef_set_mesh_triangles_`

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -351,7 +351,7 @@ PRECICE_API void precicef_set_triangle_(
  * @copydoc precice::Participant::setMeshTriangles()
  *
  */
-PRECICE_API void precicef_set_mesh_edges_(
+PRECICE_API void precicef_set_mesh_triangles_(
     const char *meshName,
     const int  *size,
     const int  *ids,


### PR DESCRIPTION
## Main changes of this PR

Changed the duplicate declaration of `precicef_set_mesh_edges_` to `precicef_set_mesh_triangles_`, as indicated by comments and the prior absence of such a function. This change fixes an undefined reference error.

## Motivation and additional information

Closes precice#2292

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [x] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
