### PR TITLE
Unify and fix logs and docs style

### DIFF
--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -380,14 +380,13 @@ void AccelerationConfiguration::addCommonIQNSubtags(xml::XMLTag &tag)
 
   XMLTag tagFilter(*this, TAG_FILTER, XMLTag::OCCUR_NOT_OR_ONCE);
   tagFilter.setDocumentation("Type of filtering technique that is used to "
-                             "maintain good conditioning in the least-squares system. Possible filters:\n"
-                             " - `QR1`: update QR-dec with (relative) test \\\\(R(i,i) < \\epsilon *\\lVert R\\rVert_F\\\\)\n"
-                             " - `QR1-absolute`: update QR-dec with (absolute) test \\\\(R(i, i) < \\epsilon\\\\)\n"
-                             " - `QR2`: en-block QR-dec with test \\\\(\\lVert v_\\text{orth} \\rVert_2 < \\epsilon * \\lVert v \\rVert_2\\\\)\n\n"
-                             " - `QR3`: update QR-dec only when the pre-scaling weights have changed or there is one or more columns are to be removed with test \\\\(\\lVert v_\\text{orth} \\rVert_2 < \\epsilon * \\lVert v \\rVert_2\\\\)\n"
-                             "Please note that a QR1 is based on Given's rotations whereas QR2 uses "
-                             "modified Gram-Schmidt. This can give different results even when no columns "
-                             "are filtered out.");
+                             "maintain good conditioning in the least-squares system. Possible filters:\n\n"
+                             "- `QR1`: update QR-dec with (relative) test \\\\(R(i,i) < \\epsilon *\\lVert R\\rVert_F\\\\)\n"
+                             "- `QR1-absolute`: update QR-dec with (absolute) test \\\\(R(i, i) < \\epsilon\\\\)\n"
+                             "- `QR2`: en-block QR-dec with test \\\\(\\lVert v_\\text{orth} \\rVert_2 < \\epsilon * \\lVert v \\rVert_2\\\\)\n\n"
+                             "- `QR3`: update QR-dec only when the pre-scaling weights have changed or there is one or more columns are to be removed with test \\\\(\\lVert v_\\text{orth} \\rVert_2 < \\epsilon * \\lVert v \\rVert_2\\\\)\n\n"
+                             "Please note that a QR1 is based on Given's rotations whereas QR2 uses modified Gram-Schmidt. "
+                             "This can give different results even when no columns are filtered out.");
   XMLAttribute<double> attrSingularityLimit(ATTR_SINGULARITYLIMIT, 1e-16);
   attrSingularityLimit.setDocumentation("Limit eps of the filter.");
   tagFilter.addAttribute(attrSingularityLimit);
@@ -437,12 +436,11 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     tag.addSubtag(tagData);
 
     XMLTag tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
