### PR TITLE
fix a crash in two-level initialization

### DIFF
--- a/docs/changelog/2446.md
+++ b/docs/changelog/2446.md
@@ -1,0 +1,1 @@
+- Fixed a race condition in the two-way initialization process that can cause a crash

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -688,12 +688,16 @@ void ReceivedPartition::createOwnerInformation()
     // Exchange list of shared vertices with the neighbor
     // to store send requests.
     std::vector<com::PtrRequest> vertexListRequests;
+    vertexListRequests.reserve(2 * sharedVerticesSendMap.size());
+    // to keep all send buffers alive until the async sends are complete
+    std::vector<int> vertexListSizeSendBuffers;
+    vertexListSizeSendBuffers.reserve(sharedVerticesSendMap.size()); // make sure there are no reallocations
 
     for (auto &receivingRank : sharedVerticesSendMap) {
-      int  sendSize = receivingRank.second.size();
-      auto request  = utils::IntraComm::getCommunication()->aSend(sendSize, receivingRank.first);
+      vertexListSizeSendBuffers.push_back(static_cast<int>(receivingRank.second.size()));
+      auto request = utils::IntraComm::getCommunication()->aSend(vertexListSizeSendBuffers.back(), receivingRank.first);
       vertexListRequests.push_back(request);
-      if (sendSize != 0) {
+      if (vertexListSizeSendBuffers.back() != 0) {
         auto request = utils::IntraComm::getCommunication()->aSend(span<const int>{receivingRank.second}, receivingRank.first);
         vertexListRequests.push_back(request);
       }


### PR DESCRIPTION
## Main changes of this PR

keep alive buffers used in aSend during two-way intialization.

## Motivation and additional information

the buffer passed to `aSend` needs to be kept alive until the send is complete, i.e., after `request->wait()`. Here, a local variable was used that is overwritten in a loop. When the send actually happens, the value at the memory location has changed and the wrong value is sent. Task A sends X to B, B receives Y. Y is either random uninitialized bits or the value that is sent to some other task later in the loop depending on timing. Can be diagnosed by logging the size that is sent and received.

In my tests, depending on the received wrong value, this manifests either as an error message from MPI_Recv about a truncated message or a bad_alloc exception because the changed value is randomly very large.

I would appreciate advice about how you would like this tested, since it is a race condition that depends on the problem size and probably also MPI implementation/config (internal buffering, scheduling, etc). Not sure how large the problem needs to be, I used 2 ASTE instances with 512 MPI tasks each.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
