### PR TITLE
Allow defining multiple access regions per rank

### DIFF
--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -390,9 +390,14 @@ const BoundingBox &Mesh::getBoundingBox() const
   return _boundingBox;
 }
 
-void Mesh::expandBoundingBox(const BoundingBox &boundingBox)
+void Mesh::appendToAccessRegions(const BoundingBox &boundingBox)
 {
-  _boundingBox.expandBy(boundingBox);
+  _accessRegions.emplace_back(boundingBox);
+}
+
+const std::vector<BoundingBox> &Mesh::getAccessRegions() const
+{
+  return _accessRegions;
 }
 
 void Mesh::preprocess()

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -311,7 +311,9 @@ public:
    */
   const BoundingBox &getBoundingBox() const;
 
-  void expandBoundingBox(const BoundingBox &bounding_box);
+  void appendToAccessRegions(const BoundingBox &bounding_box);
+
+  const std::vector<BoundingBox> &getAccessRegions() const;
 
   bool operator==(const Mesh &other) const;
 
@@ -401,7 +403,8 @@ private:
   /// for just-in-time mapping, we need an artificial mesh, which we can use
   bool _isJustInTime = false;
 
-  BoundingBox _boundingBox;
+  BoundingBox              _boundingBox;
+  std::vector<BoundingBox> _accessRegions;
 
   query::Index _index;
 

--- a/src/mesh/Utils.cpp
+++ b/src/mesh/Utils.cpp
@@ -69,9 +69,15 @@ Eigen::VectorXd integrateVolume(const PtrMesh &mesh, const Eigen::VectorXd &inpu
   return integral;
 }
 
-std::size_t countVerticesInBoundingBox(mesh::PtrMesh mesh, const mesh::BoundingBox &bb)
+std::size_t countVerticesInBoundingBox(mesh::PtrMesh mesh, const std::vector<mesh::BoundingBox> &bbs)
 {
-  return std::count_if(mesh->vertices().cbegin(), mesh->vertices().cend(), [&bb](const auto &v) { return bb.contains(v); });
+  return std::count_if(mesh->vertices().cbegin(),
+                       mesh->vertices().cend(),
+                       [&bbs](const mesh::Vertex &v) {
+                         return std::any_of(bbs.cbegin(),
+                                            bbs.cend(),
+                                            [&v](const auto &bb) { return bb.contains(v); });
+                       });
 }
 
 } // namespace precice::mesh

