### PR TITLE
Hardcode preCICE as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,15 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release RelWithDebInfo MinSizeRel)
 endif()
 
+if (DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
+  message(WARNING "You disabled BUILD_SHARED_LIBS, but preCICE unconditionally builds as shared library.")
+endif()
+
 option(PRECICE_FEATURE_MPI_COMMUNICATION "Enables MPI-based communication and running coupling tests." ON)
 option(PRECICE_FEATURE_PETSC_MAPPING "Enable use of the PETSc linear algebra library for global-iterative RBF data mappings." ON)
 option(PRECICE_FEATURE_PYTHON_ACTIONS "Enable Python support for preCICE actions." ON)
 option(PRECICE_CONFIGURE_PACKAGE_GENERATION "Configure package generation." ON)
 option(PRECICE_FEATURE_GINKGO_MAPPING "Enable use of Ginkgo for accelerated data mapping." OFF)
-option(BUILD_SHARED_LIBS "Build shared instead of static libraries" ON)
 option(BUILD_TESTING "Build tests" ON)
 option(PRECICE_ALWAYS_VALIDATE_LIBS "Validate libraries even after the validatation succeeded." OFF)
 option(PRECICE_BINDINGS_C "Enable the native C bindings" ON)
@@ -494,7 +497,7 @@ target_include_directories(preciceCore PUBLIC
   )
 
 # Add precice as an empty target
-add_library(precice)
+add_library(precice SHARED)
 set_target_properties(precice PROPERTIES
   VERSION ${preCICE_VERSION}
   SOVERSION ${preCICE_SOVERSION}
@@ -561,9 +564,7 @@ GENERATE_EXPORT_HEADER(preciceCore
   )
 
 # Workaround for making exports work for the preciceCore object library when building preCICE as a shared library
-if (BUILD_SHARED_LIBS)
-  target_compile_definitions(preciceCore PUBLIC preciceCore_EXPORTS)
-endif()
+target_compile_definitions(preciceCore PUBLIC preciceCore_EXPORTS)
 
 # Add the export header to the public headers of the preCICE lib
 set_property(TARGET precice APPEND PROPERTY PUBLIC_HEADER

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 if (DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
-  message(WARNING "You disabled BUILD_SHARED_LIBS, but preCICE unconditionally builds as shared library.")
+  message(WARNING "You disabled BUILD_SHARED_LIBS. Note that 3.2.0 was the last release to honor this option. Newer preCICE releases always build as a shared library.")
 endif()
 
 option(PRECICE_FEATURE_MPI_COMMUNICATION "Enables MPI-based communication and running coupling tests." ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -4,10 +4,7 @@
     {
       "name": "base",
       "hidden": true,
-      "binaryDir": "${sourceDir}/build",
-      "cacheVariables": {
-        "BUILD_SHARED_LIBS": "ON"
-      }
+      "binaryDir": "${sourceDir}/build"
     },
     {
       "name": "production",

--- a/cmake/PrintHelper.cmake
+++ b/cmake/PrintHelper.cmake
@@ -59,7 +59,6 @@ function(print_configuration)
   endif()
 
   print_variables( VARS
-    "BUILD_SHARED_LIBS;Build shared libraries"
     "CMAKE_SYSTEM;Target system"
     "CMAKE_HOST_SYSTEM;Host system"
     "CMAKE_INSTALL_PREFIX;Install prefix"

--- a/docs/changelog/2300.md
+++ b/docs/changelog/2300.md
@@ -1,0 +1,1 @@
+- Removed support for configuring preCICE as static library.

--- a/docs/changelog/2300.md
+++ b/docs/changelog/2300.md
@@ -1,1 +1,1 @@
-- Removed support for configuring preCICE as static library.
+- Removed support for configuring preCICE as static library, which has been broken since version 3.0.0.

--- a/tools/releasing/packaging/Arch_User_Repository/PKGBUILD
+++ b/tools/releasing/packaging/Arch_User_Repository/PKGBUILD
@@ -19,7 +19,6 @@ build() {
     cmake . \
           -DCMAKE_BUILD_TYPE=None \
           -DCMAKE_INSTALL_PREFIX=/usr \
-          -DBUILD_SHARED_LIBS=ON \
           -DPRECICE_MPICommunication=ON \
           -DPRECICE_PETScMapping=ON \
           -DPRECICE_PythonActions=ON \


### PR DESCRIPTION
## Main changes of this PR

This PR changes the preCICE CMake to always generate preCICE as a SHARED library.

## Motivation and additional information

Closes #2299

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
