### PR TITLE
Add smpd errors to ctest skip expression

### DIFF
--- a/cmake/discover_tests.py
+++ b/cmake/discover_tests.py
@@ -109,6 +109,8 @@ for name, ranks in get_tests():
         '"OMP_NUM_THREADS=2;OMP_PROC_BIND=false"',
         "TIMEOUT",
         '"30"',
+        '"SKIP_REGULAR_EXPRESSION"',
+        '"error 1175;failed to communicate with smpd manager on"',  # smpd post error
         "WORKING_DIRECTORY",
         f'"{dir.as_posix()}"',
         "LABELS",


### PR DESCRIPTION
## Main changes of this PR

This should mark test cases which run into smpd error as SKIP instead of FAIL

Examples that are matched like this:

```
Aborting: mpiexec on runnervm8crnl failed to communicate with smpd manager on runnervm8crnl
ERROR: Failed to post smpd command error 1775
ERROR: unable to send the suspend command for rank 2 error 1775.
```

## Motivation and additional information

This is a common issue on Windows.
It doesn't solve timeouts though.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
