### PR TITLE
Fix final time series test

### DIFF
--- a/tests/exporter/timeseries/FinalTimeseries.cpp
+++ b/tests/exporter/timeseries/FinalTimeseries.cpp
@@ -81,7 +81,9 @@ BOOST_AUTO_TEST_CASE(FinalTimeseries)
   BOOST_TEST(time == 5);
   BOOST_TEST(interface.getMaxTimeStepSize() == 0);
   interface.finalize();
-  BOOST_TEST(std::filesystem::exists(series));
+  if (context.isPrimary()) {
+    BOOST_TEST(std::filesystem::exists(series));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END() // Timeseries


### PR DESCRIPTION
## Main changes of this PR

Fix the test `precice.Integration/Exporter/Timeseries/FinalTimeseries` which tested a written file on the wrong rank.

## Motivation and additional information

This occasionally failed especially on the macOS runner

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
