### PR TITLE
Use brew package dependencies in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -232,7 +232,7 @@ jobs:
     - name: Install pip packages
       run: pip3 install numpy polars
     - name: Install preCICE dependencies
-      run: brew install --overwrite --quiet eigen libxml2 boost petsc openmpi ninja
+      run: brew install --build-from-source --only-dependencies --overwrite precice
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure


### PR DESCRIPTION
## Main changes of this PR

This PR changes the manual brew dependencies to the ones from the precice package.

## Motivation and additional information

Now that we have a precice package, we can ask brew to install all package dependencies of the precice package. This avoids manually listing them and should lead to a realer build environment.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
