### PR TITLE
Copy test executable dependencies to the build folder on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,6 +676,12 @@ IF (BUILD_TESTING)
     endforeach()
   endif()
 
+  if(WIN32)
+    add_custom_command(TARGET testprecice POST_BUILD
+                       COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:testprecice> $<TARGET_FILE_DIR:testprecice>
+                       COMMAND_EXPAND_LISTS
+                       )
+  endif()
 else(BUILD_TESTING)
   message(STATUS "Excluding test sources")
 endif(BUILD_TESTING)


### PR DESCRIPTION
Windows lacks the runpath, but it looks in the executable folder for the dependencies. This way, ctest can run after a build and the tests do not require installation

## Main changes of this PR


## Motivation and additional information
Closes #2425 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
