### PR TITLE
Add config validation error when neither max-time nor max-time-windows

### DIFF
--- a/docs/changelog/2459.md
+++ b/docs/changelog/2459.md
@@ -1,0 +1,1 @@
+- Added config validation error when neither max-time nor max-time-windows is defined in a coupling scheme.

--- a/src/cplscheme/config/CouplingSchemeConfiguration.cpp
+++ b/src/cplscheme/config/CouplingSchemeConfiguration.cpp
@@ -321,6 +321,13 @@ void CouplingSchemeConfiguration::xmlEndTagCallback(
 {
   PRECICE_TRACE(tag.getFullName());
   if (tag.getNamespace() == TAG) {
+    PRECICE_CHECK(_config.maxTime != CouplingScheme::UNDEFINED_MAX_TIME ||
+                      _config.maxTimeWindows != CouplingScheme::UNDEFINED_TIME_WINDOWS,
+                  "At least one termination condition is required "
+                  "for the coupling scheme of type \"{}\". "
+                  "Please add a <max-time value=\"...\"/> or <max-time-windows value=\"...\"/> tag "
+                  "inside your <coupling-scheme:{}> configuration.",
+                  _config.type, _config.type);
     if (_config.type == VALUE_SERIAL_EXPLICIT) {
       PRECICE_CHECK(!_allowRemeshing, "Remeshing is currently incompatible with serial coupling schemes. Try using a parallel or a multi coupling scheme instead.");
       std::string       accessor(_config.participants[0]);

--- a/tests/config/no-termination-condition.xml
+++ b/tests/config/no-termination-condition.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-implicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <time-window-size value="1.0" />
+    <min-iterations value="2" />
+    <max-iterations value="2" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-implicit>
+</precice-configuration>

--- a/tests/config/tests.cmake
+++ b/tests/config/tests.cmake
@@ -13,3 +13,5 @@ precice_test_config_valid(unidirectional.xml Fluid 1)
 precice_test_config_invalid(unidirectional.xml "only the mapping combinations read-consistent and write-conservative" Fluid 2)
 precice_test_config_valid(unidirectional.xml Transport 1)
 precice_test_config_valid(unidirectional.xml Transport 2)
+
+precice_test_config_invalid(no-termination-condition.xml "At least one termination condition is required")


### PR DESCRIPTION


## Main changes of this PR

Added a `PRECICE_CHECK` in` CouplingSchemeConfiguration::xmlEndTagCallback` that raises an error at configuration time if neither `max-time` nor `max-time-windows` is defined for a coupling scheme

**fixes:#1585**

## Motivation and additional information
<img width="1404" height="609" alt="Screenshot 2026-02-23 063031" src="https://github.com/user-attachments/assets/058ffc9d-90bb-4d23-a2fe-b88d78bf2553" />

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
