### PR TITLE
Start the MP-MPI launch service in runner

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -302,6 +302,9 @@ jobs:
 
           # Start the launch service
           Start-Service MsMpiLaunchSvc
+
+          # Start smpd process
+          Start-Process -FilePath "C:\Program Files\Microsoft MPI\Bin\smpd.exe" -ArgumentList '-d'
         shell: powershell
       - uses: msys2/setup-msys2@v2
         with:


### PR DESCRIPTION
## Main changes of this PR

This PR starts the MS-MPI launch service after installing MS-MPI on the windows runner.

## Motivation and additional information


## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
