### PR TITLE
Add error message in writeAndMapValues in case of misconfiguration

### DIFF
--- a/src/precice/impl/WriteDataContext.cpp
+++ b/src/precice/impl/WriteDataContext.cpp
@@ -42,12 +42,12 @@ void WriteDataContext::completeJustInTimeMapping()
 void WriteDataContext::writeAndMapValues(::precice::span<const double> coordinates, ::precice::span<const double> values)
 {
   PRECICE_TRACE();
-  PRECICE_ASSERT(mappingCache);
   PRECICE_CHECK(justInTimeMapping,
                 "This participant attempted to write data to mesh \"{}\" using a just-in-time mapping, "
                 "but there is no write mapping configured for that mesh. "
                 "Perhaps you forgot to define a <mapping:... direction=\"write\" /> or want to use direct access with the API function \"writeData({0},...)\".",
                 getMeshName(), getDataName());
+  PRECICE_ASSERT(mappingCache);
   PRECICE_ASSERT((coordinates.size() / getSpatialDimensions()) * getDataDimensions() == values.size());
   PRECICE_ASSERT(_writeDataBuffer.values.data());
 


### PR DESCRIPTION
## Main changes of this PR
Adds helpful user facing warning to address #2307.

## Motivation and additional information
Without this message, this type is misconfiguration is somewhat hard to diagnose for the user.

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
