### PR TITLE
Separate MeshContexts for received and provided meshes

### DIFF
--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -26,6 +26,8 @@
 #include "precice/impl/MappingContext.hpp"
 #include "precice/impl/MeshContext.hpp"
 #include "precice/impl/ParticipantState.hpp"
+#include "precice/impl/ProvidedMeshContext.hpp"
+#include "precice/impl/ReceivedMeshContext.hpp"
 #include "precice/impl/WatchIntegral.hpp"
 #include "precice/impl/WatchPoint.hpp"
 #include "utils/IntraComm.hpp"
@@ -488,10 +490,16 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     // safety margin such that the mapping is still correct.
     if (confMapping.requiresBasisFunction) {
       if (!confMapping.fromMesh->isJustInTime()) {
-        participant->meshContext(fromMesh).geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
+        // Only set geoFilter if this is a ReceivedMeshContext
+        if (participant->isMeshReceived(fromMesh)) {
+          participant->receivedMeshContext(fromMesh).geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
+        }
       }
       if (!confMapping.toMesh->isJustInTime()) {
-        participant->meshContext(toMesh).geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
+        // Only set geoFilter if this is a ReceivedMeshContext
+        if (participant->isMeshReceived(toMesh)) {
+          participant->receivedMeshContext(toMesh).geoFilter = partition::ReceivedPartition::GeometricFilter::NO_FILTER;
+        }
       }
     }
 
