### PR TITLE
Improve XML configuration error messages with line numbers (gsoc 2026 entry test)

### DIFF
--- a/docs/changelog/2456.md
+++ b/docs/changelog/2456.md
@@ -1,0 +1,1 @@
+* Added XML line numbers to configuration parser error messages.

--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -80,9 +80,9 @@ void MeshConfiguration::xmlTagCallback(
       }
     }
     PRECICE_CHECK(found,
-                  "Data with name \"{}\" used by mesh \"{}\" is not defined. "
+                  "[Line {}] Data with name \"{}\" used by mesh \"{}\" is not defined. "
                   "Please define a data tag with name=\"{}\".",
-                  name, _meshes.back()->getName(), name);
+                  tag.getLineNumber(), name, _meshes.back()->getName(), name);
   }
 }
 

--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -67,9 +67,17 @@ void OnStartElementNs(
 
   auto pParser = static_cast<ConfigParser *>(ctx);
 
+  int lineNumber = -1;
+  if (pParser->_parserCtxt) {
+    auto ctxt = static_cast<xmlParserCtxtPtr>(pParser->_parserCtxt);
+    if (ctxt->input) {
+      lineNumber = ctxt->input->line;
+    }
+  }
+
   std::string_view sPrefix(prefix == nullptr ? "" : reinterpret_cast<const char *>(prefix));
 
-  pParser->OnStartElement(reinterpret_cast<const char *>(localname), sPrefix, attributesMap);
+  pParser->OnStartElement(reinterpret_cast<const char *>(localname), sPrefix, attributesMap, lineNumber);
 }
 
 void OnEndElementNs(
@@ -191,7 +199,9 @@ int ConfigParser::readXmlFile(std::string const &filePath)
   xmlParserCtxtPtr ctxt = xmlCreatePushParserCtxt(&SAXHandler, static_cast<void *>(this),
                                                   content.c_str(), content.size(), nullptr);
 
+  _parserCtxt = ctxt;
   xmlParseChunk(ctxt, nullptr, 0, 1);
+  _parserCtxt = nullptr;
   xmlFreeParserCtxt(ctxt);
   xmlCleanupParser();
 
@@ -263,6 +273,7 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
     }
 
     pDefSubTag->_configuredNamespaces[pDefSubTag->_namespace] = true;
+    pDefSubTag->setLineNumber(subtag->m_LineNumber);
     pDefSubTag->readAttributes(subtag->m_aAttributes);
     pDefSubTag->_listener.xmlTagCallback(context, *pDefSubTag);
     pDefSubTag->_configured = true;
@@ -277,13 +288,15 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
 void ConfigParser::OnStartElement(
     std::string_view    localname,
     std::string_view    prefix,
-    CTag::AttributePair attributes)
+    CTag::AttributePair attributes,
+    int                 lineNumber)
 {
   auto pTag = std::make_shared<CTag>();
 
   pTag->m_Prefix      = prefix;
   pTag->m_Name        = localname;
   pTag->m_aAttributes = std::move(attributes);
+  pTag->m_LineNumber  = lineNumber;
 
   if (not m_CurrentTags.empty()) {
     auto pParentTag = m_CurrentTags.back();

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -25,7 +25,8 @@ public:
   struct CTag {
     std::string m_Name;
     std::string m_Prefix;
-    bool        m_Used = false;
+    bool        m_Used       = false;
+    int         m_LineNumber = -1;
 
     using AttributePair = std::map<std::string, std::string>;
     AttributePair                      m_aAttributes;
@@ -55,6 +56,8 @@ public:
   /// Reads the xml file
   int readXmlFile(std::string const &filePath);
 
+  void *_parserCtxt = nullptr;
+
   /// returns the hash of the processed XML file
   std::string hash() const;
 
@@ -69,7 +72,8 @@ public:
   void OnStartElement(
       std::string_view    localname,
       std::string_view    prefix,
-      CTag::AttributePair attributes);
+      CTag::AttributePair attributes,
+      int                 lineNumber);
 
   /// Callback for End-Tag
   void OnEndElement();

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -199,6 +199,15 @@ public:
     return _occurrence;
   }
 
+  void setLineNumber(int line)
+  {
+    _lineNumber = line;
+  }
+  int getLineNumber() const
+  {
+    return _lineNumber;
+  }
+
   /// reads all attributes of this tag
   void readAttributes(const std::map<std::string, std::string> &aAttributes);
 
@@ -219,6 +228,8 @@ private:
   std::string _doc;
 
   bool _configured = false;
+
+  int _lineNumber = -1;
 
   Occurrence _occurrence;
 


### PR DESCRIPTION
For the entry task of project Clean multi-step configuration , i managed to dug into the parser architecture and implemented the plumbing to pass the exact XML line number from the SAX parser up to the semantic validation macros .

earlier,

<img width="1708" height="366" alt="image" src="https://github.com/user-attachments/assets/16f56a93-1188-4a41-ad3a-256ccae9936e" />

after modifications,

<img width="867" height="146" alt="Screenshot 2026-02-22 at 11 05 23 PM" src="https://github.com/user-attachments/assets/aec86019-72b0-4f00-9c04-db725159aaab" />

## Main changes of this PR

- Parser Context Extraction: Tapped into the `libxml2` `xmlParserCtxtPtr` during the `OnStartElementNs` SAX callback to extract the current parsing line number via `input->line`.
- Data Plumbing: Passed the parsed line number through the temporary `ConfigParser::CTag` data structure during the XML reading phase.
- AST State Update: Added a `_lineNumber` member variable with getter/setter methods to the `xml::XMLTag` class to store the location state.
- Semantic Validation Enhancement: Updated the `PRECICE_CHECK` macro inside `MeshConfiguration::xmlTagCallback` to utilize `tag.getLineNumber()`, directly pointing the user to the exact XML line where the validation fails.

```
src/xml/ChangeLog:

* ConfigParser.hpp (ConfigParser::CTag): Add m_LineNumber member.
(ConfigParser::OnStartElement): Update signature to accept lineNumber.
* ConfigParser.cpp (OnStartElementNs): Extract line number from libxml2 context.
(ConfigParser::connectTags): Pass line number to XMLTag.
(ConfigParser::OnStartElement): Store line number in CTag.
* XMLTag.hpp (XMLTag): Add _lineNumber member with getter and setter.

src/mesh/config/ChangeLog:

* MeshConfiguration.cpp (xmlTagCallback): Include line number in PRECICE_CHECK error message.
```
## Motivation and additional information

Currently, when the semantic validation phase catches a configuration error (e.g., a mesh requesting a data tag that hasn't been defined), the error message lacks location context. By plumbing the line numbers from the underlying `libxml2` SAX parser up into the Configuration AST (`XMLTag`), we can dramatically improve the user experience by pointing them directly to the failing line in their `precice-config.xml` file.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
