### PR TITLE
Raise error on unsupported OS

### DIFF
--- a/src/utils/networking.cpp
+++ b/src/utils/networking.cpp
@@ -12,8 +12,7 @@ std::string loopbackInterfaceName()
   // Not required as we directly use the 127.0.0.1 under Windows
   return "";
 #else
-#warning "Your target architecture does not define a loopback interface. Please consider reporting this to the preCICE developers."
-  return "";
+#error "There is no loopback device defined for your OS. Please open an issue with a suggestion at https://github.com/precice/precice/issues"
 #endif
 }
 


### PR DESCRIPTION
## Main changes of this PR

This PR changes the loopback interface implementation to emit an error when the OS isn't known.

## Motivation and additional information

`#warning` was standardized only in C++23 and currently emits an error on MSVC.
The error forces the user to react and trigger us to add support instead of just ignoring the error in the build.


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
