### PR TITLE
Fix data id operator in testing

### DIFF
--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -18,7 +18,7 @@
 
 namespace precice::testing {
 
-DataID operator"" _dataID(unsigned long long n)
+DataID operator""_dataID(unsigned long long n)
 {
   PRECICE_ASSERT(n < std::numeric_limits<DataID>::max(), "DataID is too big");
   return static_cast<DataID>(n);

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -15,7 +15,7 @@ namespace precice::testing {
 
 namespace bt = boost::unit_test;
 
-DataID operator"" _dataID(unsigned long long n);
+DataID operator""_dataID(unsigned long long n);
 
 namespace inject {
 using precice::testing::Require;


### PR DESCRIPTION
## Main changes of this PR

Removes the space after "" in the operator definition.

## Motivation and additional information

New clang warning.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
