### PR TITLE
Add ubuntu-2604 to the ci

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -88,6 +88,10 @@ jobs:
             CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Debug
+          - IMAGE: 'ubuntu-2604'
+            CONFIG: MPIPETSc
+            CXX: 'g++'
+            TYPE: Debug
           - IMAGE: 'archlinux'
             CONFIG: MPIPETSc
             CXX: 'g++'


### PR DESCRIPTION
## Main changes of this PR

This PR adds Ubuntu 26.04 LTS to the CI.


## Motivation and additional information

This is based on the current ubuntu 26.04 testing image.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
