### PR TITLE
Use SAX2 header instead of SAX

### DIFF
--- a/cmake/Validation.cmake
+++ b/cmake/Validation.cmake
@@ -78,10 +78,10 @@ macro(precice_validate_numpy)
 endmacro()
 
 # Validation for LibXML2
-# We check for the header libxml/SAX.h as we use it in preCICE
+# We check for the header libxml/SAX2.h as we use it in preCICE
 macro(precice_validate_libxml2)
   precice_validate_lib(
-    "#include <libxml/SAX.h>\nint main() { return 0; } "
+    "#include <libxml/SAX2.h>\nint main() { return 0; } "
   NAME LibXml2
   LINK_LIBRARIES LibXml2::LibXml2
   )

--- a/docs/changelog/2306.md
+++ b/docs/changelog/2306.md
@@ -1,0 +1,1 @@
+- Fixed the use of the deprecated libxml2 header `libxml/SAX.h`, which leads to compile errors for libxml2 `2.14.0` and newer.

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -3,7 +3,7 @@
 #include <exception>
 #include <fstream>
 #include <iterator>
-#include <libxml/SAX.h>
+#include <libxml/SAX2.h>
 #include <memory>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
## Main changes of this PR

This PR changes the use of the old `libxml/SAX.h` header to using the "new" `SAX2.h` for libxml2.

## Motivation and additional information

The `libxml/SAX.h` content [was removed](https://gitlab.gnome.org/GNOME/libxml2/-/commit/1112699cfa63cb7e0d051d91fd2ddb97c5ccb2979) which impacts releases after libxml v2.14.0.
This is currently only Arch https://repology.org/project/libxml2/packages .

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