@@ -652,16 +660,17 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
   // Check for unsupported remeshing options
   for (auto &context : participant->writeDataContexts()) {
-    PRECICE_CHECK(participant->meshContext(context.getMeshName()).provideMesh || !(participant->isDirectAccessAllowed(context.getMeshName()) && _remeshing), "Writing data via API access (configuration <write-data ... mesh=\"{}\") is not (yet) supported with remeshing", context.getMeshName());
+    bool isProvided = participant->isMeshProvided(context.getMeshName());
+    PRECICE_CHECK(isProvided || !(participant->isDirectAccessAllowed(context.getMeshName()) && _remeshing), "Writing data via API access (configuration <write-data ... mesh=\"{}\") is not (yet) supported with remeshing", context.getMeshName());
   }
 
   // Add export contexts
   for (io::ExportContext &exportContext : _exportConfig->exportContexts()) {
     auto kind = exportContext.everyIteration ? io::Export::ExportKind::Iterations : io::Export::ExportKind::TimeWindows;
-    // Create one exporter per mesh
-    for (const auto &meshContext : participant->usedMeshContexts()) {
 
-      exportContext.meshName = meshContext->mesh->getName();
+    // Lambda to create exporter for any mesh context (avoids code duplication)
+    auto createExporter = [&](const impl::MeshContext &meshContext) {
+      exportContext.meshName = meshContext.mesh->getName();
 
       io::PtrExport exporter;
       if (exportContext.type == VALUE_VTK) {
@@ -678,7 +687,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
           exporter = io::PtrExport(new io::ExportVTK(
               participant->getName(),
               exportContext.location,
-              *meshContext->mesh,
+              *meshContext.mesh,
               kind,
               exportContext.everyNTimeWindows,
               context.rank,
@@ -688,7 +697,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
         exporter = io::PtrExport(new io::ExportVTU(
             participant->getName(),
             exportContext.location,
-            *meshContext->mesh,
+            *meshContext.mesh,
             kind,
             exportContext.everyNTimeWindows,
             context.rank,
@@ -697,7 +706,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
         exporter = io::PtrExport(new io::ExportVTP(
             participant->getName(),
             exportContext.location,
-            *meshContext->mesh,
+            *meshContext.mesh,
             kind,
             exportContext.everyNTimeWindows,
             context.rank,
@@ -706,7 +715,7 @@ void ParticipantConfiguration::finishParticipantConfiguration(
         exporter = io::PtrExport(new io::ExportCSV(
             participant->getName(),
             exportContext.location,
-            *meshContext->mesh,
+            *meshContext.mesh,
             kind,
             exportContext.everyNTimeWindows,
             context.rank,
@@ -716,9 +725,19 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                       _participants.back()->getName(), exportContext.type);
       }
       exportContext.exporter = std::move(exporter);
-
       _participants.back()->addExportContext(exportContext);
+    };
+
+    // Create one exporter per provided mesh
+    for (const auto &meshContext : participant->providedMeshContexts()) {
+      createExporter(meshContext);
     }
+
+    // Create one exporter per received mesh
+    for (const auto &meshContext : participant->receivedMeshContexts()) {
+      createExporter(meshContext);
+    }
+
     PRECICE_WARN_IF(exportContext.everyNTimeWindows > 1 && exportContext.everyIteration,
                     "Participant {} defines an exporter of type {} which exports every iteration. "
                     "This overrides the every-n-time-window value you provided.",
@@ -733,11 +752,12 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                     "Participant \"{}\" defines watchpoint \"{}\" for mesh \"{}\" which is not provided by the participant. "
                     "Please add <provide-mesh name=\"{}\" /> to the participant.",
                     participant->getName(), config.name, config.nameMesh, config.nameMesh);
-      const auto &meshContext = participant->usedMeshContext(config.nameMesh);
-      PRECICE_CHECK(meshContext.provideMesh,
+
+      PRECICE_CHECK(!participant->isMeshReceived(config.nameMesh),
                     "Participant \"{}\" defines watchpoint \"{}\" for the received mesh \"{}\", which is not allowed. "
                     "Please move the watchpoint definition to the participant providing mesh \"{}\".",
                     participant->getName(), config.name, config.nameMesh, config.nameMesh);
+      const auto &meshContext = participant->providedMeshContext(config.nameMesh);
       PRECICE_CHECK(config.coordinates.size() == meshContext.mesh->getDimensions(),
                     "Provided coordinate to watch is {}D, which does not match the dimension of the {}D mesh \"{}\".",
                     config.coordinates.size(), meshContext.mesh->getDimensions(), meshContext.mesh->getName());
@@ -754,8 +774,8 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                     "Participant \"{}\" defines watch integral \"{}\" for mesh \"{}\" which is not used by the participant. "
                     "Please add a provide-mesh node with name=\"{}\".",
                     participant->getName(), config.name, config.nameMesh, config.nameMesh);
-      const auto &meshContext = participant->usedMeshContext(config.nameMesh);
-      PRECICE_CHECK(meshContext.provideMesh,
+      const auto &meshContext = participant->meshContext(config.nameMesh);
+      PRECICE_CHECK(participant->isMeshProvided(config.nameMesh),
                     "Participant \"{}\" defines watch integral \"{}\" for the received mesh \"{}\", which is not allowed. "
                     "Please move the watchpoint definition to the participant providing mesh \"{}\".",
                     participant->getName(), config.name, config.nameMesh, config.nameMesh);

--- a/src/precice/impl/MeshContext.hpp
+++ b/src/precice/impl/MeshContext.hpp
@@ -6,12 +6,13 @@
 #include "com/Communication.hpp"
 #include "mapping/Mapping.hpp"
 #include "mesh/SharedPointer.hpp"
-#include "partition/ReceivedPartition.hpp"
 #include "partition/SharedPointer.hpp"
 
 namespace precice::impl {
 
-/// Stores a mesh and related objects and data.
+/** Base class storing common mesh-related objects and data.
+ * ProvidedMeshContext and ReceivedMeshContext derive from this.
+ */
 struct MeshContext {
   /** Upgrades the mesh requirement to a more specific level.
    * @param[in] requirement The requirement to upgrade to.
@@ -24,44 +25,11 @@ struct MeshContext {
   /// Determines which mesh type has to be provided by the accessor.
   mapping::Mapping::MeshRequirement meshRequirement = mapping::Mapping::MeshRequirement::UNDEFINED;
 
-  /// Name of participant that creates the mesh.
-  std::string receiveMeshFrom;
-
-  /// bounding box to speed up decomposition of received mesh is increased by this safety factor
-  double safetyFactor = -1;
-
-  /// In case a mapping done by the solver is favored over a preCICE mapping, apply user-defined
-  /// bounding-boxes.
-  bool allowDirectAccess = false;
-
-  /// setMeshAccessRegion may only be called once per mesh(context).
-  /// putting this into the mesh context means that we can only call
-  /// this once, regardless of combinations with just-in-time mappings
-  /// or multiple such mappings. If multiples are desired, we would
-  /// need to shift this into the MappingContext
-  std::shared_ptr<mesh::BoundingBox> userDefinedAccessRegion;
-
-  /// True, if accessor does create the mesh.
-  bool provideMesh = false;
-
-  /// type of geometric filter
-  partition::ReceivedPartition::GeometricFilter geoFilter = partition::ReceivedPartition::GeometricFilter::UNDEFINED;
-
-  /// Partition creating the parallel decomposition of the mesh
-  partition::PtrPartition partition;
-
   /// Mappings used when mapping data from the mesh. Can be empty.
   std::vector<MappingContext> fromMappingContexts;
 
   /// Mappings used when mapping data to the mesh. Can be empty.
   std::vector<MappingContext> toMappingContexts;
-
-  /// Checks, that all vertices are within the user-defined access region and throws
-  /// an error if vertices are not. The function does not return the result to be able
-  /// to log the actual outliers
-  void checkVerticesInsideAccessRegion(precice::span<const double> coordinates, const int meshDim, std::string_view functionName) const;
-
-  std::vector<std::reference_wrapper<const mesh::Vertex>> filterVerticesToLocalAccessRegion(bool requiresBB) const;
 
   void clearMappings()
   {
@@ -72,50 +40,11 @@ struct MeshContext {
       mc.mapping->clear();
     }
   }
-
-private:
-  mutable logging::Logger _log{"impl::MeshContext"};
 };
 
 inline void MeshContext::require(mapping::Mapping::MeshRequirement requirement)
 {
   meshRequirement = std::max(meshRequirement, requirement);
-}
-
-inline void MeshContext::checkVerticesInsideAccessRegion(precice::span<const double> coordinates, const int meshDim, std::string_view functionName) const
-{
-
-  if (userDefinedAccessRegion) {
-    const auto                        nVertices = (coordinates.size() / meshDim);
-    Eigen::Map<const Eigen::MatrixXd> C(coordinates.data(), meshDim, nVertices);
-    Eigen::VectorXd                   minCoeffs = C.rowwise().minCoeff();
-    Eigen::VectorXd                   maxCoeffs = C.rowwise().maxCoeff();
-    bool                              minCheck  = (minCoeffs.array() >= userDefinedAccessRegion->minCorner().array()).all();
-    bool                              maxCheck  = (maxCoeffs.array() <= userDefinedAccessRegion->maxCorner().array()).all();
-    PRECICE_CHECK(minCheck && maxCheck, "The provided coordinates in \"{}\" are not within the access region defined with \"setMeshAccessRegion()\". "
-                                        "Minimum corner of the provided values is (x,y,z) = ({}), the minimum corner of the access region box is (x,y,z) = ({}). "
-                                        "Maximum corner of the provided values is (x,y,z) = ({}), the maximum corner of the access region box is (x,y,z) = ({}). ",
-                  functionName, minCoeffs, userDefinedAccessRegion->minCorner(), maxCoeffs, userDefinedAccessRegion->maxCorner());
-    C.colwise().maxCoeff();
-  }
-}
-
-inline std::vector<std::reference_wrapper<const mesh::Vertex>> MeshContext::filterVerticesToLocalAccessRegion(bool requiresBB) const
-{
-  std::vector<std::reference_wrapper<const mesh::Vertex>> filteredVertices;
-  for (const auto &v : mesh->vertices()) {
-    // either the vertex lies within the region OR the user-defined region is not strictly necessary
-    if (userDefinedAccessRegion) {
-      // region is defined: only add if the vertex is inside the region
-      if (userDefinedAccessRegion->contains(v)) {
-        filteredVertices.push_back(std::cref(v));
-      }
-    } else if (!requiresBB) {
-      // region is not defined, so if filtering isn't required, add all vertices
-      filteredVertices.push_back(std::cref(v));
-    }
-  }
-  return filteredVertices;
 }
 
 } // namespace precice::impl

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -56,7 +56,9 @@
 #include "precice/impl/MappingContext.hpp"
 #include "precice/impl/MeshContext.hpp"
 #include "precice/impl/ParticipantState.hpp"
+#include "precice/impl/ProvidedMeshContext.hpp"
 #include "precice/impl/ReadDataContext.hpp"
+#include "precice/impl/ReceivedMeshContext.hpp"
 #include "precice/impl/Types.hpp"
 #include "precice/impl/ValidationMacros.hpp"
 #include "precice/impl/WatchIntegral.hpp"
@@ -239,8 +241,8 @@ void ParticipantImpl::configure(
   // Register all MeshIds to the lock, but unlock them straight away as
   // writing is allowed after configuration.
   _meshLock.clear();
-  for (const MeshContext *meshContext : _accessor->usedMeshContexts()) {
-    _meshLock.add(meshContext->mesh->getName(), false);
+  for (const auto &variant : _accessor->usedMeshContexts()) {
+    _meshLock.add(getMesh(variant).getName(), false);
   }
 }
 
@@ -262,10 +264,8 @@ void ParticipantImpl::initialize()
   _solverInitEvent.reset();
   Event e("initialize", profiling::Fundamental, profiling::Synchronize);
 
-  for (const auto &context : _accessor->usedMeshContexts()) {
-    if (context->provideMesh) {
-      e.addData("meshSize" + context->mesh->getName(), context->mesh->nVertices());
-    }
+  for (const auto &context : _accessor->providedMeshContexts()) {
+    e.addData("meshSize" + context.mesh->getName(), context.mesh->nVertices());
   }
 
   setupCommunication();
@@ -308,10 +308,8 @@ void ParticipantImpl::reinitialize()
   Event e("reinitialize", profiling::Fundamental);
   closeCommunicationChannels(CloseChannels::Distributed);
 
-  for (const auto &context : _accessor->usedMeshContexts()) {
-    if (context->provideMesh) {
-      e.addData("meshSize" + context->mesh->getName(), context->mesh->nVertices());
-    }
+  for (const auto &context : _accessor->providedMeshContexts()) {
+    e.addData("meshSize" + context.mesh->getName(), context.mesh->nVertices());
   }
 
   setupCommunication();
@@ -327,12 +325,10 @@ void ParticipantImpl::setupCommunication()
 
   // TODO only preprocess changed meshes
   PRECICE_DEBUG("Preprocessing provided meshes");
-  for (MeshContext *meshContext : _accessor->usedMeshContexts()) {
-    if (meshContext->provideMesh) {
-      auto &mesh = *meshContext->mesh;
-      Event e("preprocess." + mesh.getName());
-      mesh.preprocess();
-    }
+  for (auto &context : _accessor->providedMeshContexts()) {
+    auto &mesh = *context.mesh;
+    Event e("preprocess." + mesh.getName());
+    mesh.preprocess();
   }
 
   // Setup communication
@@ -574,9 +570,10 @@ void ParticipantImpl::samplizeWriteData(double time)
 
 void ParticipantImpl::trimOldDataBefore(double time)
 {
-  for (auto &context : _accessor->usedMeshContexts()) {
-    for (const auto &name : context->mesh->availableData()) {
-      context->mesh->data(name)->waveform().trimBefore(time);
+  for (auto &variant : _accessor->usedMeshContexts()) {
+    auto &mesh = getMesh(variant);
+    for (const auto &name : mesh.availableData()) {
+      mesh.data(name)->waveform().trimBefore(time);
     }
   }
 }
@@ -644,7 +641,7 @@ int ParticipantImpl::getMeshDimensions(std::string_view meshName) const
 {
   PRECICE_TRACE(meshName);
   PRECICE_VALIDATE_MESH_NAME(meshName);
-  return _accessor->usedMeshContext(meshName).mesh->getDimensions();
+  return _accessor->meshContext(meshName).mesh->getDimensions();
 }
 
 int ParticipantImpl::getDataDimensions(std::string_view meshName, std::string_view dataName) const
@@ -652,7 +649,7 @@ int ParticipantImpl::getDataDimensions(std::string_view meshName, std::string_vi
   PRECICE_TRACE(meshName, dataName);
   PRECICE_VALIDATE_MESH_NAME(meshName);
   PRECICE_VALIDATE_DATA_NAME(meshName, dataName);
-  return _accessor->usedMeshContext(meshName).mesh->data(dataName)->getDimensions();
+  return _accessor->meshContext(meshName).mesh->data(dataName)->getDimensions();
 }
 
 bool ParticipantImpl::isCouplingOngoing() const
@@ -724,7 +721,7 @@ bool ParticipantImpl::requiresReadingCheckpoint()
 bool ParticipantImpl::requiresMeshConnectivityFor(std::string_view meshName) const
 {
   PRECICE_VALIDATE_MESH_NAME(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  MeshContext &context = _accessor->meshContext(meshName);
   return context.meshRequirement == mapping::Mapping::MeshRequirement::FULL;
 }
 
@@ -750,29 +747,29 @@ int ParticipantImpl::getMeshVertexSize(
   PRECICE_CHECK((_state == State::Initialized) || _accessor->isMeshProvided(meshName),
                 "initialize() has to be called before accessing data of the received mesh \"{}\" on participant \"{}\".",
                 meshName, _accessor->getName());
-  MeshContext &context = _accessor->usedMeshContext(meshName);
-  PRECICE_ASSERT(context.mesh.get() != nullptr);
 
   // Returns true if we have api access configured and we run in parallel and have a received mesh
-  if ((context.userDefinedAccessRegion || requiresUserDefinedAccessRegion(meshName)) && _accessor->isDirectAccessAllowed(meshName)) {
-    // filter nVertices to the actual number of vertices queried by the user
-    PRECICE_CHECK(context.userDefinedAccessRegion, "The function getMeshVertexSize was called on the received mesh \"{0}\", "
-                                                   "but no access region was defined although this is necessary for parallel runs. "
-                                                   "Please define an access region using \"setMeshAccessRegion()\" before calling \"getMeshVertexSize()\".",
-                  meshName);
-
-    auto result = mesh::countVerticesInBoundingBox(context.mesh, *context.userDefinedAccessRegion);
-
-    PRECICE_DEBUG("Filtered {} of {} vertices out on mesh {} due to the local access region. Mesh size in the access region: {}", context.mesh->nVertices() - result, context.mesh->nVertices(), meshName, result);
-    return result;
-  } else {
-    // For provided meshes and in case the api-access was not configured, we return here all vertices
-    PRECICE_WARN_IF(_accessor->isMeshReceived(meshName) && !_accessor->isDirectAccessAllowed(meshName),
-                    "You are calling \"getMeshVertexSize()\" on a received mesh without api-access enabled (<receive-mesh name=\"{0}\" ... api-access=\"false\"/>). "
-                    "Note that enabling api-access is required for this function to work properly with direct mesh access and just-in-time mappings.",
+  if (_accessor->isMeshReceived(meshName) && _accessor->isDirectAccessAllowed(meshName)) {
+    auto &receivedContext = _accessor->receivedMeshContext(meshName);
+    if (receivedContext.userDefinedAccessRegion || requiresUserDefinedAccessRegion(meshName)) {
+      // filter nVertices to the actual number of vertices queried by the user
+      PRECICE_CHECK(receivedContext.userDefinedAccessRegion, "The function getMeshVertexSize was called on the received mesh \"{0}\", "
+                                                             "but no access region was defined although this is necessary for parallel runs. "
+                                                             "Please define an access region using \"setMeshAccessRegion()\" before calling \"getMeshVertexSize()\".",
                     meshName);
-    return context.mesh->nVertices();
+
+      auto result = mesh::countVerticesInBoundingBox(receivedContext.mesh, *receivedContext.userDefinedAccessRegion);
+
+      PRECICE_DEBUG("Filtered {} of {} vertices out on mesh {} due to the local access region. Mesh size in the access region: {}", receivedContext.mesh->nVertices() - result, receivedContext.mesh->nVertices(), meshName, result);
+      return result;
+    }
   }
+  // For provided meshes and in case the api-access was not configured, we return here all vertices
+  PRECICE_WARN_IF(_accessor->isMeshReceived(meshName) && !_accessor->isDirectAccessAllowed(meshName),
+                  "You are calling \"getMeshVertexSize()\" on a received mesh without api-access enabled (<receive-mesh name=\"{0}\" ... api-access=\"false\"/>). "
+                  "Note that enabling api-access is required for this function to work properly with direct mesh access and just-in-time mappings.",
+                  meshName);
+  return _accessor->meshContext(meshName).mesh->nVertices();
 }
 
 /// @todo Currently not supported as we would need to re-compute the re-partition
@@ -786,7 +783,7 @@ void ParticipantImpl::resetMesh(
   PRECICE_VALIDATE_MESH_NAME(meshName);
   PRECICE_CHECK(_couplingScheme->isCouplingOngoing(), "Cannot remesh after the last time window has been completed.");
   PRECICE_CHECK(_couplingScheme->isTimeWindowComplete(), "Cannot remesh while subcycling or iterating. Remeshing is only allowed when the time window is completed.");
-  impl::MeshContext &context = _accessor->usedMeshContext(meshName);
+  impl::MeshContext &context = _accessor->meshContext(meshName);
 
   PRECICE_DEBUG("Clear mesh positions for mesh \"{}\"", context.mesh->getName());
   _meshLock.unlock(meshName);
@@ -799,8 +796,8 @@ VertexID ParticipantImpl::setMeshVertex(
 {
   PRECICE_TRACE(meshName);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
-  auto        &mesh    = *context.mesh;
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
+  auto                &mesh    = *context.mesh;
   PRECICE_CHECK(position.size() == static_cast<unsigned long>(mesh.getDimensions()),
                 "Cannot set vertex for mesh \"{}\". Expected {} position components but found {}.", meshName, mesh.getDimensions(), position.size());
   Event e{fmt::format("setMeshVertex.{}", meshName), profiling::API};
@@ -824,8 +821,8 @@ void ParticipantImpl::setMeshVertices(
 {
   PRECICE_TRACE(meshName, positions.size(), ids.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
-  auto        &mesh    = *context.mesh;
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
+  auto                &mesh    = *context.mesh;
 
   const auto meshDims             = mesh.getDimensions();
   const auto expectedPositionSize = ids.size() * meshDims;
@@ -857,7 +854,7 @@ void ParticipantImpl::setMeshEdge(
 {
   PRECICE_TRACE(meshName, first, second);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -878,7 +875,7 @@ void ParticipantImpl::setMeshEdges(
 {
   PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -916,7 +913,7 @@ void ParticipantImpl::setMeshTriangle(
 {
   PRECICE_TRACE(meshName, first, second, third);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -943,7 +940,7 @@ void ParticipantImpl::setMeshTriangles(
 {
   PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -986,7 +983,7 @@ void ParticipantImpl::setMeshQuad(
   PRECICE_TRACE(meshName, first,
                 second, third, fourth);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -1036,7 +1033,7 @@ void ParticipantImpl::setMeshQuads(
 {
   PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
     return;
   }
@@ -1104,7 +1101,7 @@ void ParticipantImpl::setMeshTetrahedron(
 {
   PRECICE_TRACE(meshName, first, second, third, fourth);
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshTetrahedron is only possible for 3D meshes. "
                                                     "Please set the mesh dimension to 3 in the preCICE configuration file.");
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
@@ -1133,7 +1130,7 @@ void ParticipantImpl::setMeshTetrahedra(
 {
   PRECICE_TRACE(meshName, vertices.size());
   PRECICE_REQUIRE_MESH_MODIFY(meshName);
-  MeshContext &context = _accessor->usedMeshContext(meshName);
+  ProvidedMeshContext &context = _accessor->providedMeshContext(meshName);
   PRECICE_CHECK(context.mesh->getDimensions() == 3, "setMeshTetrahedron is only possible for 3D meshes. "
                                                     "Please set the mesh dimension to 3 in the preCICE configuration file.");
   if (context.meshRequirement != mapping::Mapping::MeshRequirement::FULL) {
@@ -1283,14 +1280,14 @@ void ParticipantImpl::mapAndReadData(
                 meshName);
   // If an access region is required, we have to check its existence
   bool requiresBB = requiresUserDefinedAccessRegion(meshName);
-  PRECICE_CHECK(!requiresBB || (requiresBB && _accessor->meshContext(meshName).userDefinedAccessRegion),
+  PRECICE_CHECK(!requiresBB || (requiresBB && _accessor->receivedMeshContext(meshName).userDefinedAccessRegion),
                 "The function \"mapAndReadData\" was called on mesh \"{0}\", "
                 "but no access region was defined although this is necessary for parallel runs. "
                 "Please define an access region using \"setMeshAccessRegion()\" before calling \"mapAndReadData()\".",
                 meshName);
 
-  PRECICE_CHECK(!_accessor->meshContext(meshName).mesh->empty(), "This participant tries to mapAndRead data values for data \"{0}\" on mesh \"{1}\", but the mesh \"{1}\" is empty within the defined access region on this rank. "
-                                                                 "How should the provided data values be read? Please make sure the mesh \"{1}\" is non-empty within the access region.",
+  PRECICE_CHECK(!_accessor->receivedMeshContext(meshName).mesh->empty(), "This participant tries to mapAndRead data values for data \"{0}\" on mesh \"{1}\", but the mesh \"{1}\" is empty within the defined access region on this rank. "
+                                                                         "How should the provided data values be read? Please make sure the mesh \"{1}\" is non-empty within the access region.",
                 dataName, meshName);
 
   ReadDataContext &dataContext = _accessor->readDataContext(meshName, dataName);
@@ -1308,13 +1305,13 @@ void ParticipantImpl::mapAndReadData(
   Event e{fmt::format("mapAndReadData.{}_{}", meshName, dataName), profiling::API};
 
   // Note that meshName refers to a remote mesh
-  const auto   dataDims  = dataContext.getDataDimensions();
-  const auto   dim       = dataContext.getSpatialDimensions();
-  const auto   nVertices = (coordinates.size() / dim);
-  MeshContext &context   = _accessor->meshContext(meshName);
+  const auto           dataDims  = dataContext.getDataDimensions();
+  const auto           dim       = dataContext.getSpatialDimensions();
+  const auto           nVertices = (coordinates.size() / dim);
+  ReceivedMeshContext &context   = _accessor->receivedMeshContext(meshName);
 
   // Check that the vertex is actually within the defined access region
-  context.checkVerticesInsideAccessRegion(coordinates, dim, "mapAndReadData");
+  _accessor->receivedMeshContext(meshName).checkVerticesInsideAccessRegion(coordinates, dim, "mapAndReadData");
 
   // Make use of the read data context
   PRECICE_CHECK(nVertices * dataDims == values.size(),
@@ -1349,7 +1346,7 @@ void ParticipantImpl::writeAndMapData(
                 meshName);
   // If an access region is required, we have to check its existence
   bool requiresBB = requiresUserDefinedAccessRegion(meshName);
-  PRECICE_CHECK(!requiresBB || (requiresBB && _accessor->meshContext(meshName).userDefinedAccessRegion),
+  PRECICE_CHECK(!requiresBB || (requiresBB && _accessor->receivedMeshContext(meshName).userDefinedAccessRegion),
                 "The function \"writeAndMapData\" was called on mesh \"{0}\", "
                 "but no access region was defined although this is necessary for parallel runs. "
                 "Please define an access region using \"setMeshAccessRegion()\" before calling \"writeAndMapData()\".",
@@ -1370,13 +1367,13 @@ void ParticipantImpl::writeAndMapData(
   Event e{fmt::format("writeAndMapData.{}_{}", meshName, dataName), profiling::API};
 
   // Note that meshName refers here typically to a remote mesh
-  const auto   dataDims  = dataContext.getDataDimensions();
-  const auto   dim       = dataContext.getSpatialDimensions();
-  const auto   nVertices = (coordinates.size() / dim);
-  MeshContext &context   = _accessor->meshContext(meshName);
+  const auto           dataDims  = dataContext.getDataDimensions();
+  const auto           dim       = dataContext.getSpatialDimensions();
+  const auto           nVertices = (coordinates.size() / dim);
+  ReceivedMeshContext &context   = _accessor->receivedMeshContext(meshName);
 
   // Check that the vertex is actually within the defined access region
-  context.checkVerticesInsideAccessRegion(coordinates, dim, "writeAndMapData");
+  _accessor->receivedMeshContext(meshName).checkVerticesInsideAccessRegion(coordinates, dim, "writeAndMapData");
 
   PRECICE_CHECK(nVertices * dataDims == values.size(),
                 "Input sizes are inconsistent attempting to write {}D data \"{}\" to mesh \"{}\". "
@@ -1453,11 +1450,11 @@ void ParticipantImpl::setMeshAccessRegion(
   PRECICE_CHECK(_state != State::Finalized, "setMeshAccessRegion() cannot be called after finalize().");
   PRECICE_CHECK(_state != State::Initialized, "setMeshAccessRegion() needs to be called before initialize().");
 
-  // Get the related mesh
-  MeshContext &context = _accessor->meshContext(meshName);
+  // Get the related mesh - setMeshAccessRegion only works for received meshes
+  ReceivedMeshContext &receivedContext = _accessor->receivedMeshContext(meshName);
 
-  PRECICE_CHECK(!context.userDefinedAccessRegion, "A mesh access region was already defined for mesh \"{}\". setMeshAccessRegion may only be called once per mesh.", context.mesh->getName());
-  mesh::Mesh &mesh = *context.mesh;
+  PRECICE_CHECK(!receivedContext.userDefinedAccessRegion, "A mesh access region was already defined for mesh \"{}\". setMeshAccessRegion may only be called once per mesh.", receivedContext.mesh->getName());
+  mesh::Mesh &mesh = *receivedContext.mesh;
   int         dim  = mesh.getDimensions();
   PRECICE_CHECK(boundingBox.size() == static_cast<unsigned long>(dim) * 2,
                 "Incorrect amount of bounding box components attempting to set the bounding box of {}D mesh \"{}\" . "
@@ -1475,9 +1472,9 @@ void ParticipantImpl::setMeshAccessRegion(
     bounds[2 * d + 1] = boundingBox[2 * d + 1];
   }
   // Create a bounding box
-  context.userDefinedAccessRegion = std::make_shared<mesh::BoundingBox>(bounds);
+  receivedContext.userDefinedAccessRegion = std::make_shared<mesh::BoundingBox>(bounds);
   // Expand the mesh associated bounding box
-  mesh.expandBoundingBox(*context.userDefinedAccessRegion.get());
+  mesh.expandBoundingBox(*receivedContext.userDefinedAccessRegion.get());
 }
 
 void ParticipantImpl::getMeshVertexIDsAndCoordinates(
@@ -1494,7 +1491,7 @@ void ParticipantImpl::getMeshVertexIDsAndCoordinates(
                 meshName);
   // If an access region is required, we have to check its existence
   bool requiresBB = requiresUserDefinedAccessRegion(meshName);
-  PRECICE_CHECK(!requiresBB || (requiresBB && _accessor->meshContext(meshName).userDefinedAccessRegion),
+  PRECICE_CHECK(!requiresBB || (requiresBB && _accessor->receivedMeshContext(meshName).userDefinedAccessRegion),
                 "The function \"getMeshVertexIDsAndCoordinates\" was called on mesh \"{0}\", "
                 "but no access region was defined although this is necessary for parallel runs. "
                 "Please define an access region using \"setMeshAccessRegion()\" before calling \"getMeshVertexIDsAndCoordinates()\".",
@@ -1515,7 +1512,7 @@ void ParticipantImpl::getMeshVertexIDsAndCoordinates(
 
   const MeshContext &context = _accessor->meshContext(meshName);
 
-  auto       filteredVertices = context.filterVerticesToLocalAccessRegion(requiresBB);
+  auto       filteredVertices = _accessor->receivedMeshContext(meshName).filterVerticesToLocalAccessRegion(requiresBB);
   const auto meshSize         = filteredVertices.size();
 
   const mesh::Mesh &mesh     = *(context.mesh);
@@ -1549,19 +1546,23 @@ void ParticipantImpl::compareBoundingBoxes()
 {
   // sort meshContexts by name, for communication in right order.
   std::sort(_accessor->usedMeshContexts().begin(), _accessor->usedMeshContexts().end(),
-            [](MeshContext const *const lhs, MeshContext const *const rhs) -> bool {
-              return lhs->mesh->getName() < rhs->mesh->getName();
+            [](const MeshContextVariant &lhs, const MeshContextVariant &rhs) -> bool {
+              return getMesh(lhs).getName() < getMesh(rhs).getName();
             });
 
-  for (MeshContext *meshContext : _accessor->usedMeshContexts()) {
-    if (meshContext->provideMesh) // provided meshes need their bounding boxes already for the re-partitioning
-      meshContext->mesh->computeBoundingBox();
-
-    meshContext->clearMappings();
+  // Provided meshes need their bounding boxes already for the re-partitioning
+  for (auto &context : _accessor->providedMeshContexts()) {
+    context.mesh->computeBoundingBox();
   }
 
-  for (MeshContext *meshContext : _accessor->usedMeshContexts()) {
-    meshContext->partition->compareBoundingBoxes();
+  // Clear mappings for all meshes
+  for (auto &variant : _accessor->usedMeshContexts()) {
+    getMeshContext(variant)->clearMappings();
+  }
+
+  // Compare bounding boxes for all meshes
+  for (const auto &variant : _accessor->usedMeshContexts()) {
+    getPartition(variant).compareBoundingBoxes();
   }
 }
 
@@ -1574,12 +1575,12 @@ void ParticipantImpl::computePartitions()
   auto &contexts = _accessor->usedMeshContexts();
 
   std::sort(contexts.begin(), contexts.end(),
-            [](MeshContext const *const lhs, MeshContext const *const rhs) -> bool {
-              return lhs->mesh->getName() < rhs->mesh->getName();
+            [](const MeshContextVariant &lhs, const MeshContextVariant &rhs) -> bool {
+              return getMesh(lhs).getName() < getMesh(rhs).getName();
             });
 
-  for (MeshContext *meshContext : contexts) {
-    meshContext->partition->communicate();
+  for (const auto &variant : contexts) {
+    getPartition(variant).communicate();
   }
 
   // for two-level initialization, there is also still communication in partition::compute()
@@ -1596,22 +1597,25 @@ void ParticipantImpl::computePartitions()
   if (resort) {
     // pull provided meshes up front, to have them ready for the decomposition of the received meshes (for the mappings)
     std::stable_partition(contexts.begin(), contexts.end(),
-                          [](MeshContext const *const meshContext) -> bool {
-                            return meshContext->provideMesh;
+                          [](const MeshContextVariant &variant) -> bool {
+                            return std::holds_alternative<ProvidedMeshContext *>(variant);
                           });
   }
 
-  for (MeshContext *meshContext : contexts) {
-    meshContext->partition->compute();
-    if (not meshContext->provideMesh) { // received mesh can only compute their bounding boxes here
-      meshContext->mesh->computeBoundingBox();
+  for (const auto &variant : contexts) {
+    auto &mesh = getMesh(variant);
+    getPartition(variant).compute();
+
+    // Received meshes can only compute their bounding boxes here
+    if (std::holds_alternative<ReceivedMeshContext *>(variant)) {
+      mesh.computeBoundingBox();
     }
 
-    meshContext->mesh->allocateDataValues();
+    mesh.allocateDataValues();
 
-    const auto requiredSize = meshContext->mesh->nVertices();
+    const auto requiredSize = mesh.nVertices();
     for (auto &context : _accessor->writeDataContexts()) {
-      if (context.getMeshName() == meshContext->mesh->getName()) {
+      if (context.getMeshName() == mesh.getName()) {
         context.resizeBufferTo(requiredSize);
       }
     }
@@ -1870,7 +1874,7 @@ bool ParticipantImpl::requiresUserDefinedAccessRegion(std::string_view meshName)
 const mesh::Mesh &ParticipantImpl::mesh(const std::string &meshName) const
 {
   PRECICE_TRACE(meshName);
-  return *_accessor->usedMeshContext(meshName).mesh;
+  return *_accessor->meshContext(meshName).mesh;
 }
 
 ParticipantImpl::MappedSamples ParticipantImpl::mappedSamples() const
@@ -1891,8 +1895,8 @@ ParticipantImpl::MeshChanges ParticipantImpl::getTotalMeshChanges() const
 
   // Gather local changes
   std::vector<double> localMeshChanges;
-  for (auto context : _accessor->usedMeshContexts()) {
-    localMeshChanges.push_back(_meshLock.check(context->mesh->getName()) ? 0.0 : 1.0);
+  for (const auto &variant : _accessor->usedMeshContexts()) {
+    localMeshChanges.push_back(_meshLock.check(getMesh(variant).getName()) ? 0.0 : 1.0);
   }
   PRECICE_DEBUG("Mesh changes of rank: {}", localMeshChanges);
 
@@ -1908,11 +1912,13 @@ ParticipantImpl::MeshChanges ParticipantImpl::getTotalMeshChanges() const
 
 void ParticipantImpl::clearStamplesOfChangedMeshes(MeshChanges totalMeshChanges)
 {
-  auto meshContexts = _accessor->usedMeshContexts();
-  for (std::size_t i = 0; i < totalMeshChanges.size(); ++i) {
+  // Clear stamples where changes were detected
+  std::size_t i = 0;
+  for (auto &variant : _accessor->usedMeshContexts()) {
     if (totalMeshChanges[i] > 0.0) {
-      meshContexts[i]->mesh->clearDataStamples();
+      getMesh(variant).clearDataStamples();
     }
+    ++i;
   }
 }
 

--- a/src/precice/impl/ProvidedMeshContext.hpp
+++ b/src/precice/impl/ProvidedMeshContext.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "MeshContext.hpp"
+#include "partition/ProvidedPartition.hpp"
+
+#include <memory>
+
+namespace precice::impl {
+
+/// Context for a mesh provided by this participant
+struct ProvidedMeshContext : MeshContext {
+  std::shared_ptr<precice::partition::ProvidedPartition> partition;
+};
+
+} // namespace precice::impl

--- a/src/precice/impl/ReceivedMeshContext.cpp
+++ b/src/precice/impl/ReceivedMeshContext.cpp
@@ -1,0 +1,47 @@
+#include "ReceivedMeshContext.hpp"
+
+#include <Eigen/Core>
+
+#include "logging/LogMacros.hpp"
+#include "mesh/Mesh.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice::impl {
+
+void ReceivedMeshContext::checkVerticesInsideAccessRegion(precice::span<const double> coordinates, int meshDim, std::string_view functionName) const
+{
+  if (!userDefinedAccessRegion) {
+    return;
+  }
+  const auto                        nVertices = (coordinates.size() / meshDim);
+  Eigen::Map<const Eigen::MatrixXd> C(coordinates.data(), meshDim, nVertices);
+  Eigen::VectorXd                   minCoeffs = C.rowwise().minCoeff();
+  Eigen::VectorXd                   maxCoeffs = C.rowwise().maxCoeff();
+  bool                              minCheck  = (minCoeffs.array() >= userDefinedAccessRegion->minCorner().array()).all();
+  bool                              maxCheck  = (maxCoeffs.array() <= userDefinedAccessRegion->maxCorner().array()).all();
+  PRECICE_CHECK(minCheck && maxCheck, "The provided coordinates in \"{}\" are not within the access region defined with \"setMeshAccessRegion()\". "
+                                      "Minimum corner of the provided values is (x,y,z) = ({}), the minimum corner of the access region box is (x,y,z) = ({}). "
+                                      "Maximum corner of the provided values is (x,y,z) = ({}), the maximum corner of the access region box is (x,y,z) = ({}). ",
+                functionName, minCoeffs, userDefinedAccessRegion->minCorner(), maxCoeffs, userDefinedAccessRegion->maxCorner());
+  C.colwise().maxCoeff();
+}
+
+std::vector<std::reference_wrapper<const mesh::Vertex>> ReceivedMeshContext::filterVerticesToLocalAccessRegion(bool requiresBB) const
+{
+  std::vector<std::reference_wrapper<const mesh::Vertex>> filteredVertices;
+  for (const auto &v : mesh->vertices()) {
+    // either the vertex lies within the region OR the user-defined region is not strictly necessary
+    if (userDefinedAccessRegion) {
+      // region is defined: only add if the vertex is inside the region
+      if (userDefinedAccessRegion->contains(v)) {
+        filteredVertices.push_back(std::cref(v));
+      }
+    } else if (!requiresBB) {
+      // region is not defined, so if filtering isn't required, add all vertices
+      filteredVertices.push_back(std::cref(v));
+    }
+  }
+  return filteredVertices;
+}
+
+} // namespace precice::impl

--- a/src/precice/impl/ReceivedMeshContext.hpp
+++ b/src/precice/impl/ReceivedMeshContext.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "MeshContext.hpp"
+#include "logging/Logger.hpp"
+#include "mesh/BoundingBox.hpp"
+#include "mesh/Vertex.hpp"
+#include "partition/ReceivedPartition.hpp"
+#include "precice/span.hpp"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace precice::impl {
+
+/// Context for a mesh received from another participant
+struct ReceivedMeshContext : MeshContext {
+  /// Members that only exist for received meshes (moved from MeshContext)
+
+  /// In case a mapping done by the solver is favored over a preCICE mapping, apply user-defined
+  /// bounding-boxes.
+  bool allowDirectAccess = false;
+
+  /// setMeshAccessRegion may only be called once per mesh(context).
+  /// putting this into the mesh context means that we can only call
+  /// this once, regardless of combinations with just-in-time mappings
+  /// or multiple such mappings. If multiples are desired, we would
+  /// need to shift this into the MappingContext
+  std::shared_ptr<mesh::BoundingBox> userDefinedAccessRegion;
+
+  /// Name of participant that provides the mesh
+  std::string receiveMeshFrom;
+
+  /// bounding box to speed up decomposition of received mesh is increased by this safety factor
+  double safetyFactor = -1;
+
+  std::shared_ptr<precice::partition::ReceivedPartition> partition;
+
+  /// type of geometric filter
+  partition::ReceivedPartition::GeometricFilter geoFilter = partition::ReceivedPartition::GeometricFilter::UNDEFINED;
+
+  /// Checks, that all vertices are within the user-defined access region and throws
+  /// an error if vertices are not. The function does not return the result to be able
+  /// to log the actual outliers
+  void checkVerticesInsideAccessRegion(precice::span<const double> coordinates, int meshDim, std::string_view functionName) const;
+
+  /// Filters vertices to those within the local access region
+  std::vector<std::reference_wrapper<const mesh::Vertex>> filterVerticesToLocalAccessRegion(bool requiresBB) const;
+
+  mutable logging::Logger _log{"impl::ReceivedMeshContext"};
+};
+
+} // namespace precice::impl

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -268,8 +268,11 @@ target_sources(preciceCore
     src/precice/impl/ParticipantImpl.hpp
     src/precice/impl/ParticipantState.cpp
     src/precice/impl/ParticipantState.hpp
+    src/precice/impl/ProvidedMeshContext.hpp
     src/precice/impl/ReadDataContext.cpp
     src/precice/impl/ReadDataContext.hpp
+    src/precice/impl/ReceivedMeshContext.cpp
+    src/precice/impl/ReceivedMeshContext.hpp
     src/precice/impl/SharedPointer.hpp
     src/precice/impl/Types.hpp
     src/precice/impl/ValidationMacros.hpp


### PR DESCRIPTION
## Main changes of this PR
### Problem
Original `MeshContext` used a boolean flag to distinguish provided/received meshes, causing bug-prone code with conditionally-valid members.

### Solution

#### Type Hierarchy
- Split `MeshContext` into a `struct` base with common members.
- Created `ProvidedMeshContext` and `ReceivedMeshContext` derived structs.
- Removed all virtual methods and `static_cast` usage.
- **Design Note**: The `partition` member is intentionally placed in derived classes (as `std::shared_ptr<ProvidedPartition>` and `std::shared_ptr<ReceivedPartition>`) to maintain type safety and avoid runtime type checks.

#### Storage
- Separate containers: `_providedMeshContexts` and `_receivedMeshContexts` (using `std::deque` for pointer stability).
- `_usedMeshContexts` is now `std::vector<std::variant<ProvidedMeshContext*, ReceivedMeshContext*>>` to maintain global ordering.

#### Call-Site Approach
- **Ordering-Critical Sections (Deadlock Prevention):** Used `std::variant` loop with `std::holds_alternative` and `std::get` (e.g., `compareBoundingBoxes`, `communicate`). This ensures all participants iterate in the same global order (by mesh name).
- **Non-Critical Sections:** Used separate loops (one for provided, one for received) or helper lambdas to simplify code where ordering is not strictly required.
- **Helpers:** Added `getMeshName` and `getMeshContext` helpers using `std::visit` for cleaner variant access.

## Motivation and additional information
closes #1489


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
