### PR TITLE
Fix setMeshTriangle to only create the triangle

### DIFF
--- a/docs/changelog/2302.md
+++ b/docs/changelog/2302.md
@@ -1,0 +1,1 @@
+- Fixed `setMeshTriangle` still creating edges instead of relying on the mesh preprocessing to generate required edges.

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -924,21 +924,12 @@ void ParticipantImpl::setMeshTriangle(
     PRECICE_CHECK(utils::unique_elements(utils::make_array(first, second, third)),
                   "setMeshTriangle() was called with repeated Vertex IDs ({}, {}, {}).",
                   first, second, third);
-    mesh::Vertex *vertices[3];
-    vertices[0] = &mesh->vertex(first);
-    vertices[1] = &mesh->vertex(second);
-    vertices[2] = &mesh->vertex(third);
-    PRECICE_CHECK(utils::unique_elements(utils::make_array(vertices[0]->getCoords(),
-                                                           vertices[1]->getCoords(), vertices[2]->getCoords())),
-                  "setMeshTriangle() was called with vertices located at identical coordinates (IDs: {}, {}, {}).",
-                  first, second, third);
-    Event       e{fmt::format("setMeshTriangle.{}", meshName), profiling::Fundamental};
-    mesh::Edge *edges[3];
-    edges[0] = &mesh->createEdge(*vertices[0], *vertices[1]);
-    edges[1] = &mesh->createEdge(*vertices[1], *vertices[2]);
-    edges[2] = &mesh->createEdge(*vertices[2], *vertices[0]);
 
-    mesh->createTriangle(*edges[0], *edges[1], *edges[2]);
+    mesh::Vertex &A = mesh->vertex(first);
+    mesh::Vertex &B = mesh->vertex(second);
+    mesh::Vertex &C = mesh->vertex(third);
+
+    mesh->createTriangle(A, B, C);
   }
 }
 

--- a/tests/serial/mapping-volume/helpers.cpp
+++ b/tests/serial/mapping-volume/helpers.cpp
@@ -34,7 +34,6 @@ void testMappingVolumeOneTriangle(const std::string configFile, const TestContex
 
     auto &mesh = precice::testing::WhiteboxAccessor::impl(participant).mesh("MeshOne");
     BOOST_REQUIRE(mesh.nVertices() == 3);
-    BOOST_REQUIRE(mesh.edges().size() == 3);
     BOOST_REQUIRE(mesh.triangles().size() == 1);
 
     BOOST_TEST(equals(mesh.triangles()[0].getArea(), 0.5), "Triangle area must be 0.5");


### PR DESCRIPTION
## Main changes of this PR

This PR changes setMeshTriangle to only create the triangle.

## Motivation and additional information

Manually creating hierarchical primitives is undesirable since the introduction of mesh preprocessing in #1494 (3.0.0)

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
