### PR TITLE
Fix QR3 filter not falling back to QR2 on coef change

### DIFF
--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -293,6 +293,9 @@ void BaseQNAcceleration::performAcceleration(
     if (not(_filter == Acceleration::QR2FILTER || _filter == Acceleration::QR3FILTER)) { // for QR2 and QR3 filter, there is no need to do this twice
       _qrV.reset(_matrixV, getLSSystemRows());
     }
+    if (_filter == Acceleration::QR3FILTER) { // QR3 filter needs to recompute QR3 filter
+      _qrV.requireQR3Fallback();
+    }
     _preconditioner->newQRfulfilled();
   }
 

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -102,6 +102,12 @@ QRFactorization::QRFactorization(
 {
 }
 
+void QRFactorization::requireQR3Fallback()
+{
+  PRECICE_ASSERT(_filter == Acceleration::QR3FILTER);
+  _computeQR2Filter = true;
+}
+
 void QRFactorization::applyFilter(double singularityLimit, std::vector<int> &delIndices, Eigen::MatrixXd &V)
 {
   PRECICE_TRACE();

--- a/src/acceleration/impl/QRFactorization.hpp
+++ b/src/acceleration/impl/QRFactorization.hpp
@@ -166,6 +166,9 @@ public:
   // @brief returns the number of times the QR2 filter step was performed
   size_t getResetFilterCounter() const;
 
+  // @brief marks that the prescaling coefficients aren't constant and the QR3 filter needs to fallback to QR2
+  void requireQR3Fallback();
+
 private:
   struct givensRot {
     int    i, j;


### PR DESCRIPTION
## Main changes of this PR

This PR fixed the QR3 filter not falling back to QR2 whenever the coefficients change.

## Motivation and additional information

This change was introduced in preCICE 3.2.0.
The elastic-tube-3d triggers this issue.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
