### PR TITLE
Split precice-tools into individual commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,7 +753,7 @@ mark_as_advanced(PRECICE_PACKAGING_DIR)
 find_program(GZIP_EXE gzip DOC "The gzip executable")
 if(GZIP_EXE)
   # Process manpages for binaries
-  file(COPY docs/man/man1/precice-tools.1 DESTINATION packaging/man1)
+  file(COPY docs/man/man1/precice-tools.1 docs/man/man1/precice-version.1 docs/man/man1/precice-config-validate.1 docs/man/man1/precice-config-doc.1 DESTINATION packaging/man1)
   file(GLOB PRECICE_MAN_PAGES "${PRECICE_PACKAGING_DIR}/man1/*.1")
   foreach(manpage ${PRECICE_MAN_PAGES})
     message(STATUS "Compressing manpage: ${manpage}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,20 +571,27 @@ set_property(TARGET precice APPEND PROPERTY PUBLIC_HEADER
     ${PROJECT_BINARY_DIR}/src/precice/export.h)
 
 #
-# Configuration of Target precice-tools
+# Configuration of precice tools
 #
 if (PRECICE_BUILD_TOOLS)
-  add_executable(precice-tools "src/drivers/main.cpp")
-  target_link_libraries(precice-tools
-   PRIVATE
-   precice
-   )
-  set_target_properties(precice-tools PROPERTIES
-    # precice is a C++17 project
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED Yes
-    CXX_EXTENSIONS No
-    )
+  macro(precice_add_tool TARGET MAIN)
+    add_executable(${TARGET} ${MAIN})
+    target_link_libraries(${TARGET}
+      PRIVATE
+      precice
+      )
+    set_target_properties(${TARGET} PROPERTIES
+      # precice is a C++17 project
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED Yes
+      CXX_EXTENSIONS No
+      )
+  endmacro()
+
+  precice_add_tool(precice-tools "src/drivers/main.cpp")
+  precice_add_tool(precice-config-doc "src/drivers/doc.cpp")
+  precice_add_tool(precice-config-validate "src/drivers/validate.cpp")
+  precice_add_tool(precice-version "src/drivers/version.cpp")
 endif()
 
 #
@@ -693,7 +700,7 @@ install(TARGETS precice
   )
 
 if(PRECICE_BUILD_TOOLS)
