### PR TITLE
Add simple config testing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
   hooks:
   - id: precice-config-format
     name: format preCICE configs
-    exclude: "^src/precice/tests/emptyconfig.xml"
+    exclude: "^(src/precice/tests/emptyconfig.xml|tests/config/empty.xml)"
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.1
   hooks:

--- a/cmake/CTestConfig.cmake
+++ b/cmake/CTestConfig.cmake
@@ -340,6 +340,57 @@ if(PRECICE_BUILD_TOOLS)
     NAME config-validate.file+name+size
     COMMAND precice-config-validate ${PROJECT_SOURCE_DIR}/src/precice/tests/config-checker.xml SolverTwo 2
     )
+
+  # Simple configuration tests
+
+  function(precice_test_config_valid path)
+    set(name "precice.config.${path}.valid")
+    set(solver "")
+    set(ranks "")
+
+    if (ARGC GREATER 1)
+      set(solver "${ARGV1}")
+      set(name "${name}:${solver}")
+    endif()
+
+    if (ARGC GREATER 2)
+      set(ranks "${ARGV2}")
+      set(name "${name}@${ranks}")
+    endif()
+    add_test(NAME ${name}
+      COMMAND precice-config-validate "${PROJECT_SOURCE_DIR}/tests/config/${path}" ${name} ${ranks}
+      )
+    set_tests_properties(${name}
+      PROPERTIES
+      TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+      LABELS "tools;bin;config;valid")
+  endfunction()
+
+  function(precice_test_config_invalid path expression)
+    set(name "precice.config.${path}.invalid")
+    set(solver "")
+    set(ranks "")
+
+    if (ARGC GREATER 2)
+      set(solver "${ARGV2}")
+      set(name "${name}:${solver}")
+    endif()
+
+    if (ARGC GREATER 3)
+      set(ranks "${ARGV3}")
+      set(name "${name}@${ranks}")
+    endif()
+    add_test(NAME ${name}
+      COMMAND precice-config-validate "${PROJECT_SOURCE_DIR}/tests/config/${path}" ${name} ${ranks}
+      )
+    set_tests_properties(${name}
+      PROPERTIES
+      TIMEOUT ${PRECICE_TEST_TIMEOUT_SHORT}
+      PASS_REGULAR_EXPRESSION "${expression}"
+      LABELS "tools;bin;config;invalid")
+  endfunction()
+
+  include(${PROJECT_SOURCE_DIR}/tests/config/tests.cmake)
 endif()
 
 # Add a separate target to test only the base

--- a/tests/config/empty.xml
+++ b/tests/config/empty.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+</precice-configuration>

--- a/tests/config/solverdummies.xml
+++ b/tests/config/solverdummies.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <min-iterations value="2" />
+    <max-iterations value="2" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/config/tests.cmake
+++ b/tests/config/tests.cmake
@@ -1,0 +1,10 @@
+# precice_test_config_invalid( <PATH> <EXPECTED EXPRESSION> [Solver] [Ranks])
+# precice_test_config_valid( <PATH> [Solver] [Ranks])
+
+precice_test_config_invalid(missing.xml "unable to open configuration file")
+precice_test_config_invalid(empty.xml "Tag <mesh> was not found")
+
+precice_test_config_valid(solverdummies.xml)
+precice_test_config_valid(solverdummies.xml SolverTwo)
+precice_test_config_valid(solverdummies.xml SolverTwo 3)
+precice_test_config_valid(solverdummies.xml SolverOne)


### PR DESCRIPTION
## Main changes of this PR

This PR adds a simple system for testing configuration files to be valid or invalid.

These tests live in `tests/config/tests.cmake` and the folder contain all configurations.

The usage is:

```
# Usage is identical to precice-config-validate
precice_test_config_valid( <PATH> [Solver] [Ranks])

# Second argument is an expresssion that is used to detect the error message for the test to pass
precice_test_config_invalid( <PATH> <EXPECTED EXPRESSION> [Solver] [Ranks])
```

## Motivation and additional information

The configs are not split into valid and invalid as one Solver or even runtime situations (Solvers and ranks) can lead to different failure.
Example: define an intra-com and run in serial vs in parallel.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
