### PR TITLE
Remove windows debug build from CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -284,7 +284,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        TYPE: [Release, Debug]
+        TYPE: [Release]
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CMAKE_BUILD_TYPE: ${{ matrix.TYPE }}


### PR DESCRIPTION
## Main changes of this PR

Removes the frequently failing windows debug builds from the CI.

## Motivation and additional information

I opened #2396 and documented challenges regarding running on the system.
Let's disable the debug builds until they are actually useful again.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)