### PR TITLE
Use pre-commit action

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,16 +40,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
          python-version: '3.x'
-      - name: Install pre-commit
-        run: pip install pre-commit
-      - name: Run checks
-        run: pre-commit run -a -v
-      - name: Git status
-        if: always()
-        run: git status
-      - name: Full diff
-        if: always()
-        run: git diff
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
 
   linux:
     name: ${{ format('{0} {1} {2} {3}', matrix.IMAGE, matrix.CXX, matrix.CONFIG, matrix.TYPE) }}


### PR DESCRIPTION
## Main changes of this PR

This PR migrates the CI workflow to the pre-commit action.


## Motivation and additional information

This caches the venvs and reduces the time taken until the other runs start

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
