### PR TITLE
Add optional mesh attribute to export tags to allow selective mesh export

### DIFF
--- a/docs/changelog/2462.md
+++ b/docs/changelog/2462.md
@@ -1,0 +1,1 @@
+- Added option to export only given meshes using `<export:X mesh="Name" />`. Not specifying a mesh will export all meshes known to the participant.

--- a/src/io/ExportContext.hpp
+++ b/src/io/ExportContext.hpp
@@ -23,6 +23,9 @@ struct ConfiguredExport {
 
   // @brief type of the exporter (e.g. vtk).
   std::string type;
+
+  // @brief Configured mesh name to export (empty means export all meshes).
+  std::string configuredMeshName;
 };
 
 struct ExportContext : public ConfiguredExport {

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -33,6 +33,9 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
     tags.push_back(tag);
   }
 
+  auto attrMesh = XMLAttribute<std::string>(ATTR_MESH, "")
+                      .setDocumentation("Name of the mesh to export, or empty to export all meshes of the participant.");
+
   auto attrLocation = XMLAttribute<std::string>(ATTR_LOCATION, ".")
                           .setDocumentation("Directory to export the files to.");
 
@@ -46,6 +49,7 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
                               .setDocumentation("Update the series file after every export instead of at the end of the simulation.");
 
   for (XMLTag &tag : tags) {
+    tag.addAttribute(attrMesh);
     tag.addAttribute(attrLocation);
     tag.addAttribute(attrEveryNTimeWindows);
     tag.addAttribute(attrEveryIteration);
@@ -60,11 +64,12 @@ void ExportConfiguration::xmlTagCallback(
 {
   if (tag.getNamespace() == TAG) {
     ConfiguredExport config;
-    config.location          = tag.getStringAttributeValue(ATTR_LOCATION);
-    config.everyNTimeWindows = tag.getIntAttributeValue(ATTR_EVERY_N_TIME_WINDOWS);
-    config.everyIteration    = tag.getBooleanAttributeValue(ATTR_EVERY_ITERATION);
-    config.updateSeries      = tag.getBooleanAttributeValue(ATTR_UPDATE_SERIES);
-    config.type              = tag.getName();
+    config.configuredMeshName = tag.getStringAttributeValue(ATTR_MESH);
+    config.everyIteration     = tag.getBooleanAttributeValue(ATTR_EVERY_ITERATION);
+    config.everyNTimeWindows  = tag.getIntAttributeValue(ATTR_EVERY_N_TIME_WINDOWS);
+    config.location           = tag.getStringAttributeValue(ATTR_LOCATION);
+    config.type               = tag.getName();
+    config.updateSeries       = tag.getBooleanAttributeValue(ATTR_UPDATE_SERIES);
     _contexts.push_back(std::move(config));
   }
 }

--- a/src/io/config/ExportConfiguration.hpp
+++ b/src/io/config/ExportConfiguration.hpp
@@ -46,6 +46,7 @@ private:
   const std::string VALUE_VTP     = "vtp";
   const std::string VALUE_CSV     = "csv";
 
+  const std::string ATTR_MESH                 = "mesh";
   const std::string ATTR_EVERY_N_TIME_WINDOWS = "every-n-time-windows";
   const std::string ATTR_NEIGHBORS            = "neighbors";
   const std::string ATTR_EVERY_ITERATION      = "every-iteration";

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -658,10 +658,26 @@ void ParticipantConfiguration::finishParticipantConfiguration(
 
   // Add export contexts
   for (const io::ConfiguredExport &exportConfig : _exportConfig->exportContexts()) {
-    auto kind = exportConfig.everyIteration ? io::Export::ExportKind::Iterations : io::Export::ExportKind::TimeWindows;
+    // Check if meshes to export even exist
+    if (!exportConfig.configuredMeshName.empty()) {
+      PRECICE_CHECK(
+          participant->hasMesh(exportConfig.configuredMeshName),
+          "Participant \"{}\" defines an <export:{} mesh=\"{}\" ... /> tag, but mesh \"{}\" is not known to this participant. "
+          "Please check the mesh name or remove the mesh attribute to export all meshes.",
+          participant->getName(), exportConfig.type,
+          exportConfig.configuredMeshName, exportConfig.configuredMeshName);
+    }
 
-    // Lambda to create exporter for any mesh context (avoids code duplication)
+    // Lambda to create exporter for any mesh context if the name matches
     auto createExporter = [&](const impl::MeshContext &meshContext) {
+      // Skip meshes that don't match the configured mesh filter
+      if (!exportConfig.configuredMeshName.empty() &&
+          exportConfig.configuredMeshName != meshContext.mesh->getName()) {
+        return;
+      }
+
+      auto kind = exportConfig.everyIteration ? io::Export::ExportKind::Iterations : io::Export::ExportKind::TimeWindows;
+
       std::unique_ptr<io::Export> exporter;
       if (exportConfig.type == VALUE_VTK) {
         // This is handled with respect to the current configuration context.
@@ -720,12 +736,12 @@ void ParticipantConfiguration::finishParticipantConfiguration(
           io::makeExportContext(exportConfig, std::move(exporter), meshContext.mesh->getName()));
     };
 
-    // Create one exporter per provided mesh
+    // Create exporter for provided meshes
     for (const auto &meshContext : participant->providedMeshContexts()) {
       createExporter(meshContext);
     }
 
-    // Create one exporter per received mesh
+    // Create exporter for received meshes
     for (const auto &meshContext : participant->receivedMeshContexts()) {
       createExporter(meshContext);
     }

--- a/src/testing/Testing.cpp
+++ b/src/testing/Testing.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <regex>
 #include <string>
+#include <unordered_set>
 
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
@@ -137,6 +138,40 @@ boost::test_tools::predicate_result equals(double a, double b, double tolerance)
 void expectFile(std::string_view name)
 {
   BOOST_TEST(std::filesystem::is_regular_file(name), "File " << name << " is not a regular file or doesn't exist.");
+}
+
+void expectDirectoryContent(std::string_view dir, std::vector<std::string> filenames)
+{
+  bool dirExists = std::filesystem::is_directory(dir);
+  BOOST_TEST(dirExists, "Directory " << dir << " doesn't exist.");
+  if (dirExists) {
+    std::unordered_set<std::string> actual;
+    for (const auto &entry : std::filesystem::directory_iterator(dir)) {
+      if (entry.is_regular_file()) {
+        actual.insert(entry.path().filename().string());
+      }
+    }
+
+    std::unordered_set<std::string> expected(filenames.begin(), filenames.end());
+
+    for (const auto &file : expected) {
+      BOOST_TEST(actual.count(file) > 0, "Missing file: " << file);
+    }
+
+    for (const auto &file : actual) {
+      BOOST_TEST(expected.count(file) > 0, "Unexpected file: " << file);
+    }
+  }
+}
+
+void expectNoDirectory(std::string_view dir)
+{
+  BOOST_TEST(!std::filesystem::is_directory(dir), "Directory " << dir << " shouldn't exist.");
+}
+
+void removeDirectory(std::string_view name)
+{
+  std::filesystem::remove_all(name);
 }
 
 ErrorPredicate errorContains(std::string_view substring)

--- a/src/testing/Testing.hpp
+++ b/src/testing/Testing.hpp
@@ -168,6 +168,12 @@ void expectFiles(Args... args)
   (expectFile(args), ...);
 }
 
+void expectDirectoryContent(std::string_view dir, std::vector<std::string> filenames);
+
+void expectNoDirectory(std::string_view dir);
+
+void removeDirectory(std::string_view name);
+
 using ErrorPredicate = std::function<bool(::precice::Error)>;
 
 /// Checks if the message of a given precice::Error contains a substring

--- a/tests/config/exporter-all.xml
+++ b/tests/config/exporter-all.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+    <export:vtu />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+    <export:vtu />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/config/exporter-empty.xml
+++ b/tests/config/exporter-empty.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+    <export:vtu mesh="" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+    <export:vtu mesh="" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/config/exporter-provided.xml
+++ b/tests/config/exporter-provided.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+    <export:vtu mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+    <export:vtu mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/config/exporter-received.xml
+++ b/tests/config/exporter-received.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+    <export:vtu mesh="SolverOne-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/config/exporter-unavailable.xml
+++ b/tests/config/exporter-unavailable.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <log>
+    <sink
+      type="stream"
+      output="stdout"
+      filter="%Severity% > debug"
+      format="preCICE:%ColorizedSeverity% %Message%"
+      enabled="true" />
+  </log>
+
+  <data:vector name="Data-One" />
+  <data:vector name="Data-Two" />
+
+  <mesh name="SolverOne-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <mesh name="SolverTwo-Mesh" dimensions="3">
+    <use-data name="Data-One" />
+    <use-data name="Data-Two" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <export:vtu mesh="SolverTwo-Mesh" />
+    <provide-mesh name="SolverOne-Mesh" />
+    <write-data name="Data-One" mesh="SolverOne-Mesh" />
+    <read-data name="Data-Two" mesh="SolverOne-Mesh" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="SolverOne-Mesh" from="SolverOne" />
+    <provide-mesh name="SolverTwo-Mesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="SolverTwo-Mesh"
+      to="SolverOne-Mesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="SolverOne-Mesh"
+      to="SolverTwo-Mesh"
+      constraint="consistent" />
+    <write-data name="Data-Two" mesh="SolverTwo-Mesh" />
+    <read-data name="Data-One" mesh="SolverTwo-Mesh" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="Data-One" mesh="SolverOne-Mesh" from="SolverOne" to="SolverTwo" />
+    <exchange data="Data-Two" mesh="SolverOne-Mesh" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/config/tests.cmake
+++ b/tests/config/tests.cmake
@@ -15,3 +15,9 @@ precice_test_config_valid(unidirectional.xml Transport 1)
 precice_test_config_valid(unidirectional.xml Transport 2)
 
 precice_test_config_invalid(no-termination-condition.xml "At least one termination condition is required")
+
+precice_test_config_valid(exporter-all.xml)
+precice_test_config_valid(exporter-empty.xml)
+precice_test_config_valid(exporter-provided.xml)
+precice_test_config_valid(exporter-received.xml)
+precice_test_config_invalid(exporter-unavailable.xml "is not known to this participant")

--- a/tests/exporter/filter/All.cpp
+++ b/tests/exporter/filter/All.cpp
@@ -1,0 +1,50 @@
+#ifndef PRECICE_NO_MPI
+
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Exporter)
+BOOST_AUTO_TEST_SUITE(Filter)
+PRECICE_TEST_SETUP("SA"_on(1_rank), "SB"_on(1_rank))
+BOOST_AUTO_TEST_CASE(All)
+{
+  PRECICE_TEST();
+  if (context.isNamed("SA")) {
+    precice::testing::removeDirectory("ExportsA");
+  } else {
+    precice::testing::removeDirectory("ExportsB");
+  }
+  runExporter(context.config(), context);
+
+  if (context.isNamed("SA")) {
+    precice::testing::expectDirectoryContent(
+        "ExportsA",
+        {
+            "MA-SA.init.vtu",
+            "MA-SA.dt1.vtu",
+            "MA-SA.dt2.vtu",
+            "MA-SA.vtu.series",
+
+            "MB-SA.init.vtu",
+            "MB-SA.dt1.vtu",
+            "MB-SA.dt2.vtu",
+            "MB-SA.vtu.series",
+        });
+  } else {
+    precice::testing::expectDirectoryContent(
+        "ExportsB",
+        {
+            "MB-SB.init.vtu",
+            "MB-SB.dt1.vtu",
+            "MB-SB.dt2.vtu",
+            "MB-SB.vtu.series",
+        });
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Filter
+BOOST_AUTO_TEST_SUITE_END() // Exporter
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/exporter/filter/All.xml
+++ b/tests/exporter/filter/All.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="S" />
+  <data:vector name="V" />
+
+  <mesh name="MB" dimensions="3">
+    <use-data name="S" />
+    <use-data name="V" />
+  </mesh>
+
+  <mesh name="MA" dimensions="3">
+    <use-data name="S" />
+    <use-data name="V" />
+  </mesh>
+
+  <participant name="SA">
+    <receive-mesh name="MB" from="SB" />
+    <provide-mesh name="MA" />
+    <mapping:nearest-neighbor direction="write" from="MA" to="MB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+    <write-data name="S" mesh="MA" />
+    <read-data name="V" mesh="MA" />
+    <export:vtu directory="ExportsA" />
+  </participant>
+
+  <participant name="SB">
+    <provide-mesh name="MB" />
+    <write-data name="V" mesh="MB" />
+    <read-data name="S" mesh="MB" />
+    <export:vtu directory="ExportsB" />
+  </participant>
+
+  <m2n:sockets acceptor="SA" connector="SB" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SA" second="SB" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="S" mesh="MB" from="SA" to="SB" />
+    <exchange data="V" mesh="MB" from="SB" to="SA" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/exporter/filter/Provided.cpp
+++ b/tests/exporter/filter/Provided.cpp
@@ -1,0 +1,45 @@
+#ifndef PRECICE_NO_MPI
+
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Exporter)
+BOOST_AUTO_TEST_SUITE(Filter)
+PRECICE_TEST_SETUP("SA"_on(1_rank), "SB"_on(1_rank))
+BOOST_AUTO_TEST_CASE(Provided)
+{
+  PRECICE_TEST();
+  if (context.isNamed("SA")) {
+    precice::testing::removeDirectory("ExportsA");
+  } else {
+    precice::testing::removeDirectory("ExportsB");
+  }
+  runExporter(context.config(), context);
+
+  if (context.isNamed("SA")) {
+    precice::testing::expectDirectoryContent(
+        "ExportsA",
+        {
+            "MA-SA.init.vtu",
+            "MA-SA.dt1.vtu",
+            "MA-SA.dt2.vtu",
+            "MA-SA.vtu.series",
+        });
+  } else {
+    precice::testing::expectDirectoryContent(
+        "ExportsB",
+        {
+            "MB-SB.init.vtu",
+            "MB-SB.dt1.vtu",
+            "MB-SB.dt2.vtu",
+            "MB-SB.vtu.series",
+        });
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Filter
+BOOST_AUTO_TEST_SUITE_END() // Exporter
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/exporter/filter/Provided.xml
+++ b/tests/exporter/filter/Provided.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="S" />
+  <data:vector name="V" />
+
+  <mesh name="MB" dimensions="3">
+    <use-data name="S" />
+    <use-data name="V" />
+  </mesh>
+
+  <mesh name="MA" dimensions="3">
+    <use-data name="S" />
+    <use-data name="V" />
+  </mesh>
+
+  <participant name="SA">
+    <receive-mesh name="MB" from="SB" />
+    <provide-mesh name="MA" />
+    <mapping:nearest-neighbor direction="write" from="MA" to="MB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+    <write-data name="S" mesh="MA" />
+    <read-data name="V" mesh="MA" />
+    <export:vtu directory="ExportsA" mesh="MA" />
+  </participant>
+
+  <participant name="SB">
+    <provide-mesh name="MB" />
+    <write-data name="V" mesh="MB" />
+    <read-data name="S" mesh="MB" />
+    <export:vtu directory="ExportsB" mesh="MB" />
+  </participant>
+
+  <m2n:sockets acceptor="SA" connector="SB" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SA" second="SB" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="S" mesh="MB" from="SA" to="SB" />
+    <exchange data="V" mesh="MB" from="SB" to="SA" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/exporter/filter/Received.cpp
+++ b/tests/exporter/filter/Received.cpp
@@ -1,0 +1,38 @@
+#ifndef PRECICE_NO_MPI
+
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Exporter)
+BOOST_AUTO_TEST_SUITE(Filter)
+PRECICE_TEST_SETUP("SA"_on(1_rank), "SB"_on(1_rank))
+BOOST_AUTO_TEST_CASE(Received)
+{
+  PRECICE_TEST();
+  if (context.isNamed("SA")) {
+    precice::testing::removeDirectory("ExportsA");
+  } else {
+    precice::testing::removeDirectory("ExportsB");
+  }
+  runExporter(context.config(), context);
+
+  if (context.isNamed("SA")) {
+    precice::testing::expectDirectoryContent(
+        "ExportsA",
+        {
+            "MB-SA.init.vtu",
+            "MB-SA.dt1.vtu",
+            "MB-SA.dt2.vtu",
+            "MB-SA.vtu.series",
+        });
+  } else {
+    precice::testing::expectNoDirectory("ExportsB");
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Filter
+BOOST_AUTO_TEST_SUITE_END() // Exporter
+BOOST_AUTO_TEST_SUITE_END() // Integration
+
+#endif // PRECICE_NO_MPI

--- a/tests/exporter/filter/Received.xml
+++ b/tests/exporter/filter/Received.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="S" />
+  <data:vector name="V" />
+
+  <mesh name="MB" dimensions="3">
+    <use-data name="S" />
+    <use-data name="V" />
+  </mesh>
+
+  <mesh name="MA" dimensions="3">
+    <use-data name="S" />
+    <use-data name="V" />
+  </mesh>
+
+  <participant name="SA">
+    <receive-mesh name="MB" from="SB" />
+    <provide-mesh name="MA" />
+    <mapping:nearest-neighbor direction="write" from="MA" to="MB" constraint="conservative" />
+    <mapping:nearest-neighbor direction="read" from="MB" to="MA" constraint="consistent" />
+    <write-data name="S" mesh="MA" />
+    <read-data name="V" mesh="MA" />
+    <export:vtu directory="ExportsA" mesh="MB" />
+  </participant>
+
+  <participant name="SB">
+    <provide-mesh name="MB" />
+    <write-data name="V" mesh="MB" />
+    <read-data name="S" mesh="MB" />
+  </participant>
+
+  <m2n:sockets acceptor="SA" connector="SB" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SA" second="SB" />
+    <max-time-windows value="2" />
+    <time-window-size value="1.0" />
+    <exchange data="S" mesh="MB" from="SA" to="SB" />
+    <exchange data="V" mesh="MB" from="SB" to="SA" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/exporter/filter/helpers.cpp
+++ b/tests/exporter/filter/helpers.cpp
@@ -1,0 +1,29 @@
+#ifndef PRECICE_NO_MPI
+
+#include <array>
+#include <boost/test/unit_test_log.hpp>
+#include <precice/precice.hpp>
+
+#include "helpers.hpp"
+#include "testing/Testing.hpp"
+
+/// Test to run simple "do nothing" coupling between two solvers.
+void runExporter(std::string const &configurationFileName, precice::testing::TestContext const &context)
+{
+  BOOST_TEST_MESSAGE("Config: " << configurationFileName);
+  precice::Participant p(context.name, configurationFileName, 0, 1);
+
+  std::array<double, 6> pos{0, 0, 0, 1, 1, 1};
+  std::array<int, 2>    vids;
+
+  auto meshName = context.isNamed("SA") ? "MA" : "MB";
+  BOOST_REQUIRE(p.getMeshDimensions(meshName) == 3);
+  p.setMeshVertices(meshName, pos, vids);
+
+  p.initialize();
+  while (p.isCouplingOngoing()) {
+    p.advance(p.getMaxTimeStepSize());
+  }
+}
+
+#endif

--- a/tests/exporter/filter/helpers.hpp
+++ b/tests/exporter/filter/helpers.hpp
@@ -1,0 +1,8 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+/// Test to run simple "do nothing" coupling between two solvers.
+void runExporter(std::string const &configurationFileName, precice::testing::TestContext const &context);
+
+#endif

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -3,6 +3,11 @@
 #
 target_sources(testprecice
     PRIVATE
+    tests/exporter/filter/All.cpp
+    tests/exporter/filter/Provided.cpp
+    tests/exporter/filter/Received.cpp
+    tests/exporter/filter/helpers.cpp
+    tests/exporter/filter/helpers.hpp
     tests/exporter/timeseries/ExportTimeseries.cpp
     tests/exporter/timeseries/FinalTimeseries.cpp
     tests/exporter/timeseries/UpdatedTimeseries.cpp


### PR DESCRIPTION
## Main changes of this PR

_edit by @fsimonis_

This PR adds an attribute to restrict an export to a given mesh.
`<export:X mesh="Name" />` now only exports the mesh `Name`.

Closes #1888 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
