### PR TITLE
Fix CMake configuration for backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,14 +287,9 @@ if(PRECICE_FEATURE_GINKGO_MAPPING OR PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING)
   endif()
   include(CMakeDependentOption)
 
-  cmake_dependent_option(PRECICE_WITH_CUDA "Enable Ginkgo Cuda support in preCICE" ON "PRECICE_FEATURE_GINKGO_MAPPING;Kokkos_ENABLE_CUDA" OFF)
-  cmake_dependent_option(PRECICE_WITH_CUDA "Enable Kokkos Cuda support in preCICE" ON "PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING;Kokkos_ENABLE_CUDA" OFF)
-
-  cmake_dependent_option(PRECICE_WITH_HIP "Enable Ginkgo HIP support in preCICE" ON "PRECICE_FEATURE_GINKGO_MAPPING;Kokkos_ENABLE_HIP" OFF)
-  cmake_dependent_option(PRECICE_WITH_HIP "Enable Kokkos HIP support in preCICE" ON "PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING;Kokkos_ENABLE_HIP" OFF)
-
-  cmake_dependent_option(PRECICE_WITH_OPENMP "Enable Ginkgo OpenMP support in preCICE" ON "PRECICE_FEATURE_GINKGO_MAPPING;Kokkos_ENABLE_OPENMP" OFF)
-  cmake_dependent_option(PRECICE_WITH_OPENMP "Enable Kokkos OpenMP support in preCICE" ON "PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING;Kokkos_ENABLE_OPENMP" OFF)
+  cmake_dependent_option(PRECICE_WITH_CUDA "Enable CUDA support in preCICE through Kokkos or Ginkgo" ON "Kokkos_ENABLE_CUDA AND (PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING OR PRECICE_FEATURE_GINKGO_MAPPING)" OFF)
+  cmake_dependent_option(PRECICE_WITH_HIP "Enable HIP support in preCICE through Kokkos or Ginkgo" ON "Kokkos_ENABLE_HIP AND (PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING OR PRECICE_FEATURE_GINKGO_MAPPING)" OFF)
+  cmake_dependent_option(PRECICE_WITH_OPENMP "Enable OpenMP support in preCICE through Kokkos or Ginkgo" ON "Kokkos_ENABLE_OPENMP AND (PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING OR PRECICE_FEATURE_GINKGO_MAPPING)" OFF)
 
   # SYCL is only supported in Kokkos-kernels currently
   cmake_dependent_option(PRECICE_WITH_SYCL "Enable Kokkos SYCL support in preCICE" ON "PRECICE_FEATURE_KOKKOS_KERNELS_MAPPING;Kokkos_ENABLE_SYCL" OFF)


### PR DESCRIPTION
## Main changes of this PR

While I was certain that I tested the current approach as part of #2346, I might have run into a CMake caching behavior. The fix here is well-defined as part of the official documentation https://cmake.org/cmake/help/latest/module/CMakeDependentOption.html

The syntax is supported in CMake version 3.22 and later.

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
