### PR TITLE
Add changelog checker script

### DIFF
--- a/tools/releasing/README.md
+++ b/tools/releasing/README.md
@@ -3,4 +3,5 @@
 - `packaging/`: Recipes for package managers
     - `Arch_User_Repository/`: Recipe for the [preCICE AUR package](https://aur.archlinux.org/packages/precice/).
     - `debian/`: Files for the CPack Debian package generator.
-- `bumpversion.h`: Script to set the version in all relevant configuration files and update the debian changelog
+- `bumpversion.sh`: Script to set the version in all relevant configuration files and update the debian changelog
+- `checkChangelogs.py`: Script that checks which changelog files are missing from a milestone

--- a/tools/releasing/checkChangelogs.py
+++ b/tools/releasing/checkChangelogs.py
@@ -1,0 +1,40 @@
+#! python3
+
+import json
+import pathlib
+import subprocess
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("milestone")
+milestone = parser.parse_args().milestone
+
+REPO_CMD = ("git", "rev-parse", "--show-toplevel")
+PR_CMD = (
+    "gh",
+    "pr",
+    "list",
+    "--search",
+    f'is:pr is:closed milestone:"{milestone}"',
+    "--limit",
+    "200",
+    "--json",
+    "number,title",
+)
+
+root = pathlib.Path(
+    subprocess.run(REPO_CMD, stdout=subprocess.PIPE, encoding="utf8").stdout.strip()
+)
+prlist = json.loads(
+    subprocess.run(
+        PR_CMD, cwd=str(root.absolute()), stdout=subprocess.PIPE
+    ).stdout.strip()
+)
+
+prs = {pr["number"]: pr["title"] for pr in prlist}
+
+print("Missing")
+for num, title in prs.items():
+    cl = root / "docs" / "changelog" / f"{num}.md"
+    if not cl.exists():
+        print(f"{num:>4} {title}")


### PR DESCRIPTION
## Main changes of this PR

Adds a script that checks which changelog files are missing from a milestone.

## Motivation and additional information

This simplifies a manual and tedious job.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
