### PR TITLE
Move test list generation to separate target

### DIFF
--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -183,7 +183,7 @@ else()
     VERBATIM)
 
   # Custom target that forces the test list to be updated
-  add_custom_target(test-list ALL
+  add_custom_target(precice-test-list ALL
     DEPENDS "${ctest_tests_file}"
   )
 endif()

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -164,9 +164,9 @@ else()
     APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_tests_file}"
   )
 
-  # Custom command that generates the tests list after the testprecice binary is build
+  # Custom command to generate the tests list using the testprecice binary
   add_custom_command(
-    TARGET testprecice POST_BUILD
+    OUTPUT "${ctest_tests_file}"
     COMMAND "${CMAKE_COMMAND}"
     -D "TEST_EXECUTABLE=$<TARGET_FILE:testprecice>"
     -D "TEST_FILE=${ctest_tests_file}"
@@ -178,10 +178,14 @@ else()
     -D "MPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}"
     -D "MPIEXEC_POSTFLAGS=${MPIEXEC_POSTFLAGS}"
     -P "${preCICE_SOURCE_DIR}/cmake/discover_tests.cmake"
+    DEPENDS testprecice
     COMMENT "Generating list of tests"
-    BYPRODUCTS "${preCICE_BINARY_DIR}/tests.txt"
     VERBATIM)
 
+  # Custom target that forces the test list to be updated
+  add_custom_target(test-list ALL
+    DEPENDS "${ctest_tests_file}"
+  )
 endif()
 
 # Add solverdummy tests

--- a/docs/changelog/2310.md
+++ b/docs/changelog/2310.md
@@ -1,0 +1,1 @@
+- Moved the generation of the test list to a separate target `precice-test-list`. Use `make testprecice precice-test-list` if you only want to run the tests.


### PR DESCRIPTION
## Main changes of this PR

This PR moves the test list generation to a separate target which is built by default in `ALL` or if make is involved without arguments.

## Motivation and additional information

Before this PR, `testprecice` is executed after it is build to produce the test list. If this fails, the build is considered a failure and the `testprecice` executable is deleted. Therefore, only `make testprecice` is required to run `ctest`.

This PR moves the generation of the test list to a separate command and adds the target `precice-test-list`. Meaning that `make testprecice precice-test-list` is required to run `ctest`. `make testprecice` is not sufficient any more.
The upside is that if the generation of the test list fails, the `testprecice` executable is still present. It can then be debugged or ran separately to create said file.

Fixes https://github.com/precice/precice/issues/2303#issuecomment-2965715922

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
