### PR TITLE
Add default intracom without MPI

### DIFF
--- a/docs/changelog/2336.md
+++ b/docs/changelog/2336.md
@@ -1,0 +1,1 @@
+- Added implicit socket-based intra-comms for parallel participants in case preCICE is compiled without MPI.

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -8,7 +8,6 @@
 
 #include "action/Action.hpp"
 #include "action/config/ActionConfiguration.hpp"
-#include "com/MPIDirectCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "com/config/CommunicationConfiguration.hpp"
 #include "io/ExportCSV.hpp"
@@ -34,6 +33,12 @@
 #include "utils/networking.hpp"
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLAttribute.hpp"
+
+#ifdef PRECICE_NO_MPI
+#include "com/SocketCommunication.hpp"
+#else
+#include "com/MPIDirectCommunication.hpp"
+#endif
 
 namespace precice::config {
 
@@ -759,12 +764,15 @@ void ParticipantConfiguration::finishParticipantConfiguration(
   // create default primary communication if needed
   if (context.size > 1 && not _isIntraCommDefined && participant->getName() == context.name) {
 #ifdef PRECICE_NO_MPI
-    PRECICE_ERROR("Implicit intra-participant communications for parallel participants are only available if preCICE was built with MPI. "
-                  "Either explicitly define an intra-participant communication for each parallel participant or rebuild preCICE with \"PRECICE_MPICommunication=ON\".");
+    auto lo = utils::networking::loopbackInterfaceName();
+    PRECICE_INFO("Implicit intra-participant communications for parallel participants using preCICE without MPI defaults to a sockets intracomm using the default loopback device {}. "
+                 "Define your own <intra-comm:sockets ... /> to modify these defaults.",
+                 lo);
+    utils::IntraComm::getCommunication() = std::make_shared<com::SocketCommunication>(0, false, lo, ".");
 #else
     utils::IntraComm::getCommunication() = std::make_shared<com::MPIDirectCommunication>();
-    participant->setUsePrimaryRank(true);
 #endif
+    participant->setUsePrimaryRank(true);
   }
   _isIntraCommDefined = false; // to not mess up with previous participant
 }


### PR DESCRIPTION
## Main changes of this PR

This PR adds a default intra-comm for the case that preCICE is not build with MPI.
It uses the default loopback as network and emits an info message on how to customize the comm by defining your own.

## Motivation and additional information

Closes #2026
Related to #2334

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
