### PR TITLE
Fix Boost ASIO 1.89

### DIFF
--- a/docs/changelog/2351.md
+++ b/docs/changelog/2351.md
@@ -1,0 +1,1 @@
+- Fixed compatibility with boost.asio 1.89.0

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
 
 #include <filesystem>
 #include <sstream>


### PR DESCRIPTION
## Main changes of this PR

This PR fixes incompatibility with boost asio 1.89

## Motivation and additional information

```
 Removed deadline_timer, basic_deadline_timer and time_traits from the convenience header boost/asio.hpp. 
```

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