-    tagPreconditioner.setDocumentation("To improve the numerical stability of multiple data vectors a preconditioner"
-                                       " can be applied. A constant preconditioner scales every acceleration data by a constant value, which you can define as"
-                                       " an attribute of data. "
-                                       " A value preconditioner scales every acceleration data by the norm of the data in the previous time window."
-                                       " A residual preconditioner scales every acceleration data by the current residual."
-                                       " A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current time window.");
+    tagPreconditioner.setDocumentation("To improve the numerical stability of multiple data vectors a preconditioner can be applied. "
+                                       "A constant preconditioner scales every acceleration data by a constant value, which you can define as an attribute of data. "
+                                       "A value preconditioner scales every acceleration data by the norm of the data in the previous time window. "
+                                       "A residual preconditioner scales every acceleration data by the current residual. "
+                                       "A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current time window.");
     auto attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
                                       .setOptions({VALUE_CONSTANT_PRECONDITIONER,
                                                    VALUE_VALUE_PRECONDITIONER,
@@ -485,13 +483,12 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
     addCommonIQNSubtags(tag);
 
     XMLTag tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
-    tagPreconditioner.setDocumentation("To improve the performance of a parallel or a multi coupling schemes a preconditioner"
-                                       " can be applied. "
+    tagPreconditioner.setDocumentation("To improve the performance of a parallel or a multi coupling schemes a preconditioner can be applied.\n\n"
                                        "- A constant preconditioner scales every acceleration data by a constant value, which you can define as an attribute of data. \n "
                                        "- A value preconditioner scales every acceleration data by the norm of the data in the previous time window.\n"
                                        "- A residual preconditioner scales every acceleration data by the current residual.\n"
-                                       "- A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current time window.\n"
-                                       " If this tag is not provided, the residual-sum preconditioner is employed.");
+                                       "- A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current time window.\n\n"
+                                       "If this tag is not provided, the residual-sum preconditioner is employed.");
     auto attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
                                       .setOptions({VALUE_CONSTANT_PRECONDITIONER,
                                                    VALUE_VALUE_PRECONDITIONER,
@@ -564,12 +561,12 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
 
     XMLTag tagPreconditioner(*this, TAG_PRECONDITIONER, XMLTag::OCCUR_NOT_OR_ONCE);
     tagPreconditioner.setDocumentation(
-        "To improve the performance of a parallel or a multi coupling schemes a preconditioner can be applied."
+        "To improve the performance of a parallel or a multi coupling schemes a preconditioner can be applied.\n\n"
         "- A constant preconditioner scales every acceleration data by a constant value, which you can define as an attribute of data.\n"
         "- A value preconditioner scales every acceleration data by the norm of the data in the previous time window.\n"
         "- A residual preconditioner scales every acceleration data by the current residual.\n"
-        "- A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current time window.\n"
-        " If this tag is not provided, the residual-sum preconditioner is employed.");
+        "- A residual-sum preconditioner scales every acceleration data by the sum of the residuals from the current time window.\n\n"
+        "If this tag is not provided, the residual-sum preconditioner is employed.");
     auto attrPreconditionerType = XMLAttribute<std::string>(ATTR_TYPE)
                                       .setOptions({VALUE_CONSTANT_PRECONDITIONER,
                                                    VALUE_VALUE_PRECONDITIONER,

--- a/src/acceleration/config/AccelerationConfiguration.cpp
+++ b/src/acceleration/config/AccelerationConfiguration.cpp
@@ -117,9 +117,8 @@ void AccelerationConfiguration::connectTags(xml::XMLTag &parent)
     tag.setDocumentation("Accelerates coupling data with the interface quasi-Newton inverse multi-vector Jacobian method.");
 
     auto alwaybuildJacobian = makeXMLAttribute(ATTR_BUILDJACOBIAN, false)
-                                  .setDocumentation("If set to true, the IMVJ will set up the Jacobian matrix"
-                                                    " in each coupling iteration, which is inefficient. If set to false (or not set)"
-                                                    " the Jacobian is only build in the last iteration and the updates are computed using (relatively) cheap MATVEC products.");
+                                  .setDocumentation("If set to true, the IMVJ will set up the Jacobian matrix in each coupling iteration, which is inefficient. "
+                                                    "If set to false (or not set) the Jacobian is only build in the last iteration and the updates are computed using (relatively) cheap MATVEC products.");
     tag.addAttribute(alwaybuildJacobian);
 
     auto reducedTimeGridQN = makeXMLAttribute(ATTR_REDUCEDTIMEGRIDQN, true)
@@ -497,9 +496,9 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                       .setDocumentation("The type of the preconditioner.");
     tagPreconditioner.addAttribute(attrPreconditionerType);
     auto attrpreconditionerUpdateOnThreshold = XMLAttribute<bool>(ATTR_PRECOND_UPDATE_ON_THRESHOLD, true)
-                                                   .setDocumentation("To update the preconditioner weights after the first time window:"
-                                                                     "- `true`: The preconditioner weights are only updated if the weights will change by more than one order of magnitude.\n"
-                                                                     "- `false`: The preconditioner weights are updated after every iteration.");
+                                                   .setDocumentation("To update the preconditioner weights after the first time window: "
+                                                                     "`true`: The preconditioner weights are only updated if the weights will change by more than one order of magnitude. "
+                                                                     "`false`: The preconditioner weights are updated after every iteration.");
     tagPreconditioner.addAttribute(attrpreconditionerUpdateOnThreshold);
     auto nonconstTWindows = makeXMLAttribute(ATTR_PRECOND_NONCONST_TIME_WINDOWS, -1)
                                 .setDocumentation(
@@ -527,12 +526,12 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                .setDefaultValue(VALUE_SVD_RESTART)
                                .setDocumentation("Type of the restart mode.");
     tagIMVJRESTART.addAttribute(attrRestartName);
-    tagIMVJRESTART.setDocumentation("Type of IMVJ restart mode that is used:\n"
-                                    "- `no-restart`: IMVJ runs in normal mode with explicit representation of Jacobian\n"
-                                    "- `RS-0`:    IMVJ runs in restart mode. After M time windows all Jacobain information is dropped, restart with no information\n"
-                                    "- `RS-LS`:      IMVJ runs in restart mode. After M time windows a IQN-LS like approximation for the initial guess of the Jacobian is computed.\n"
-                                    "- `RS-SVD`:     IMVJ runs in restart mode. After M time windows a truncated SVD of the Jacobian is updated.\n"
-                                    "- `RS-SLIDE`:   IMVJ runs in sliding window restart mode.\n"
+    tagIMVJRESTART.setDocumentation("Enable IMVJ Type of IMVJ restart mode that is used: "
+                                    "`no-restart`: IMVJ runs in normal mode with explicit representation of Jacobian. "
+                                    "`RS-0`: IMVJ runs in restart mode. After M time windows all Jacobain information is dropped, restart with no information. "
+                                    "`RS-LS`: IMVJ runs in restart mode. After M time windows a IQN-LS like approximation for the initial guess of the Jacobian is computed. "
+                                    "`RS-SVD`: IMVJ runs in restart mode. After M time windows a truncated SVD of the Jacobian is updated. "
+                                    "`RS-SLIDE`: IMVJ runs in sliding window restart mode. "
                                     "If this tag is not provided, IMVJ runs in restart mode with SVD-method.");
     auto attrChunkSize = makeXMLAttribute(ATTR_IMVJCHUNKSIZE, 8)
                              .setDocumentation("Specifies the number of time windows M after which the IMVJ restarts, if run in restart-mode. Default value is M=8.");
@@ -575,9 +574,9 @@ void AccelerationConfiguration::addTypeSpecificSubtags(
                                       .setDocumentation("Type of the preconditioner.");
     tagPreconditioner.addAttribute(attrPreconditionerType);
     auto attrpreconditionerUpdateOnThreshold = XMLAttribute<bool>(ATTR_PRECOND_UPDATE_ON_THRESHOLD, true)
-                                                   .setDocumentation("To update the preconditioner weights after the first time window:"
-                                                                     "- `true`:  The preconditioner weights are only updated if the weights will change by more than one order of magnitude.\n"
-                                                                     "- `false`: The preconditioner weights are updated after every iteration.");
+                                                   .setDocumentation("To update the preconditioner weights after the first time window: "
+                                                                     "`true`: The preconditioner weights are only updated if the weights will change by more than one order of magnitude. "
+                                                                     "`false`: The preconditioner weights are updated after every iteration.");
     tagPreconditioner.addAttribute(attrpreconditionerUpdateOnThreshold);
     auto nonconstTWindows = makeXMLAttribute(ATTR_PRECOND_NONCONST_TIME_WINDOWS, -1)
                                 .setDocumentation("After the given number of time windows, the preconditioner weights are frozen and the preconditioner acts like a constant preconditioner.");

--- a/src/action/config/ActionConfiguration.cpp
+++ b/src/action/config/ActionConfiguration.cpp
@@ -78,12 +78,12 @@ ActionConfiguration::ActionConfiguration(
   }
   {
     XMLTag tag(*this, NAME_PYTHON, occ, TAG);
-    tag.setDocumentation("Calls Python script to execute action."
-                         " See preCICE file \"src/action/PythonAction.py\" for an example.");
+    tag.setDocumentation("Calls Python script to execute action. "
+                         "See preCICE file \"src/action/PythonAction.py\" for an example.");
 
     XMLTag tagModulePath(*this, TAG_MODULE_PATH, XMLTag::OCCUR_NOT_OR_ONCE);
-    tagModulePath.setDocumentation("Directory path to Python module, i.e. script file."
-                                   " If it doesn't occur, the current path is used");
+    tagModulePath.setDocumentation("Directory path to Python module, i.e. script file. "
+                                   "If it doesn't occur, the current path is used");
     tagModulePath.addAttribute(makeXMLAttribute(ATTR_NAME, "").setDocumentation("The path to the directory of the module."));
     tag.addSubtag(tagModulePath);
 
@@ -95,14 +95,14 @@ ActionConfiguration::ActionConfiguration(
     tag.addSubtag(tagModule);
 
     XMLTag tagOptionalSourceData(*this, TAG_SOURCE_DATA, XMLTag::OCCUR_NOT_OR_ONCE);
-    tagOptionalSourceData.setDocumentation("Source data to be read is handed to the Python module."
-                                           " Can be omitted, if only a target data is needed.");
+    tagOptionalSourceData.setDocumentation("Source data to be read is handed to the Python module. "
+                                           "Can be omitted, if only a target data is needed.");
     tagOptionalSourceData.addAttribute(attrName);
     tag.addSubtag(tagOptionalSourceData);
 
     XMLTag tagOptionalTargetData(*this, TAG_TARGET_DATA, XMLTag::OCCUR_NOT_OR_ONCE);
-    tagOptionalTargetData.setDocumentation("Target data to be read and written to is handed to the Python module."
-                                           " Can be omitted, if only source data is needed.");
+    tagOptionalTargetData.setDocumentation("Target data to be read and written to is handed to the Python module. "
+                                           "Can be omitted, if only source data is needed.");
     tagOptionalTargetData.addAttribute(attrName);
     tag.addSubtag(tagOptionalTargetData);
 

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -976,11 +976,11 @@ void CouplingSchemeConfiguration::checkIterationLimits() const
 {
   if (_config.convergenceMeasureDefinitions.empty()) {
     PRECICE_CHECK(_config.maxIterations != -1,
-                  "Not defining convergence measures without providing a maximum iteration limit is forbidden."
+                  "Not defining convergence measures without providing a maximum iteration limit is forbidden. "
                   "Please define a convergence measure or set a maximum iteration limit using <max-iterations value=\"...\" />.");
 
     PRECICE_INFO("No convergence measures were defined for an implicit coupling scheme. "
-                 "It will always iterate the maximum amount iterations, which is {}."
+                 "It will always iterate the maximum amount iterations, which is {}. "
                  "You may want to add a convergence measure in your <coupling-scheme:.../> in your configuration.",
                  _config.maxIterations);
   }
@@ -1203,7 +1203,7 @@ void CouplingSchemeConfiguration::setParallelAcceleration(
         dynamic_cast<acceleration::AitkenAcceleration *>(_accelerationConfig->getAcceleration().get()) != nullptr,
         "You configured participant \"{}\" in a parallel-implicit coupling scheme with \"Aitken\" "
         "acceleration, which is known to perform bad in parallel coupling schemes. "
-        "See https://precice.org/configuration-acceleration.html#dynamic-aitken-under-relaxation for details."
+        "See https://precice.org/configuration-acceleration.html#dynamic-aitken-under-relaxation for details. "
         "Consider switching to a serial-implicit coupling scheme or changing the acceleration method.",
         participant);
   }

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -579,7 +579,7 @@ void CouplingSchemeConfiguration::addTagAbsoluteOrRelativeConvergenceMeasure(
   using namespace xml;
   XMLTag tagConvergenceMeasure(*this, TAG_ABS_OR_REL_CONV_MEASURE, XMLTag::OCCUR_ARBITRARY);
   tagConvergenceMeasure.setDocumentation(
-      "Absolute or relative convergence, which is the disjunction of an absolute criterion based on the two-norm difference of data values between iterations and a relative criterion based on the relative two-norm difference of data values between iterations,i.e. convergence is reached as soon as one of the both criteria is fulfilled."
+      "Absolute or relative convergence, which is the disjunction of an absolute criterion based on the two-norm difference of data values between iterations and a relative criterion based on the relative two-norm difference of data values between iterations,i.e. convergence is reached as soon as one of the both criteria is fulfilled. "
       "\\$$\\left\\lVert H(x^k) - x^k \\right\\rVert_2 < \\text{abs-limit}\\quad\\text{or}\\quad\\frac{\\left\\lVert H(x^k) - x^k \\right\\rVert_2}{\\left\\lVert H(x^k) \\right\\rVert_2} < \\text{rel-limit} \\$$  ");
   addBaseAttributesTagConvergenceMeasure(tagConvergenceMeasure);
   XMLAttribute<double> attrAbsLimit(ATTR_ABS_LIMIT);

--- a/src/mapping/LinearCellInterpolationMapping.cpp
+++ b/src/mapping/LinearCellInterpolationMapping.cpp
@@ -96,7 +96,7 @@ void LinearCellInterpolationMapping::computeMapping()
       // We have the connectivity, but some fallbacks occurred
       PRECICE_INFO(
           "Linear Cell Interpolation is used, but some points from {} don't lie in the domain defined by the {}. "
-          "These points have been projected on the domain boundary. This could come from non-matching discrete geometries or erroneous connectivity information."
+          "These points have been projected on the domain boundary. This could come from non-matching discrete geometries or erroneous connectivity information. "
           "If distances seem too large, please check your mesh. "
           "The fallback statistics are: {} ",
           searchSpace->getName(), getDimensions() == 2 ? "triangles" : "tetrahedra",

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -273,9 +273,8 @@ std::pair<std::vector<int>, std::vector<double>> PartitionOfUnityMapping<RADIAL_
   // However, this leads to a conflict with weights already set in the corresponding cluster, since we insert the ID and, later on, map the ID to a local weight index
   // Of course, we could rearrange the weights, but we want to avoid the case here anyway, i.e., prefer to abort.
   PRECICE_CHECK(localNumberOfClusters > 0,
-                "Output vertex {} of mesh \"{}\" could not be assigned to any cluster in the rbf-pum mapping. This probably means that the meshes do not match well geometry-wise: Visualize the exported preCICE meshes to confirm."
-                " If the meshes are fine geometry-wise, you can try to increase the number of \"vertices-per-cluster\" (default is 50), the \"relative-overlap\" (default is 0.15),"
-                " or disable the option \"project-to-input\"."
+                "Output vertex {} of mesh \"{}\" could not be assigned to any cluster in the rbf-pum mapping. This probably means that the meshes do not match well geometry-wise: Visualize the exported preCICE meshes to confirm. "
+                "If the meshes are fine geometry-wise, you can try to increase the number of \"vertices-per-cluster\" (default is 50), the \"relative-overlap\" (default is 0.15), or disable the option \"project-to-input\". "
                 "These options are only valid for the <mapping:rbf-pum-direct/> tag.",
                 vertex.getCoords(), mesh);
 

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -670,7 +670,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
         if (context.size > 1) {
           // Only display the warning message if this participant configuration is the current one.
           if (context.name == participant->getName()) {
-            PRECICE_ERROR("You attempted to use the legacy VTK exporter with the parallel participant {}, which isn't supported."
+            PRECICE_ERROR("You attempted to use the legacy VTK exporter with the parallel participant {}, which isn't supported. "
                           "Migrate to another exporter, such as the VTU exporter by specifying \"<export:vtu ... />\"  instead of \"<export:vtk ... />\".",
                           participant->getName());
           }

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -743,8 +743,8 @@ int ParticipantImpl::getMeshVertexSize(
   PRECICE_REQUIRE_MESH_USE(meshName);
   // In case we access received mesh data: check, if the requested mesh data has already been received.
   // Otherwise, the function call doesn't make any sense
-  PRECICE_CHECK((_state == State::Initialized) || _accessor->isMeshProvided(meshName), "initialize() has to be called before accessing"
-                                                                                       " data of the received mesh \"{}\" on participant \"{}\".",
+  PRECICE_CHECK((_state == State::Initialized) || _accessor->isMeshProvided(meshName),
+                "initialize() has to be called before accessing data of the received mesh \"{}\" on participant \"{}\".",
                 meshName, _accessor->getName());
   MeshContext &context = _accessor->usedMeshContext(meshName);
   PRECICE_ASSERT(context.mesh.get() != nullptr);
@@ -1002,7 +1002,7 @@ void ParticipantImpl::setMeshQuad(
 
   auto coords = mesh::coordsFor(mesh, vertexIDs);
   PRECICE_CHECK(utils::unique_elements(coords),
-                "The four vertices that form the quad are not unique. The resulting shape may be a point, line or triangle."
+                "The four vertices that form the quad are not unique. The resulting shape may be a point, line or triangle. "
                 "Please check that the adapter sends the four unique vertices that form the quad, or that the mesh on the interface is composed of quads.");
 
   auto convexity = math::geometry::isConvexQuad(coords);
@@ -1066,7 +1066,7 @@ void ParticipantImpl::setMeshQuads(
 
     auto coords = mesh::coordsFor(mesh, vertexIDs);
     PRECICE_CHECK(utils::unique_elements(coords),
-                  "The four vertices that form the quad nr {} are not unique. The resulting shape may be a point, line or triangle."
+                  "The four vertices that form the quad nr {} are not unique. The resulting shape may be a point, line or triangle. "
                   "Please check that the adapter sends the four unique vertices that form the quad, or that the mesh on the interface is composed of quads.",
                   i);
 
@@ -1103,8 +1103,8 @@ void ParticipantImpl::setMeshTetrahedron(
   PRECICE_TRACE(meshName, first, second, third, fourth);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
-  PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshTetrahedron is only possible for 3D meshes."
-                                                    " Please set the mesh dimension to 3 in the preCICE configuration file.");
+  PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshTetrahedron is only possible for 3D meshes. "
+                                                    "Please set the mesh dimension to 3 in the preCICE configuration file.");
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -1132,8 +1132,8 @@ void ParticipantImpl::setMeshTetrahedra(
   PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
   MeshContext &context = _accessor->usedMeshContext(meshName);
-  PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshTetrahedron is only possible for 3D meshes."
-                                                    " Please set the mesh dimension to 3 in the preCICE configuration file.");
+  PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshTetrahedron is only possible for 3D meshes. "
+                                                    "Please set the mesh dimension to 3 in the preCICE configuration file.");
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -1501,8 +1501,8 @@ void ParticipantImpl::getMeshVertexIDsAndCoordinates(
   PRECICE_DEBUG("Get {} mesh vertices with IDs", ids.size());
 
   // Check, if the requested mesh data has already been received. Otherwise, the function call doesn't make any sense
-  PRECICE_CHECK((_state == State::Initialized) || _accessor->isMeshProvided(meshName), "initialize() has to be called before accessing"
-                                                                                       " data of the received mesh \"{}\" on participant \"{}\".",
+  PRECICE_CHECK((_state == State::Initialized) || _accessor->isMeshProvided(meshName),
+                "initialize() has to be called before accessing data of the received mesh \"{}\" on participant \"{}\".",
                 meshName, _accessor->getName());
 
   if (ids.empty() && coordinates.empty()) {

--- a/src/profiling/config/ProfilingConfiguration.cpp
+++ b/src/profiling/config/ProfilingConfiguration.cpp
@@ -47,7 +47,7 @@ ProfilingConfiguration::ProfilingConfiguration(xml::XMLTag &parent)
 
   auto attrFlush = makeXMLAttribute<int>("flush-every", DEFAULT_SYNC_EVERY)
                        .setDocumentation("Set the amount of event records that should be kept in memory before flushing them to file. "
-                                         "One event consists out of multiple records."
+                                         "One event consists out of multiple records. "
                                          "0 keeps all records in memory and writes them at the end of the program, useful for slower network filesystems. "
                                          "1 writes records directly to the file, useful to get profiling data despite program crashes. "
                                          "Settings greater than 1 keep records in memory and write them to file in blocks, which is recommended.");

--- a/src/xml/Printer.cpp
+++ b/src/xml/Printer.cpp
@@ -230,7 +230,7 @@ std::ostream &printMD(std::ostream &out, const XMLTag &tag, int level, std::map<
 
   out << tag.getDocumentation() << "\n\n";
 
-  out << "**Example:**  \n```xml\n";
+  out << "**Example:**  \n\n```xml\n";
   printExample(out, tag, 0) << "\n```\n\n";
 
   if (const auto &attributes = tag.getAttributes();


### PR DESCRIPTION
## Main changes of this PR

This PR cleans up some styling in log messages, and documentation.

Multi-line comments with multiple sentences now use:

```cpp
PRECICE_INFO("Line one. "
             "Line Two.");
```

Fixes include the above leading to missing spaces after `.`.

The generated markdown in tags is now cleaner, and in attributes now avoids line breaks.


## Motivation and additional information

Uniform style and cleaner outputs with less obvious mistakes.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)