### PR TITLE
Use gh-cli to create the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,14 @@ jobs:
   release-draft:
     name: 'Draft release'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
-        - name: "Create draft release"
-          uses: softprops/action-gh-release@v2
-          with:
-            draft: True
+      - name: Create draft release
+        run: gh release create "${{ github.ref_name}}" --draft --verify-tag -R precice/precice
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   package-deb:
     needs: release-draft


### PR DESCRIPTION
## Main changes of this PR

This changes the release pipeline to use gh-cli.

## Motivation and additional information

I tested this to my fork using a release.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
