### PR TITLE
Assert received data matching expected size

### DIFF
--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -7,6 +7,7 @@
 #include "com/MPIRequest.hpp"
 #include "logging/LogMacros.hpp"
 #include "precice/impl/Types.hpp"
+#include "utils/assertion.hpp"
 #include "utils/span_tools.hpp"
 
 template <size_t>
@@ -200,14 +201,23 @@ void MPICommunication::receive(precice::span<int> itemsToReceive, Rank rankSende
   PRECICE_TRACE(itemsToReceive.size());
   rankSender = adjustRank(rankSender);
 
-  MPI_Status status;
+#ifndef PRECICE_NO_ASSERTIONS
+  {
+    MPI_Status status;
+    MPI_Probe(rank(rankSender), 0, communicator(rankSender), &status);
+    int received = 0;
+    MPI_Get_count(&status, MPI_INT, &received);
+    PRECICE_ASSERT(received == itemsToReceive.size(), received, itemsToReceive.size());
+  }
+#endif
+
   MPI_Recv(itemsToReceive.data(),
            itemsToReceive.size(),
            MPI_INT,
            rank(rankSender),
            0,
            communicator(rankSender),
-           &status);
+           MPI_STATUS_IGNORE);
 }
 
 void MPICommunication::receive(precice::span<double> itemsToReceive, Rank rankSender)
@@ -215,14 +225,23 @@ void MPICommunication::receive(precice::span<double> itemsToReceive, Rank rankSe
   PRECICE_TRACE(itemsToReceive.size());
   rankSender = adjustRank(rankSender);
 
-  MPI_Status status;
+#ifndef PRECICE_NO_ASSERTIONS
+  {
+    MPI_Status status;
+    MPI_Probe(rank(rankSender), 0, communicator(rankSender), &status);
+    int received = 0;
+    MPI_Get_count(&status, MPI_DOUBLE, &received);
+    PRECICE_ASSERT(received == itemsToReceive.size(), received, itemsToReceive.size());
+  }
+#endif
+
   MPI_Recv(itemsToReceive.data(),
            itemsToReceive.size(),
            MPI_DOUBLE,
            rank(rankSender),
            0,
            communicator(rankSender),
-           &status);
+           MPI_STATUS_IGNORE);
 }
 
 PtrRequest MPICommunication::aReceive(precice::span<double> itemsToReceive, Rank rankSender)
@@ -247,14 +266,21 @@ void MPICommunication::receive(double &itemToReceive, Rank rankSender)
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
 
+#ifndef PRECICE_NO_ASSERTIONS
   MPI_Status status;
+  MPI_Probe(rank(rankSender), 0, communicator(rankSender), &status);
+  int received = 0;
+  MPI_Get_count(&status, MPI_DOUBLE, &received);
+  PRECICE_ASSERT(received == 1, received);
+#endif
+
   MPI_Recv(&itemToReceive,
            1,
            MPI_DOUBLE,
            rank(rankSender),
            0,
            communicator(rankSender),
-           &status);
+           MPI_STATUS_IGNORE);
   PRECICE_DEBUG("Received {} from rank {}", itemToReceive, rankSender);
 }
 
@@ -268,14 +294,21 @@ void MPICommunication::receive(int &itemToReceive, Rank rankSender)
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
 
+#ifndef PRECICE_NO_ASSERTIONS
   MPI_Status status;
+  MPI_Probe(rank(rankSender), 0, communicator(rankSender), &status);
+  int received = 0;
+  MPI_Get_count(&status, MPI_INT, &received);
+  PRECICE_ASSERT(received == 1, received);
+#endif
+
   MPI_Recv(&itemToReceive,
            1,
            MPI_INT,
            rank(rankSender),
            0,
            communicator(rankSender),
-           &status);
+           MPI_STATUS_IGNORE);
   PRECICE_DEBUG("Received {} from rank {}", itemToReceive, rankSender);
 }
 
@@ -301,14 +334,21 @@ void MPICommunication::receive(bool &itemToReceive, Rank rankSender)
   PRECICE_TRACE(rankSender);
   rankSender = adjustRank(rankSender);
 
+#ifndef PRECICE_NO_ASSERTIONS
   MPI_Status status;
+  MPI_Probe(rank(rankSender), 0, communicator(rankSender), &status);
+  int received = 0;
+  MPI_Get_count(&status, MPI_BOOL, &received);
+  PRECICE_ASSERT(received == 1, received);
+#endif
+
   MPI_Recv(&itemToReceive,
            1,
            MPI_BOOL,
            rank(rankSender),
            0,
            communicator(rankSender),
-           &status);
+           MPI_STATUS_IGNORE);
   PRECICE_DEBUG("Received {} from rank {}", itemToReceive, rankSender);
 }
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds an assertion before blocking receives that probes MPI to get the amount of elements to receive and compares that against the receive buffer size.

## Motivation and additional information

Inspired by #2446

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
