### PR TITLE
Add function to create Fortran participant using custom communicator

### DIFF
--- a/docs/changelog/2363.md
+++ b/docs/changelog/2363.md
@@ -1,0 +1,1 @@
+- Added function to create a participant from Fortran with a custom communicator.

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -40,6 +40,31 @@ PRECICE_API void precicef_create_(
     int         participantNameLength,
     int         configFileNameLength);
 
+/**
+ * Fortran syntax:
+ * precicef_create_with_communicator_(
+ *   CHARACTER participantName(*),
+ *   CHARACTER configFileName(*),
+ *   INTEGER   solverProcessIndex,
+ *   INTEGER   solverProcessSize,
+ *   INTEGER   communicator )
+ *
+ * IN:  participantName, configFileName, solverProcessIndex, solverProcessSize,
+ *      communicator
+ * OUT: -
+ *
+ * @copydoc precice::Participant::Participant()
+ *
+ */
+PRECICE_API void precicef_create_with_communicator_(
+    const char *participantName,
+    const char *configFileName,
+    const int  *solverProcessIndex,
+    const int  *solverProcessSize,
+    const int  *communicator,
+    int         participantNameLength,
+    int         configFileNameLength);
+
 ///@}
 
 /// @name Steering Methods

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -72,7 +72,7 @@ try {
   // However, the Fortran standard guarantees interoperability of the int type,
   // so that is what is passed. Do the conversion in case int is not identical
   // to MPI_Fint.
-  MPI_Fint f_communicator = (MPI_Fint) *communicator;
+  MPI_Fint f_communicator = static_cast<MPI_Fint>(*communicator);
   auto     c_communicator = MPI_Comm_f2c(f_communicator);
   impl                    = std::make_unique<precice::Participant>(
       precice::impl::strippedStringView(participantName, participantNameLength),

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -2,6 +2,9 @@
 #include <cstddef>
 #include <iostream>
 #include <memory>
+#ifndef PRECICE_NO_MPI
+#include <mpi.h>
+#endif
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -51,6 +54,40 @@ try {
       precice::impl::strippedStringView(configFileName, configFileNameLength),
       *solverProcessIndex,
       *solverProcessSize);
+} catch (::precice::Error &e) {
+  std::abort();
+}
+
+void precicef_create_with_communicator_(
+    const char *participantName,
+    const char *configFileName,
+    const int  *solverProcessIndex,
+    const int  *solverProcessSize,
+    const int  *communicator,
+    int         participantNameLength,
+    int         configFileNameLength)
+try {
+#ifndef PRECICE_NO_MPI
+  // MPI_Comm_f2c requires an MPI_Fint argument, which may differ from int.
+  // However, the Fortran standard guarantees interoperability of the int type,
+  // so that is what is passed. Do the conversion in case int is not identical
+  // to MPI_Fint.
+  MPI_Fint f_communicator = (MPI_Fint) *communicator;
+  auto     c_communicator = MPI_Comm_f2c(f_communicator);
+  impl                    = std::make_unique<precice::Participant>(
+      precice::impl::strippedStringView(participantName, participantNameLength),
+      precice::impl::strippedStringView(configFileName, configFileNameLength),
+      *solverProcessIndex,
+      *solverProcessSize,
+      &c_communicator);
+#else
+  PRECICE_WARN("preCICE was configured without MPI but you passed an MPI communicator. preCICE ignores the communicator and continues.");
+  impl = std::make_unique<precice::Participant>(
+      precice::impl::strippedStringView(participantName, participantNameLength),
+      precice::impl::strippedStringView(configFileName, configFileNameLength),
+      *solverProcessIndex,
+      *solverProcessSize);
+#endif
 } catch (::precice::Error &e) {
   std::abort();
 }


### PR DESCRIPTION
Use MPI_Comm_f2c to convert the Fortran communicator handle to a C handle, which is then used to create the participant as usual.

## Main changes of this PR

Add a Fortran binding to create a participant from Fortran using a specified MPI communicator.

## Motivation and additional information
See issue #479
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
