### PR TITLE
GSoC entry test draft pr

### DIFF
--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -80,9 +80,9 @@ void MeshConfiguration::xmlTagCallback(
       }
     }
     PRECICE_CHECK(found,
-                  "Data with name \"{}\" used by mesh \"{}\" is not defined. "
+                  "[Context: Error inside <{}> tag] Data with name \"{}\" used by mesh \"{}\" is not defined. "
                   "Please define a data tag with name=\"{}\".",
-                  name, _meshes.back()->getName(), name);
+                  tag.getFullName(), name, _meshes.back()->getName(), name);
   }
 }
 


### PR DESCRIPTION
## Main changes of this PR
Updated the PRECICE_CHECK macro in MeshConfiguration.cpp to include the XML tag context when a configured data mesh is missing. Used tag.getFullName() instead of getName() to ensure full context.

## Motivation and additional information
This is for the entry test of multi step configuration project(gsoc)

before:
<img width="1920" height="1080" alt="bf" src="https://github.com/user-attachments/assets/65179597-f25d-42fc-a8fd-f51e8401a235" />

after:
<img width="1920" height="1080" alt="af" src="https://github.com/user-attachments/assets/463cffd8-25b3-41d4-80d4-e8f63944d012" />

Could've done same for other configs, but how tightly coupled parsing and object creation are, we definitely need an ast layer and will be overwritten anyways then.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
