### PR TITLE
Refactor configuration in ParticipantImpl

### DIFF
--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -27,8 +27,7 @@ MeshConfiguration::MeshConfiguration(
       _meshDimensionsMap(),
       _dataConfig(std::move(config)),
       _meshes(),
-      _neededMeshes(),
-      _meshIdManager(new utils::ManageUniqueIDs())
+      _neededMeshes()
 {
   using namespace xml;
   std::string doc;
@@ -68,8 +67,7 @@ void MeshConfiguration::xmlTagCallback(
     int         dimensions = tag.getIntAttributeValue(ATTR_DIMENSIONS);
     insertMeshToMeshDimensionsMap(name, dimensions);
     PRECICE_ASSERT(dimensions != 0);
-    PRECICE_ASSERT(_meshIdManager);
-    _meshes.push_back(std::make_shared<Mesh>(name, dimensions, _meshIdManager->getFreeID()));
+    _meshes.push_back(std::make_shared<Mesh>(name, dimensions, _meshIdManager.getFreeID()));
   } else if (tag.getName() == TAG_DATA) {
     std::string name  = tag.getStringAttributeValue(ATTR_NAME);
     bool        found = false;

--- a/src/mesh/config/MeshConfiguration.hpp
+++ b/src/mesh/config/MeshConfiguration.hpp
@@ -60,11 +60,6 @@ public:
       const std::string &participant,
       const std::string &mesh);
 
-  std::unique_ptr<utils::ManageUniqueIDs> extractMeshIdManager()
-  {
-    return std::move(_meshIdManager);
-  }
-
   /// Initialize the map between meshes and dimensions, for unit tests that directly create mesh objects without going through the config reading.
   void insertMeshToMeshDimensionsMap(const std::string &mesh,
                                      int                dimensions);
@@ -92,7 +87,7 @@ private:
   /// to check later if all meshes that any coupling scheme needs are actually used by the participants
   std::map<std::string, std::vector<std::string>> _neededMeshes;
 
-  std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
+  utils::ManageUniqueIDs _meshIdManager;
 
   utils::ManageUniqueIDs _dataIDManager;
 };

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -116,6 +116,8 @@ public:
 
   std::map<std::string, m2n::BoundM2N> getBoundM2NsFor(std::string_view participant) const;
 
+  void configurePartitionsFor(std::string_view participantName);
+
 private:
   logging::Logger _log{"config::Configuration"};
 

--- a/src/precice/config/Configuration.hpp
+++ b/src/precice/config/Configuration.hpp
@@ -6,6 +6,7 @@
 #include "cplscheme/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "logging/config/LogConfiguration.hpp"
+#include "m2n/BoundM2N.hpp"
 #include "m2n/M2N.hpp"
 #include "m2n/config/M2NConfiguration.hpp"
 #include "mapping/SharedPointer.hpp"
@@ -112,6 +113,8 @@ public:
   {
     _participantConfiguration = config;
   }
+
+  std::map<std::string, m2n::BoundM2N> getBoundM2NsFor(std::string_view participant) const;
 
 private:
   logging::Logger _log{"config::Configuration"};

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -347,7 +347,7 @@ ParticipantConfiguration::getParticipants() const
   return _participants;
 }
 
-const impl::PtrParticipant ParticipantConfiguration::getParticipant(const std::string &participantName) const
+const impl::PtrParticipant ParticipantConfiguration::getParticipant(std::string_view participantName) const
 {
   auto participant = std::find_if(_participants.begin(), _participants.end(), [&participantName](const auto &p) { return p->getName() == participantName; });
   PRECICE_ASSERT(participant != _participants.end(), "Did not find participant \"{}\"", participantName);

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -341,6 +341,11 @@ void ParticipantConfiguration::xmlEndTagCallback(
   }
 }
 
+std::size_t ParticipantConfiguration::nParticipants() const
+{
+  return _participants.size();
+}
+
 const std::vector<impl::PtrParticipant> &
 ParticipantConfiguration::getParticipants() const
 {

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -48,6 +48,8 @@ public:
       const xml::ConfigurationContext &context,
       xml::XMLTag                     &callingTag) override;
 
