### PR TITLE
Fix parameter descriptions in `preciceC.h`

### DIFF
--- a/extras/bindings/c/include/precice/preciceC.h
+++ b/extras/bindings/c/include/precice/preciceC.h
@@ -338,7 +338,7 @@ PRECICE_API void precicec_readData(
  * See @see precice::Participant::writeAndMapData() and the just-in-time mapping doxygen section for more information.
  *
  * @param[in] meshName Name of the mesh to write and map the data to. Typically a received mesh
- * @param[in] dataName Name of the data to field on this mesh.
+ * @param[in] dataName Name of the data to write on this mesh.
  * @param[in] size Number of vertices to write
  * @param[in] coordinates Pointer to the coordinates where we write the data. Needs to have \p size x \ref precicec_getMeshDimensions( \p meshName ) entries
  * @param[in] values Pointer to the data values we want to pass to preCICE. Needs  to have \p size x \ref precicec_getDataDimensions( \p meshName , \p dataName ) entries
@@ -356,9 +356,9 @@ PRECICE_API void precicec_writeAndMapData(
  * @brief Reads data using just-in-time data mapping.
  * See @see precice::Participant::mapAndReadData() and the just-in-time mapping doxygen section for more information.
  *
- * @param[in] meshName Name of the mesh to write and map the data to. Typically a received mesh
- * @param[in] dataName Name of the data to field on this mesh.
- * @param[in] size Number of vertices to write
+ * @param[in] meshName Name of the mesh to read and map the data from. Typically a received mesh
+ * @param[in] dataName Name of the data to read on this mesh.
+ * @param[in] size Number of vertices to read
  * @param [in] coordinates Pointer to the coordinates where we read the data. Needs to have \p size x \ref precicec_getMeshDimensions( \p meshName ) entries
  * @param[in] relativeReadTime Same as in @see precice::Participant::readData()
  * @param[in/out] values Pointer to the values to be filled by preCICE. Needs to have \p size x \ref precicec_getDataDimensions( \p meshName , \p dataName ) entries


### PR DESCRIPTION
## Main changes of this PR
Fix the parameter descriptions of `precicec_writeAndMapData` and `precicec_mapAndReadData`.

## Motivation and additional information
The parameter descriptions contained copy-paste-mistakes.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