--- a/src/mesh/Utils.cpp
+++ b/src/mesh/Utils.cpp
@@ -73,7 +73,7 @@ std::size_t countVerticesInBoundingBox(mesh::PtrMesh mesh, const std::vector<mes
 {
   return std::count_if(mesh->vertices().cbegin(),
                        mesh->vertices().cend(),
-                       [&bbs](const mesh::Vertex &v) {
+                       [&bbs](const auto &v) {
                          return std::any_of(bbs.cbegin(),
                                             bbs.cend(),
                                             [&v](const auto &bb) { return bb.contains(v); });

--- a/src/mesh/Utils.hpp
+++ b/src/mesh/Utils.hpp
@@ -154,6 +154,6 @@ std::optional<std::size_t> locateInvalidVertexID(const Mesh &mesh, const Contain
 }
 
 /// Given a Mesh and a bounding box, counts all vertices within the bounding box
-std::size_t countVerticesInBoundingBox(mesh::PtrMesh mesh, const mesh::BoundingBox &bb);
+std::size_t countVerticesInBoundingBox(mesh::PtrMesh mesh, const std::vector<mesh::BoundingBox> &bbs);
 
 } // namespace precice::mesh

--- a/src/partition/ReceivedPartition.hpp
+++ b/src/partition/ReceivedPartition.hpp
@@ -85,7 +85,8 @@ private:
 
   GeometricFilter _geometricFilter;
 
-  mesh::BoundingBox _bb;
+  mesh::BoundingBox              _bb;
+  std::vector<mesh::BoundingBox> _accessCollection;
 
   int _dimensions;
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1427,7 +1427,7 @@ void ParticipantImpl::setMeshAccessRegion(
   PRECICE_TRACE(meshName, boundingBox.size());
   PRECICE_REQUIRE_MESH_USE(meshName);
   PRECICE_CHECK(_accessor->isMeshReceived(meshName) && _accessor->isDirectAccessAllowed(meshName),
-                "This participant attempteded to set an access region (via \"setMeshAccessRegion\") on mesh \"{0}\", "
+                "This participant attempted to set an access region (via \"setMeshAccessRegion\") on mesh \"{0}\", "
                 "but mesh \"{0}\" is either not a received mesh or its api access was not enabled in the configuration. "
                 "setMeshAccessRegion(...) is only valid for (<receive-mesh name=\"{0}\" ... api-access=\"true\"/>).",
                 meshName);
@@ -1458,7 +1458,7 @@ void ParticipantImpl::setMeshAccessRegion(
   // Create a bounding box
   context.userDefinedAccessRegions.emplace_back(mesh::BoundingBox{bounds});
   // Expand the mesh associated bounding box
-  mesh.expandBoundingBox(*context.userDefinedAccessRegion.get());
+  mesh.appendToAccessRegions(context.userDefinedAccessRegions.back());
 }
 
 void ParticipantImpl::getMeshVertexIDsAndCoordinates(

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel.cpp
@@ -10,12 +10,13 @@ BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
 PRECICE_TEST_SETUP("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks))
-BOOST_AUTO_TEST_CASE(AccessReceivedMeshMultipleBoundingBoxes)
+BOOST_AUTO_TEST_CASE(AccessReceivedMeshMultipleBBTwoLevel)
 {
   PRECICE_TEST();
 
   /// Tests setting the access region multiple times
   /// ranks are overlapping and the bounding boxes are complementing
+  /// Same as AccessReceivedMeshMultipleBoundingBoxes using 2LI
   runTestMultipleBoundingBoxes2D(context);
 }
 

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Velocities" />
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Velocities" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <receive-mesh name="MeshTwo" from="SolverTwo" api-access="true" />
+    <write-data name="Velocities" mesh="MeshTwo" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Velocities" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" use-two-level-initialization="true" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel3D.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel3D.cpp
@@ -1,0 +1,25 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+#include "helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+PRECICE_TEST_SETUP("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks))
+BOOST_AUTO_TEST_CASE(AccessReceivedMeshMultipleBBTwoLevel3D)
+{
+  PRECICE_TEST();
+
+  /// Tests setting the access region multiple times
+  runTestMultipleBoundingBoxes3D(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel3D.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel3D.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Velocities" />
+  <data:scalar name="Forces" />
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="Velocities" />
+    <use-data name="Forces" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <receive-mesh name="MeshTwo" from="SolverTwo" api-access="true" />
+    <write-data name="Velocities" mesh="MeshTwo" />
+    <read-data name="Forces" mesh="MeshTwo" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Velocities" mesh="MeshTwo" />
+    <write-data name="Forces" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" use-two-level-initialization="true" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+    <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes.cpp
@@ -1,0 +1,33 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+#include "helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+PRECICE_TEST_SETUP("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks))
+BOOST_AUTO_TEST_CASE(AccessReceivedMeshOverlap)
+{
+  PRECICE_TEST();
+  // Test case for parallel mesh partitioning without any mapping. Each solver
+  // runs on two ranks. SolverTwo defines 5(2 and 3) vertices which need to be
+  // repartitioned on SolverOne according to the defined boundingBoxes
+  // (resulting in 3 and 3 vertices per rank). The boundingBoxes of the other
+  // participant have an overlap including the common vertex with position 3.
+  // The vertex is 'written' by both ranks and summed up on the receiver side.  BOOST_TEST(false);
+  const std::vector<double> boundingBoxSecondaryRank      = std::vector<double>{0.0, 1.0, 3.0, 7};
+  const std::vector<double> expectedPositionSecondaryRank = std::vector<double>{0.0, 3.0, 0.0, 4.0, 0.0, 5.0};
+  const std::vector<double> writeDataSecondaryRank        = std::vector<double>({4, 5, 6});
+  const std::vector<double> expectedReadDataSecondaryRank = std::vector<double>({7, 5, 6});
+  runTestAccessReceivedMesh(context, boundingBoxSecondaryRank, writeDataSecondaryRank, expectedPositionSecondaryRank, expectedReadDataSecondaryRank, 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Velocities" />
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Velocities" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <receive-mesh name="MeshTwo" from="SolverTwo" api-access="true" />
+    <write-data name="Velocities" mesh="MeshTwo" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Velocities" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes3D.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes3D.cpp
@@ -1,0 +1,25 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+#include "helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+PRECICE_TEST_SETUP("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks))
+BOOST_AUTO_TEST_CASE(AccessReceivedMeshMultipleBoundingBoxes3D)
+{
+  PRECICE_TEST();
+
+  /// Tests setting the access region multiple times
+  runTestMultipleBoundingBoxes3D(context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes3D.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes3D.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Velocities" />
+  <data:scalar name="Forces" />
+
+  <mesh name="MeshTwo" dimensions="3">
+    <use-data name="Velocities" />
+    <use-data name="Forces" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <receive-mesh name="MeshTwo" from="SolverTwo" api-access="true" />
+    <write-data name="Velocities" mesh="MeshTwo" />
+    <read-data name="Forces" mesh="MeshTwo" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Velocities" mesh="MeshTwo" />
+    <write-data name="Forces" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" use-two-level-initialization="false" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+    <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.cpp
@@ -6,6 +6,17 @@
 #include <vector>
 #include "helpers.hpp"
 
+// Test case for a direct mesh access on one participant to a mesh defined
+// by another participant. In addition to the direct mesh access
+// and data writing in one direction, an additional mapping (NN) is defined
+// in the other direction.
+// We also test that getMeshVertexSize and getMeshVertexIDsAndCoordinates
+// correctly filter out one vertex (-0.5, -0.5) which is not in the access
+// region, but is used for mapping.
+// Since the user has no opportunity to get the "filtered" vertex (unless
+// the bounding box is enlarged), the read data value on the SolverTwo
+// participant is zero ( last entry in l115 {15, 16, 0}).
+// The access region is set via two bounding boxes
 BOOST_AUTO_TEST_SUITE(Integration)
 BOOST_AUTO_TEST_SUITE(Parallel)
 BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
@@ -30,7 +41,10 @@ BOOST_AUTO_TEST_CASE(AccessReceivedMeshMultipleBoundingBoxesWithMapping)
     std::vector<int> ownIDs(positions.size() / dim, -1);
     interface.setMeshVertices(ownMeshName, positions, ownIDs);
 
-    std::array<double, dim * 2> boundingBox = context.isPrimary() ? std::array<double, dim * 2>{0.0, 1.0, 0.0, 3.5} : std::array<double, dim * 2>{0.0, 1.0, 3.5, 5.0};
+    std::array<double, dim * 2> boundingBox = context.isPrimary() ? std::array<double, dim * 2>{0.0, 1.0, 0.0, 1.5} : std::array<double, dim * 2>{0.0, 1.0, 3.5, 4.0};
+    // Define region of interest, where we could obtain direct write access
+    interface.setMeshAccessRegion(otherMeshName, boundingBox);
+    boundingBox = context.isPrimary() ? std::array<double, dim * 2>{0.0, 1.0, 1.4, 3.5} : std::array<double, dim * 2>{0.0, 1.0, 4.0, 5.0};
     // Define region of interest, where we could obtain direct write access
     interface.setMeshAccessRegion(otherMeshName, boundingBox);
     // interface.setMeshAccessRegion(otherMeshName, boundingBox);

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.cpp
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.cpp
@@ -1,0 +1,116 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+#include "helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(DirectMeshAccess)
+PRECICE_TEST_SETUP("SolverOne"_on(2_ranks), "SolverTwo"_on(2_ranks))
+BOOST_AUTO_TEST_CASE(AccessReceivedMeshMultipleBoundingBoxesWithMapping)
+{
+  PRECICE_TEST();
+
+  if (context.isNamed("SolverOne")) {
+    // Set up Participant
+    precice::Participant interface(context.name, context.config(), context.rank, context.size);
+    constexpr int        dim           = 2;
+    auto                 ownMeshName   = "MeshOne";
+    auto                 otherMeshName = "MeshTwo";
+    auto                 readDataName  = "Forces";
+    auto                 writeDataName = "Velocities";
+    BOOST_TEST(interface.getMeshDimensions(ownMeshName) == 2);
+    BOOST_TEST(interface.getMeshDimensions(otherMeshName) == 2);
+
+    std::vector<double> positions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.0, -0.5, -0.5}) : std::vector<double>({0.0, 4.0, 0.0, 5.0, 0.0, 6.0});
+
+    std::vector<int> ownIDs(positions.size() / dim, -1);
+    interface.setMeshVertices(ownMeshName, positions, ownIDs);
+
+    std::array<double, dim * 2> boundingBox = context.isPrimary() ? std::array<double, dim * 2>{0.0, 1.0, 0.0, 3.5} : std::array<double, dim * 2>{0.0, 1.0, 3.5, 5.0};
+    // Define region of interest, where we could obtain direct write access
+    interface.setMeshAccessRegion(otherMeshName, boundingBox);
+    // interface.setMeshAccessRegion(otherMeshName, boundingBox);
+
+    interface.initialize();
+    double dt = interface.getMaxTimeStepSize();
+    // Get the size of the filtered mesh within the bounding box
+    // (provided by the coupling participant)
+    const int otherMeshSize = interface.getMeshVertexSize(otherMeshName);
+    BOOST_TEST(otherMeshSize == 3);
+
+    // Allocate a vector containing the vertices
+    std::vector<double> solverTwoMesh(otherMeshSize * dim);
+    std::vector<int>    otherIDs(otherMeshSize, -1);
+    // Here, we don't receive vertex -0.5,-0.5, it's filtered out
+    interface.getMeshVertexIDsAndCoordinates(otherMeshName, otherIDs, solverTwoMesh);
+    // Expected data = positions of the other participant's mesh
+    const std::vector<double> expectedData = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, 0.0, 3.5}) : std::vector<double>({0.0, 3.5, 0.0, 4.0, 0.0, 5.0});
+    BOOST_TEST(solverTwoMesh == expectedData, boost::test_tools::per_element());
+
+    // Some dummy writeData
+    std::vector<double> writeData;
+    for (int i = 0; i < otherMeshSize; ++i)
+      writeData.emplace_back(i + 5 + (10 * context.isPrimary()));
+
+    std::vector<double> readData(ownIDs.size(), -1);
+
+    while (interface.isCouplingOngoing()) {
+      // Write data
+      interface.writeData(otherMeshName, writeDataName, otherIDs, writeData);
+      interface.advance(dt);
+      dt = interface.getMaxTimeStepSize();
+      interface.readData(ownMeshName, readDataName, ownIDs, dt, readData);
+
+      // Expected data according to the writeData
+      // Values are summed up
+      std::vector<double> expectedData = context.isPrimary() ? std::vector<double>({0, 1, 0, 2}) : std::vector<double>({1, 2, 2});
+      BOOST_TEST(precice::testing::equals(expectedData, readData));
+    }
+  } else {
+    // Query IDs
+    auto meshName      = "MeshTwo";
+    auto writeDataName = "Forces";
+    auto readDataName  = "Velocities";
+
+    precice::Participant interface(context.name, context.config(), context.rank, context.size);
+    const int            dim = interface.getMeshDimensions(meshName);
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    std::vector<double> positions = context.isPrimary() ? std::vector<double>({0.0, 1.0, 0.0, 2.0, -0.5, -0.5}) : std::vector<double>({0.0, 3.5, 0.0, 4.0, 0.0, 5.0});
+    std::vector<int>    ids(positions.size() / dim, -1);
+
+    // Define the mesh
+    interface.setMeshVertices(meshName, positions, ids);
+    // Allocate data to read
+    std::vector<double> readData(ids.size(), -1);
+    std::vector<double> writeData;
+    for (unsigned int i = 0; i < ids.size(); ++i)
+      writeData.emplace_back(i);
+
+    // Initialize
+    interface.initialize();
+    double dt = interface.getMaxTimeStepSize();
+
+    while (interface.isCouplingOngoing()) {
+
+      interface.writeData(meshName, writeDataName, ids, writeData);
+      interface.advance(dt);
+      dt = interface.getMaxTimeStepSize();
+
+      interface.readData(meshName, readDataName, ids, dt, readData);
+      // Expected data according to the writeData
+      // Values are summed up
+      std::vector<double> expectedData = context.isPrimary() ? std::vector<double>({15, 16, 0}) : std::vector<double>({22, 6, 7});
+      BOOST_TEST(expectedData == readData, boost::test_tools::per_element());
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DirectMeshAccess
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.xml
+++ b/tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Velocities" />
+  <data:scalar name="Forces" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="Forces" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="Velocities" />
+    <use-data name="Forces" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <receive-mesh name="MeshTwo" from="SolverTwo" safety-factor="0" api-access="true" />
+    <write-data name="Velocities" mesh="MeshTwo" />
+    <read-data name="Forces" mesh="MeshOne" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <provide-mesh name="MeshTwo" />
+    <read-data name="Velocities" mesh="MeshTwo" />
+    <write-data name="Forces" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Velocities" mesh="MeshTwo" from="SolverOne" to="SolverTwo" />
+    <exchange data="Forces" mesh="MeshTwo" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/direct-mesh-access/helpers.hpp
+++ b/tests/parallel/direct-mesh-access/helpers.hpp
@@ -16,4 +16,6 @@ void runTestAccessReceivedMesh(const TestContext        &context,
 
 void runTestMultipleBoundingBoxes2D(const TestContext &context);
 
+void runTestMultipleBoundingBoxes3D(const TestContext &context);
+
 #endif

--- a/tests/parallel/direct-mesh-access/helpers.hpp
+++ b/tests/parallel/direct-mesh-access/helpers.hpp
@@ -14,4 +14,6 @@ void runTestAccessReceivedMesh(const TestContext        &context,
                                const std::vector<double> expectedReadDataSecondaryRank,
                                const size_t              startIndex);
 
+void runTestMultipleBoundingBoxes2D(const TestContext &context);
+
 #endif

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -33,7 +33,9 @@ target_sources(testprecice
     tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.cpp
+    tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes.cpp
+    tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -34,7 +34,9 @@ target_sources(testprecice
     tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel.cpp
+    tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBBTwoLevel3D.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes.cpp
+    tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes3D.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxesWithMapping.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.cpp

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -33,6 +33,7 @@ target_sources(testprecice
     tests/parallel/direct-mesh-access/AccessReceivedMeshAndMapping.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartition.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshEmptyPartitionTwoLevelInit.cpp
+    tests/parallel/direct-mesh-access/AccessReceivedMeshMultipleBoundingBoxes.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlap.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshNoOverlapTwoLevelInit.cpp
     tests/parallel/direct-mesh-access/AccessReceivedMeshOverlap.cpp


### PR DESCRIPTION
## Main changes of this PR

Allows defining multiple access regions per rank.

## Motivation and additional information

Allows calling `setMeshAccessRegion` multiple times before calling `initialize()`. preCICE then repartitions and operates on a bounding box collection rather than a single bounding box. This gives additional flexibility for describing the domain in terms of axis-aligned bounding boxes.

FYI @IshaanDesai 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
