### PR TITLE
Cleanup configuration check

### DIFF
--- a/src/drivers/main.cpp
+++ b/src/drivers/main.cpp
@@ -64,6 +64,7 @@ int main(int argc, char **argv)
     try {
       precice::tooling::checkConfiguration(file, participant, size);
     } catch (const ::precice::Error &) {
+      return 2;
     }
     return 0;
   }

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -35,7 +35,7 @@ void checkConfiguration(const std::string &filename, const std::string &particip
     logging::BackendConfiguration config;
 
     // Console output
-    config.format = "precice-tools: %ColorizedSeverity%%Message%";
+    config.format = "%ColorizedSeverity%%Message%";
     config.filter = "%Severity% >= info";
     config.type   = "stream";
     config.output = "stdout";

--- a/src/precice/Tooling.cpp
+++ b/src/precice/Tooling.cpp
@@ -58,7 +58,7 @@ void checkConfiguration(const std::string &filename, const std::string &particip
       0,
       size};
   xml::configure(config.getXMLTag(), context, filename);
-  fmt::print(fmt::emphasis::bold | fg(fmt::color::green), "No major issues detected\n", filename);
+  fmt::print(fmt::emphasis::bold | fg(fmt::color::green), "No major issues detected\n");
   if (!wasInitialized) {
     utils::Petsc::finalize();
     utils::Parallel::finalizeTestingMPI();


### PR DESCRIPTION
## Main changes of this PR

This PR cleans up some minor things regarding the tooling of configuration checking:

- **Remove precice-tools prefix from tooling messages**
- **Make preCICE tools return 2 on failing check**
- **Remove unused filename from print**

## Motivation and additional information

Simplifies the integration with precice-cli.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