+  std::size_t nParticipants() const;
+
   /// Returns all configured participants.
   const std::vector<impl::PtrParticipant> &getParticipants() const;
 

--- a/src/precice/config/ParticipantConfiguration.hpp
+++ b/src/precice/config/ParticipantConfiguration.hpp
@@ -52,7 +52,7 @@ public:
   const std::vector<impl::PtrParticipant> &getParticipants() const;
 
   /// Returns a participant with the given name
-  const impl::PtrParticipant getParticipant(const std::string &participantName) const;
+  const impl::PtrParticipant getParticipant(std::string_view participantName) const;
 
   std::set<std::string> knownParticipants() const;
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -215,7 +215,6 @@ void ParticipantImpl::configure(
   _allowsRemeshing    = config.allowsRemeshing();
   _waitInFinalize     = config.waitInFinalize();
   _accessor           = determineAccessingParticipant(config);
-  _accessor->setMeshIdManager(config.getMeshConfiguration()->extractMeshIdManager());
 
   PRECICE_ASSERT(_accessorCommunicatorSize == 1 || _accessor->useIntraComm(),
                  "A parallel participant needs an intra-participant communication");

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1757,16 +1757,13 @@ void ParticipantImpl::resetWrittenData()
 PtrParticipant ParticipantImpl::determineAccessingParticipant(
     const config::Configuration &config)
 {
-  const auto &partConfig = config.getParticipantConfiguration();
-  for (const PtrParticipant &participant : partConfig->getParticipants()) {
-    if (participant->getName() == _accessorName) {
-      return participant;
-    }
-  }
-  PRECICE_ERROR("This participant's name, which was specified in the constructor of the preCICE interface as \"{}\", "
+  const auto &partConfig = *config.getParticipantConfiguration();
+  PRECICE_CHECK(partConfig.hasParticipant(_accessorName),
+                "This participant's name, which was specified in the constructor of the preCICE interface as \"{}\", "
                 "is not defined in the preCICE configuration. "
                 "Please double-check the correct spelling.",
                 _accessorName);
+  return partConfig.getParticipant(_accessorName);
 }
 
 void ParticipantImpl::initializeIntraCommunication()

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -385,8 +385,6 @@ private:
    */
   void configure(const config::Configuration &configuration);
 
-  void configureM2Ns(const m2n::M2NConfiguration::SharedPointer &config);
-
   enum struct ExportTiming : bool {
     Advance = false,
     Initial = true

--- a/src/precice/impl/ParticipantImpl.hpp
+++ b/src/precice/impl/ParticipantImpl.hpp
@@ -394,10 +394,6 @@ private:
   /// @param[in] timing when the exports are requested
   void handleExports(ExportTiming timing);
 
-  /// Determines participants providing meshes to other participants.
-  void configurePartitions(
-      const m2n::M2NConfiguration::SharedPointer &m2nConfig);
-
   /// Communicate bounding boxes and look for overlaps
   void compareBoundingBoxes();
 

--- a/src/precice/impl/ParticipantState.hpp
+++ b/src/precice/impl/ParticipantState.hpp
@@ -112,12 +112,6 @@ public:
   /// Sets weather the participant was configured with a primary tag
   void setUsePrimaryRank(bool useIntraComm);
 
-  /// Sets the manager responsible for providing unique IDs to meshes.
-  void setMeshIdManager(std::unique_ptr<utils::ManageUniqueIDs> &&idm)
-  {
-    _meshIdManager = std::move(idm);
-  }
-
   /// Adds a configured \ref Action to the participant
   void addAction(action::PtrAction &&action);
 
@@ -360,8 +354,6 @@ private:
   DataMap<ReadDataContext> _readDataContexts;
 
   bool _useIntraComm = false;
-
-  std::unique_ptr<utils::ManageUniqueIDs> _meshIdManager;
 
   template <typename ELEMENT_T>
   bool isDataValid(


### PR DESCRIPTION
## Main changes of this PR

This PR refactors the configuration in the ParticipantImpl by

- moving configureM2N and configurePartitions into Configuration
- removing unused mesh ID manager in ParticipantState

## Motivation and additional information

This PR aims to reduce complexity and move code into the Configuration classes instead.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
