### PR TITLE
Cleanup docker releases in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,3 +68,11 @@ jobs:
       version: ${{ github.ref_name }}
       latest: true
     secrets: inherit
+
+  docker-nightly:
+    name: "Release Nightly"
+    needs: release-draft
+    uses: ./.github/workflows/publish-docker-nightly.yml
+    with:
+      branch: ${{ github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Main changes of this PR

This PR reuses the docker release workflow we already have to make the workflow easier to test.
It also adds the nightly docker release to the workflow, which is important to make the release process of bindings smoother.

## Motivation and additional information

Testing the release workflows isn't easily possible, it is way easier and more robust to compose the release from tested workflows.

This is a succesor of #2379

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.