### PR TITLE
Add error for blind advance using first-participant method

### DIFF
--- a/docs/changelog/2347.md
+++ b/docs/changelog/2347.md
@@ -1,0 +1,1 @@
+- Added a clear error message when calling `advance(getMaxTimeStepSize())` on the participant that is supposed to provide the time-window size due to `<time-window-size method="first-participant"/>`.

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -457,6 +457,13 @@ bool BaseCouplingScheme::addComputedTime(
   PRECICE_TRACE(timeToAdd, getTime());
   PRECICE_ASSERT(isCouplingOngoing(), "Invalid call of addComputedTime() after simulation end.");
 
+  if (!hasTimeWindowSize()) {
+    PRECICE_CHECK(timeToAdd < std::numeric_limits<double>::max(),
+                  "advance() was called with the max value of double which is not allowed. "
+                  "As this participant prescribes the time-window size using <time-window-size method=\"first-participant\" />, directly using getMaxTimeStepSize() is not permitted. "
+                  "Make sure to pass your own desired time-step size or use the recommended limiting \"dt = min(solver_dt, getMaxTimeStepSize())\".");
+  }
+
   // Check validness
   bool valid = math::greaterEquals(getNextTimeStepMaxSize(), timeToAdd);
   PRECICE_CHECK(valid,

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -410,8 +410,12 @@ void ParticipantImpl::advance(
   PRECICE_CHECK(_state == State::Initialized, "initialize() has to be called before advance().");
   PRECICE_ASSERT(_couplingScheme->isInitialized());
   PRECICE_CHECK(isCouplingOngoing(), "advance() cannot be called when isCouplingOngoing() returns false.");
+
+  // validating computed time step
+  PRECICE_CHECK(std::isfinite(computedTimeStepSize), "advance() cannot be called with an infinite time step size.");
   PRECICE_CHECK(!math::equals(computedTimeStepSize, 0.0), "advance() cannot be called with a time step size of 0.");
   PRECICE_CHECK(computedTimeStepSize > 0.0, "advance() cannot be called with a negative time step size {}.", computedTimeStepSize);
+
   _numberAdvanceCalls++;
 
 #ifndef NDEBUG

--- a/tests/fundamental/first-participant/InfiniteAdvance.cpp
+++ b/tests/fundamental/first-participant/InfiniteAdvance.cpp
@@ -1,0 +1,38 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Fundamental)
+BOOST_AUTO_TEST_SUITE(FirstParticipant)
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank))
+BOOST_AUTO_TEST_CASE(InfiniteAdvance)
+{
+  PRECICE_TEST();
+
+  precice::Participant participant(context.name, context.config(), context.rank, context.size);
+
+  std::vector<double> coords{0.0, 0.0, 0.0};
+  participant.setMeshVertex(context.name + "-Mesh", coords);
+
+  if (context.isNamed("SolverOne")) {
+    participant.initialize();
+
+    // fails as max dt is infinite / max double
+    BOOST_CHECK_EXCEPTION(participant.advance(participant.getMaxTimeStepSize()),
+                          ::precice::Error,
+                          ::precice::testing::errorContains("time-window-size method="));
+  } else {
+    // fails as the connection is cut
+    BOOST_CHECK_THROW(participant.initialize(), ::precice::Error);
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // FirstParticipant
+BOOST_AUTO_TEST_SUITE_END() // Fundamental
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/fundamental/first-participant/InfiniteAdvance.xml
+++ b/tests/fundamental/first-participant/InfiniteAdvance.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1000" />
+    <time-window-size method="first-participant" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -7,6 +7,7 @@ target_sources(testprecice
     tests/exporter/timeseries/FinalTimeseries.cpp
     tests/exporter/timeseries/UpdatedTimeseries.cpp
     tests/fundamental/DifferentConfigs.cpp
+    tests/fundamental/first-participant/InfiniteAdvance.cpp
     tests/fundamental/initial-data/InterleavedCreation.cpp
     tests/fundamental/initial-data/InterleavedCreationWithGradients.cpp
     tests/fundamental/just-in-time/Both/NoneConfigured.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR adds an error for the case where a user calls `p.advance(p.getMaxTimeStepSize())` on the first participant using `<time-window-size method="first-participant"/>`.
As the participant dictate the time-window-size, the max timestep is max double in practise.

Note that this isn't an issue if the user employs the recommended time negotiation:

```
precice_dt = getMaxTimeStepSize()
solver_dt = askSolver()
dt = min(solver_dt, precice_dt)
```

## Motivation and additional information

Closes #2341

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
