### PR TITLE
Fix first-participant time computation bug

### DIFF
--- a/docs/changelog/2344.md
+++ b/docs/changelog/2344.md
@@ -1,0 +1,1 @@
+- Fixed rounding errors computing time-window size to send to the second participant using `<time-window-size method="first-participant" />`.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -516,6 +516,11 @@ double BaseCouplingScheme::getTimeWindowStart() const
   return _time.windowStart();
 }
 
+double BaseCouplingScheme::getTimeWindowProgress() const
+{
+  return _time.windowProgress();
+}
+
 int BaseCouplingScheme::getTimeWindows() const
 {
   return _timeWindows;

--- a/src/cplscheme/BaseCouplingScheme.hpp
+++ b/src/cplscheme/BaseCouplingScheme.hpp
@@ -114,6 +114,8 @@ public:
 
   double getTimeWindowStart() const final override;
 
+  double getTimeWindowProgress() const;
+
   /**
    * @brief getter for _timeWindows
    * @returns the number of currently computed time windows of the coupling scheme.

--- a/src/cplscheme/SerialCouplingScheme.cpp
+++ b/src/cplscheme/SerialCouplingScheme.cpp
@@ -62,7 +62,7 @@ void SerialCouplingScheme::sendTimeWindowSize()
 {
   PRECICE_TRACE();
   if (_participantSetsTimeWindowSize) {
-    setTimeWindowSize(getTime() - getTimeWindowStart());
+    setTimeWindowSize(getTimeWindowProgress());
     setNextTimeWindowSize(UNDEFINED_TIME_WINDOW_SIZE);
     PRECICE_DEBUG("sending time window size of {}", getTimeWindowSize());
     getM2N()->send(getTimeWindowSize());

--- a/tests/serial/time/explicit/serial-coupling/FirstParticipantTimeBug.cpp
+++ b/tests/serial/time/explicit/serial-coupling/FirstParticipantTimeBug.cpp
@@ -1,0 +1,53 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Explicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+/**
+ * @brief ParticipantFirst leads to rounding errors in time management super quickly
+ * Triggers an assertion in tw=3
+ */
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank))
+BOOST_AUTO_TEST_CASE(FirstParticipantTimeBug)
+{
+  PRECICE_TEST();
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  std::string meshName;
+  if (context.isNamed("SolverOne")) {
+    meshName = "SolverOne-Mesh";
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName = "SolverTwo-Mesh";
+  }
+
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
+  precice.initialize();
+  while (precice.isCouplingOngoing()) {
+    if (context.isNamed("SolverOne")) {
+      precice.advance(101.1);
+    } else {
+      // Hits assertion in tw=3
+      precice.advance(precice.getMaxTimeStepSize());
+    }
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Explicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/explicit/serial-coupling/FirstParticipantTimeBug.xml
+++ b/tests/serial/time/explicit/serial-coupling/FirstParticipantTimeBug.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="4" />
+    <time-window-size method="first-participant" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -420,6 +420,7 @@ target_sources(testprecice
     tests/serial/time/explicit/serial-coupling/DoNothingWithSmallStepsNoSubsteps.cpp
     tests/serial/time/explicit/serial-coupling/DoNothingWithSmallStepsSubsteps.cpp
     tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
+    tests/serial/time/explicit/serial-coupling/FirstParticipantTimeBug.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataWithSubcycling.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR fixes severe rounding error when computing the passed time to send to the second participant using `<time-window-size method="first-participant" />`.

## Motivation and additional information

See this [Discourse post](https://precice.discourse.group/t/issue-with-variable-time-window-size-in-serial-explicit-coupling-readdata-cannot-sample-data-outside-of-current-time-window/2592)

This was not yet ported to the new time accumulators.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
