### PR TITLE
Add return code on validate error

### DIFF
--- a/src/drivers/validate.cpp
+++ b/src/drivers/validate.cpp
@@ -38,6 +38,7 @@ int main(int argc, char **argv)
   try {
     precice::tooling::checkConfiguration(file, participant, size);
   } catch (const ::precice::Error &) {
+    return 2;
   }
   return 0;
 }


### PR DESCRIPTION
## Main changes of this PR

This PR adds return code 2 when validation fails with an error using `precice-config-validate`.

## Motivation and additional information

This is seen as a bug fix for a73ae00b89061530155554212dfdf34490b0c5b9

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
