### PR TITLE
Fix file detection of precice-profiling merge

### DIFF
--- a/docs/changelog/2298.md
+++ b/docs/changelog/2298.md
@@ -1,0 +1,1 @@
+- Fixed `precice-profiling merge` mistakenly detecting non-precice json files such as solver or adapter configuration files.

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -812,9 +812,17 @@ def detectFiles(files):
 
     def searchDir(directory):
         assert os.path.isdir(directory)
+        import re
         import glob
 
-        return glob.glob(os.path.join(directory, "*-*-*.json"))
+        nameMatcher = r".+-\d+-\d+.json"
+        return [
+            candidate
+            for candidate in glob.glob(
+                os.path.join(directory, "**/*.json"), recursive=True
+            )
+            if re.fullmatch(nameMatcher, os.path.basename(candidate))
+        ]
 
     resolved = []
     for path in files:
@@ -824,9 +832,8 @@ def detectFiles(files):
         if os.path.isdir(path):
             candidates = [
                 ".",
-                "precice-profiling",
-                "../precice-profiling",
-                "../../precice-profiling",
+                "..",
+                "../..",
             ]
             found = False
             for candidate in candidates:


### PR DESCRIPTION
## Main changes of this PR

This PR changes the file detection of precice-profiling merge by detecting all json files recursively that follow the naming scheme `NAME-DIGITS-DIGITS.json`.

## Motivation and additional information

This prevents incorrect detection of solver provided json files.

Closes https://github.com/precice/precice/issues/2297

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
