### PR TITLE
Add deprecation warning to precice-profiling

### DIFF
--- a/docs/changelog/2317.md
+++ b/docs/changelog/2317.md
@@ -1,0 +1,1 @@
+- Deprecated the `precice-profiling` script in favor of the `precice-profiling` python package or the `precice-cli`.

--- a/tools/profiling/precice-profiling
+++ b/tools/profiling/precice-profiling
@@ -929,6 +929,13 @@ def mergeCommand(files, outfile, align):
 
 
 if __name__ == "__main__":
+    print(
+        "This script is deprecated, will no longer receive upgrades, and will be removed in preCICE release 4.\n"
+        "Please migrate to the precice-cli (pipx install precice-cli) or the new profiling scripts repository (pipx install precice-profiling).\n"
+        "More information at https://precice.org/tooling-overview.html",
+        file=sys.stderr,
+    )
+
     parser = argparse.ArgumentParser(description="", epilog="")
     subparsers = parser.add_subparsers(
         title="commands",


### PR DESCRIPTION
## Main changes of this PR

This PR deprecates the `precice-profiling` script in favor of the `precice-profiling` package or the `precice-cli`.

## Motivation and additional information

Less to maintain.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