-  install(TARGETS precice-tools
+  install(TARGETS precice-tools precice-version precice-config-validate precice-config-doc
     EXPORT preciceTargets
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -221,60 +221,122 @@ if(PRECICE_BUILD_TOOLS)
     endif()
   endfunction()
 
+  # precice-tools
 
   add_tools_test(
-    NAME noarg
+    NAME legacy.noarg
     COMMAND precice-tools
     WILL_FAIL)
 
   add_tools_test(
-    NAME invalidcmd
+    NAME legacy.invalidcmd
     COMMAND precice-tools invalidcommand
     WILL_FAIL)
 
   add_tools_test(
-    NAME version
+    NAME legacy.version
     COMMAND precice-tools version
     MATCH "${CMAKE_PROJECT_VERSION}"
     )
 
   add_tools_test(
-    NAME versionopt
+    NAME legacy.versionopt
     COMMAND precice-tools --version
     MATCH "${CMAKE_PROJECT_VERSION}"
     )
 
   add_tools_test(
-    NAME markdown
+    NAME legacy.markdown
     COMMAND precice-tools md
     MATCH "# precice-configuration"
     )
 
   add_tools_test(
-    NAME xml
+    NAME legacy.xml
     COMMAND precice-tools xml
     MATCH "<!-- TAG precice-configuration"
     )
 
   add_tools_test(
-    NAME dtd
+    NAME legacy.dtd
     COMMAND precice-tools dtd
     MATCH "<!ELEMENT precice-configuration"
     )
 
   add_tools_test(
-    NAME check.file
+    NAME legacy.check.file
     COMMAND precice-tools check ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml
     )
 
   add_tools_test(
-    NAME check.file+name
+    NAME legacy.check.file+name
     COMMAND precice-tools check ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo
     )
 
   add_tools_test(
-    NAME check.file+name+size
+    NAME legacy.check.file+name+size
     COMMAND precice-tools check ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
+    )
+
+  # precice-version
+
+  add_tools_test(
+    NAME version
+    COMMAND precice-version
+    MATCH "${CMAKE_PROJECT_VERSION}"
+    )
+
+  # precice-config-doc
+
+  add_tools_test(
+    NAME config-doc.noarg
+    COMMAND precice-config-doc
+    WILL_FAIL)
+
+  add_tools_test(
+    NAME config-doc.markdown
+    COMMAND precice-config-doc md
+    MATCH "# precice-configuration"
+    )
+
+  add_tools_test(
+    NAME config-doc.xml
+    COMMAND precice-config-doc xml
+    MATCH "<!-- TAG precice-configuration"
+    )
+
+  add_tools_test(
+    NAME config-doc.dtd
+    COMMAND precice-config-doc dtd
+    MATCH "<!ELEMENT precice-configuration"
+    )
+
+  # precice-config-validate
+
+  add_tools_test(
+    NAME config-validate.noarg
+    COMMAND precice-config-validate
+    WILL_FAIL)
+
+  add_tools_test(
+    NAME config-validate.missingfile
+    COMMAND precice-config-validate ${PROJECT_SOURCE_DIR}/definitely/missing/file.xml
+    MATCH ERROR:
+    )
+
+  add_tools_test(
+    NAME config-validate.file
+    COMMAND precice-config-validate ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml
+    )
+
+  add_tools_test(
+    NAME config-validate.file+name
+    COMMAND precice-config-validate ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo
+    )
+
+  add_tools_test(
+    NAME config-validate.file+name+size
+    COMMAND precice-config-validate ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
     )
 endif()
 

--- a/docs/changelog/2312.md
+++ b/docs/changelog/2312.md
@@ -1,0 +1,2 @@
+- Deprecated the executable `precice-tools` in favor of `precice-version`, `precice-config-validate`, and `precice-config-doc`.
+- Added executables `precice-version`, `precice-config-validate`, and `precice-config-doc`.

--- a/docs/man/man1/precice-config-doc.1
+++ b/docs/man/man1/precice-config-doc.1
@@ -1,0 +1,36 @@
+.TH precice-config-doc 1
+
+.SH NAME
+precice-config-doc \- command line utility for preCICE
+
+.SH SYNOPSIS
+.B precice-config-doc
+.B xml
+|
+.B dtd
+|
+.B md
+
+.SH OPTIONS
+
+.TP
+.B xml
+Prints the configuration reference as XML with inlined help to the standard output.
+
+.TP
+.B dtd
+Prints the DTD file to the standard output, which may be used to check XML configuration files.
+
+.TP
+.B md
+Prints the configuration reference as markdown to the standard output.
+
+.SH EXIT STATUS
+precice-config-doc returns a zero exit status if it succeeds to run the provided command.
+Non zero is returned in case of failure.
+
+.SH SEE ALSO
+.BR precice-version (1),
+.BR precice-config-validate (1)
+.PP
+precice.org \- the website of the project

--- a/docs/man/man1/precice-config-validate.1
+++ b/docs/man/man1/precice-config-validate.1
@@ -1,0 +1,19 @@
+.TH precice-config-validate 1
+
+.SH NAME
+precice-config-validate \- command line utility to validate preCICE configuration files
+
+.SH SYNOPSIS
+.B precice-config-validate \fIfile\fR [\fIparticipant\fR [\fIsize\fR]]
+
+Checks given preCICE configuration \fIfile\fR and prints any errors. Pass the name of a \fIparticipant\fR to fully check its configuration. The optional \fIsize\fR indicates how many ranks run in parallel, which checks custom \fI<intra-comm: ... />\fR tags.
+
+.SH EXIT STATUS
+precice-config-validate returns a zero exit status if it succeeds to run the provided command.
+Non zero is returned in case of failure.
+
+.SH SEE ALSO
+.BR precice-version (1),
+.BR precice-config-doc (1)
+.PP
+precice.org \- the website of the project

--- a/docs/man/man1/precice-tools.1
+++ b/docs/man/man1/precice-tools.1
@@ -41,5 +41,9 @@ precice-tools returns a zero exit status if it succeeds to run the provided comm
 Non zero is returned in case of failure.
 
 .SH SEE ALSO
+.BR precice-version (1),
+.BR precice-config-validate (1),
+.BR precice-config-doc (1)
+
 .PP
 precice.org \- the website of the project

--- a/docs/man/man1/precice-version.1
+++ b/docs/man/man1/precice-version.1
@@ -1,0 +1,17 @@
+.TH precice-version 1
+
+.SH NAME
+precice-version \- command line utility to show the version of preCICE
+
+.SH SYNOPSIS
+.B precice-version
+
+.SH EXIT STATUS
+precice-version returns a zero exit status if it succeeds to run the provided command.
+Non zero is returned in case of failure.
+
+.SH SEE ALSO
+.BR precice-config-validate (1),
+.BR precice-config-doc (1)
+.PP
+precice.org \- the website of the project

--- a/src/drivers/doc.cpp
+++ b/src/drivers/doc.cpp
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <precice/Tooling.hpp>
+#include <string>
+
+void printUsage()
+{
+  std::cerr << "Usage:\n\n";
+  std::cerr << "Print XML reference      :  precice-config-doc xml\n";
+  std::cerr << "Print DTD for XML config :  precice-config-doc dtd\n";
+  std::cerr << "Print Markdown reference :  precice-config-doc md\n";
+}
+
+int main(int argc, char **argv)
+{
+  if (argc < 2) {
+    printUsage();
+    return 1;
+  }
+
+  const std::string action(argv[1]);
+  const int         args = argc - 2;
+
+  using namespace precice::tooling;
+
+  if (action == "dtd" && args == 0) {
+    printConfigReference(std::cout, ConfigReferenceType::DTD);
+    return 0;
+  }
+  if (action == "md" && args == 0) {
+    printConfigReference(std::cout, ConfigReferenceType::MD);
+    return 0;
+  }
+  if (action == "xml" && args == 0) {
+    printConfigReference(std::cout, ConfigReferenceType::XML);
+    return 0;
+  }
+
+  printUsage();
+  return 1;
+}

--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -17,6 +17,10 @@ void printUsage()
 
 int main(int argc, char **argv)
 {
+
+  std::cout << "WARNING: precice-tools is deprecated and will be removed in preCICE version 4.\n"
+               "Please use precice-version , precice-config-validate or precice-config-doc instead.\n";
+
   if (argc < 2) {
     printUsage();
     return 1;

--- a/src/drivers/validate.cpp
+++ b/src/drivers/validate.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+#include <precice/Exceptions.hpp>
+#include <precice/Tooling.hpp>
+#include <stdexcept>
+#include <string>
+
+void printUsage()
+{
+  std::cerr << "Usage:\n\n";
+  std::cerr << "precice-config-validate FILE [ PARTICIPANT [ COMMSIZE ] ]\n";
+}
+
+int main(int argc, char **argv)
+{
+  const int args = argc - 1;
+
+  if (args < 1 || args > 3) {
+    printUsage();
+    return 1;
+  }
+
+  using namespace precice::tooling;
+
+  std::string file(argv[1]);
+  std::string participant = (args > 1) ? std::string(argv[2]) : "";
+
+  int size = 1;
+  if (args == 3) {
+    try {
+      size = std::stoi(argv[3]);
+    } catch (std::invalid_argument &e) {
+      std::cerr << "ERROR: passed COMMSIZE is not a valid number\n";
+      printUsage();
+      return 1;
+    }
+  }
+
+  try {
+    precice::tooling::checkConfiguration(file, participant, size);
+  } catch (const ::precice::Error &) {
+  }
+  return 0;
+}

--- a/src/drivers/version.cpp
+++ b/src/drivers/version.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include <precice/Tooling.hpp>
+
+int main(int argc, char **argv)
+{
+  std::cout << precice::getVersionInformation() << '\n';
+  return 0;
+}


### PR DESCRIPTION
## Main changes of this PR

This PR splits the commands of the precice-tools binary into individual commands.


| `precice-tools X` | new binary |
| --- | --- |
| `version`, `--version` | `precice-version` |
| `check` | `precice-config-validate` |
| `xml`, `dtd`, `md` | `precice-config-doc X` |

It also adds a deprecation warning to `precice-tools`, new manpages and adds the tools to the test suite.


## Motivation and additional information

Closes https://github.com/orgs/precice/projects/21?pane=issue&itemId=111925011


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
