### PR TITLE
Fortran: precicef_get_mesh_vertex_ids_and_coordinates_ size as pointer

### DIFF
--- a/docs/changelog/2316.md
+++ b/docs/changelog/2316.md
@@ -1,0 +1,1 @@
+- Fixed a bug in the Fortran bindings signature of `precicef_get_mesh_vertex_ids_and_coordinates_`, making the variable `size` a pointer.

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -608,7 +608,7 @@ PRECICE_API void precicef_set_mesh_access_region_(
  */
 PRECICE_API void precicef_get_mesh_vertex_ids_and_coordinates_(
     const char *meshName,
-    const int   size,
+    const int  *size,
     int        *ids,
     double     *coordinates,
     int         meshNameLength);

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -506,15 +506,15 @@ try {
 
 void precicef_get_mesh_vertex_ids_and_coordinates_(
     const char *meshName,
-    const int   size,
+    const int  *size,
     int        *ids,
     double     *coordinates,
     int         meshNameLength)
 try {
   PRECICE_CHECK(impl != nullptr, errormsg);
   auto sv              = precice::impl::strippedStringView(meshName, meshNameLength);
-  auto coordinatesSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * size);
-  impl->getMeshVertexIDsAndCoordinates(sv, {ids, static_cast<unsigned long>(size)}, {coordinates, coordinatesSize});
+  auto coordinatesSize = static_cast<unsigned long>(impl->getMeshDimensions(sv) * *size);
+  impl->getMeshVertexIDsAndCoordinates(sv, {ids, static_cast<unsigned long>(*size)}, {coordinates, coordinatesSize});
 } catch (::precice::Error &e) {
   std::abort();
 }


### PR DESCRIPTION
## Main changes of this PR

In the `precicef_get_mesh_vertex_ids_and_coordinates_`, the variable `size` is currently the only instance in the Fortran bindings not declared as a pointer, **besides** the additional arguments regarding string lengths.

As @fsimonis pointed in a meeting, this should stem from some requirement that, in the way we do interoperability with Fortran, every argument should be a pointer. However, since this already (partially) worked, I am not sure if this is indeed needed.

@ivan-pi do you maybe know more about this?

## Motivation and additional information

Fixes #2315

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [x] ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change) -> Actually, the system tests don't yet cover anything Fortran-related.

## Reviewers' checklist

* Does the changelog entry make sense? Is it formatted correctly? @fsimonis 
* Do you understand the code changes? @fsimonis 
* Do we need a bugfix release? @fsimonis @YaSquall2020