### PR TITLE
Add test using random participant-first timesteps

### DIFF
--- a/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.cpp
+++ b/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.cpp
@@ -41,7 +41,6 @@ BOOST_AUTO_TEST_CASE(FirstParticipantRandomTimeWindows)
     double dt = context.isNamed("SolverOne") ? dist(gen) : precice.getMaxTimeStepSize();
 
     if (context.isNamed("SolverTwo")) {
-      // Bug #2160, read fails in tw=7 t=60.06
       precice.readData(meshName, "Data-One", {&vertexID, 1}, dt, value);
     } else {
       precice.writeData(meshName, "Data-One", {&vertexID, 1}, value);

--- a/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.cpp
+++ b/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.cpp
@@ -1,0 +1,59 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <random>
+
+using namespace precice;
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Time)
+BOOST_AUTO_TEST_SUITE(Explicit)
+BOOST_AUTO_TEST_SUITE(SerialCoupling)
+
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank))
+BOOST_AUTO_TEST_CASE(FirstParticipantRandomTimeWindows)
+{
+  PRECICE_TEST();
+
+  Participant precice(context.name, context.config(), 0, 1);
+
+  std::mt19937                        gen(101); // seed for reproducibility
+  std::lognormal_distribution<double> dist(-2.0, 0.5);
+
+  std::array<double, 3> value{1, 1, 1}; // value doesn't matter
+
+  std::string meshName, writeDataName, readDataName;
+  if (context.isNamed("SolverOne")) {
+    meshName = "SolverOne-Mesh";
+  } else {
+    BOOST_TEST(context.isNamed("SolverTwo"));
+    meshName = "SolverTwo-Mesh";
+  }
+
+  double   v0[]     = {0, 0, 0};
+  VertexID vertexID = precice.setMeshVertex(meshName, v0);
+  precice.initialize();
+  while (precice.isCouplingOngoing()) {
+    // SolverOne takes random steps
+    double dt = context.isNamed("SolverOne") ? dist(gen) : precice.getMaxTimeStepSize();
+
+    if (context.isNamed("SolverTwo")) {
+      // Bug #2160, read fails in tw=7 t=60.06
+      precice.readData(meshName, "Data-One", {&vertexID, 1}, dt, value);
+    } else {
+      precice.writeData(meshName, "Data-One", {&vertexID, 1}, value);
+    }
+    precice.advance(dt);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Serial
+BOOST_AUTO_TEST_SUITE_END() // Time
+BOOST_AUTO_TEST_SUITE_END() // Explicit
+BOOST_AUTO_TEST_SUITE_END() // SerialCoupling
+
+#endif // PRECICE_NO_MPI

--- a/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.cpp
+++ b/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.cpp
@@ -41,6 +41,8 @@ BOOST_AUTO_TEST_CASE(FirstParticipantRandomTimeWindows)
     double dt = context.isNamed("SolverOne") ? dist(gen) : precice.getMaxTimeStepSize();
 
     if (context.isNamed("SolverTwo")) {
+      precice.readData(meshName, "Data-One", {&vertexID, 1}, 0.0, value);
+      precice.readData(meshName, "Data-One", {&vertexID, 1}, dt / 2, value);
       precice.readData(meshName, "Data-One", {&vertexID, 1}, dt, value);
     } else {
       precice.writeData(meshName, "Data-One", {&vertexID, 1}, value);

--- a/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.xml
+++ b/tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1000" />
+    <time-window-size method="first-participant" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -420,6 +420,7 @@ target_sources(testprecice
     tests/serial/time/explicit/serial-coupling/DoNothingWithSmallStepsNoSubsteps.cpp
     tests/serial/time/explicit/serial-coupling/DoNothingWithSmallStepsSubsteps.cpp
     tests/serial/time/explicit/serial-coupling/DoNothingWithSubcycling.cpp
+    tests/serial/time/explicit/serial-coupling/FirstParticipantRandomTimeWindows.cpp
     tests/serial/time/explicit/serial-coupling/FirstParticipantTimeBug.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipant.cpp
     tests/serial/time/explicit/serial-coupling/ReadWriteScalarDataFirstParticipantInitData.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds a test with random time-window sizes using the participant-first method.

## Motivation and additional information

This attempts to prevent time problems with varying time-window sizes.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
