### PR TITLE
Add performance regression test workflow

### DIFF
--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -1,6 +1,6 @@
 name: Performance Regression Test
 # Compare precice-bench results between base and PR branch.
-# Based on the approach from build-and-test.yml (archlinux Release config).
+# Uses the production CMakePreset and Google Benchmark's compare.py.
 
 on:
   pull_request:
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: '0 4 * * 1'  # weekly on Monday
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: 'Base ref to compare against (branch, tag, or SHA)'
+        required: false
+        default: 'develop'
 
 concurrency:
   group: perf-${{ github.event.pull_request.number || github.ref }}
@@ -35,75 +40,58 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Build and run benchmarks for the base branch first, then HEAD.
+      # Figure out which commits to compare.
+      # PRs: base.sha vs head.sha
+      # Schedule: main vs develop
+      # Manual: user-provided base_ref vs current SHA
+      - name: Set refs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "BASE_REF=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
+            echo "HEAD_REF=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "BASE_REF=main" >> $GITHUB_ENV
+            echo "HEAD_REF=develop" >> $GITHUB_ENV
+          else
+            echo "BASE_REF=${{ github.event.inputs.base_ref || 'develop' }}" >> $GITHUB_ENV
+            echo "HEAD_REF=${{ github.sha }}" >> $GITHUB_ENV
+          fi
+
       # Both run on the same machine so the comparison is fair.
       - name: Build and benchmark base
         run: |
-          git checkout ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
-          cmake -B build-base -DCMAKE_BUILD_TYPE=Release -DPRECICE_BUILD_BENCHMARKS=ON -DPRECICE_FEATURE_MPI_COMMUNICATION=ON -DPRECICE_FEATURE_PETSC_MAPPING=ON
-          cmake --build build-base -j$(nproc)
-          cd build-base
+          git checkout $BASE_REF
+          cmake --preset production -DPRECICE_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
+          cmake --build build --target precice-bench
+          cd build
           ./precice-bench --benchmark_out=base.json --benchmark_out_format=json --benchmark_repetitions=3
 
       - name: Build and benchmark head
         run: |
-          git checkout ${{ github.event.pull_request.head.sha || github.sha }}
-          cmake -B build-head -DCMAKE_BUILD_TYPE=Release -DPRECICE_BUILD_BENCHMARKS=ON -DPRECICE_FEATURE_MPI_COMMUNICATION=ON -DPRECICE_FEATURE_PETSC_MAPPING=ON
-          cmake --build build-head -j$(nproc)
-          cd build-head
+          git checkout $HEAD_REF
+          cmake --preset production -DPRECICE_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
+          cmake --build build --target precice-bench
+          cd build
           ./precice-bench --benchmark_out=head.json --benchmark_out_format=json --benchmark_repetitions=3
 
       - name: Compare results
         run: |
-          python3 << 'EOF'
-          import json, sys
-
-          # google benchmark json has individual runs + aggregates when using repetitions.
-          # we only care about the mean values for comparison.
-          def load(path):
-              with open(path) as f:
-                  data = json.load(f)
-              means = {}
-              for b in data["benchmarks"]:
-                  if b.get("aggregate_name") == "mean":
-                      means[b["name"].replace("_mean", "")] = b["real_time"]
-              return means
-
-          base = load("build-base/base.json")
-          head = load("build-head/head.json")
-
-          print("| Benchmark | Base (ns) | Head (ns) | Change |")
-          print("|-----------|-----------|-----------|--------|")
-          for name in sorted(base.keys()):
-              if name not in head:
-                  continue
-              b, h = base[name], head[name]
-              pct = ((h - b) / b) * 100 if b > 0 else 0
-              print(f"| {name} | {b:.1f} | {h:.1f} | {pct:+.1f}% |")
-
-          # also write it out for the job summary step
-          with open("summary.md", "w") as f:
-              f.write("| Benchmark | Base (ns) | Head (ns) | Change |\n")
-              f.write("|-----------|-----------|-----------|--------|\n")
-              for name in sorted(base.keys()):
-                  if name not in head:
-                      continue
-                  b, h = base[name], head[name]
-                  pct = ((h - b) / b) * 100 if b > 0 else 0
-                  f.write(f"| {name} | {b:.1f} | {h:.1f} | {pct:+.1f}% |\n")
-          EOF
+          pip install scipy
+          python3 /usr/share/googlebenchmark/tools/compare.py benchmarks build/base.json build/head.json | tee comparison.txt
 
       - name: Job summary
         if: always()
         run: |
-          echo "## Benchmark results" >> $GITHUB_STEP_SUMMARY
-          cat summary.md >> $GITHUB_STEP_SUMMARY
+          echo "## Benchmark comparison" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          cat comparison.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
 
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: benchmark-results
           path: |
-            build-base/base.json
-            build-head/head.json
-            summary.md
+            build/base.json
+            build/head.json
+            comparison.txt

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -1,0 +1,109 @@
+name: Performance Regression Test
+# Compare precice-bench results between base and PR branch.
+# Based on the approach from build-and-test.yml (archlinux Release config).
+
+on:
+  pull_request:
+    types: [labeled]
+  schedule:
+    - cron: '0 4 * * 1'  # weekly on Monday
+  workflow_dispatch:
+
+concurrency:
+  group: perf-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CMAKE_GENERATOR: Ninja
+
+jobs:
+  benchmark:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      github.event.label.name == 'trigger-perf-test'
+    runs-on: ubuntu-latest
+    container:
+      image: 'precice/ci-archlinux:latest'
+      options: --shm-size=2gb
+    defaults:
+      run:
+        shell: "bash --login -eo pipefail {0}"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Build and run benchmarks for the base branch first, then HEAD.
+      # Both run on the same machine so the comparison is fair.
+      - name: Build and benchmark base
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
+          cmake -B build-base -DCMAKE_BUILD_TYPE=Release -DPRECICE_BUILD_BENCHMARKS=ON -DPRECICE_FEATURE_MPI_COMMUNICATION=ON -DPRECICE_FEATURE_PETSC_MAPPING=ON
+          cmake --build build-base -j$(nproc)
+          cd build-base
+          ./precice-bench --benchmark_out=base.json --benchmark_out_format=json --benchmark_repetitions=3
+
+      - name: Build and benchmark head
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha || github.sha }}
+          cmake -B build-head -DCMAKE_BUILD_TYPE=Release -DPRECICE_BUILD_BENCHMARKS=ON -DPRECICE_FEATURE_MPI_COMMUNICATION=ON -DPRECICE_FEATURE_PETSC_MAPPING=ON
+          cmake --build build-head -j$(nproc)
+          cd build-head
+          ./precice-bench --benchmark_out=head.json --benchmark_out_format=json --benchmark_repetitions=3
+
+      - name: Compare results
+        run: |
+          python3 << 'EOF'
+          import json, sys
+
+          # google benchmark json has individual runs + aggregates when using repetitions.
+          # we only care about the mean values for comparison.
+          def load(path):
+              with open(path) as f:
+                  data = json.load(f)
+              means = {}
+              for b in data["benchmarks"]:
+                  if b.get("aggregate_name") == "mean":
+                      means[b["name"].replace("_mean", "")] = b["real_time"]
+              return means
+
+          base = load("build-base/base.json")
+          head = load("build-head/head.json")
+
+          print("| Benchmark | Base (ns) | Head (ns) | Change |")
+          print("|-----------|-----------|-----------|--------|")
+          for name in sorted(base.keys()):
+              if name not in head:
+                  continue
+              b, h = base[name], head[name]
+              pct = ((h - b) / b) * 100 if b > 0 else 0
+              print(f"| {name} | {b:.1f} | {h:.1f} | {pct:+.1f}% |")
+
+          # also write it out for the job summary step
+          with open("summary.md", "w") as f:
+              f.write("| Benchmark | Base (ns) | Head (ns) | Change |\n")
+              f.write("|-----------|-----------|-----------|--------|\n")
+              for name in sorted(base.keys()):
+                  if name not in head:
+                      continue
+                  b, h = base[name], head[name]
+                  pct = ((h - b) / b) * 100 if b > 0 else 0
+                  f.write(f"| {name} | {b:.1f} | {h:.1f} | {pct:+.1f}% |\n")
+          EOF
+
+      - name: Job summary
+        if: always()
+        run: |
+          echo "## Benchmark results" >> $GITHUB_STEP_SUMMARY
+          cat summary.md >> $GITHUB_STEP_SUMMARY
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: benchmark-results
+          path: |
+            build-base/base.json
+            build-head/head.json
+            summary.md

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -9,6 +9,10 @@ on:
     - cron: '0 4 * * 1'  # weekly on Monday
   workflow_dispatch:
     inputs:
+      target_ref:
+        description: 'Target ref to compare (branch, tag, or SHA)'
+        required: false
+        default: 'main'
       base_ref:
         description: 'Base ref to compare against (branch, tag, or SHA)'
         required: false
@@ -36,56 +40,59 @@ jobs:
         shell: "bash --login -eo pipefail {0}"
 
     steps:
+      # Figure out which commits to compare.
+      # PRs: base.sha vs head.sha
+      # Schedule: main vs develop
+      # Manual: user-provided base_ref and target_ref
+      - name: Set refs
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "BASE_REF=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_ENV"
+            echo "HEAD_REF=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            echo "BASE_REF=main" >> "$GITHUB_ENV"
+            echo "HEAD_REF=develop" >> "$GITHUB_ENV"
+          else
+            echo "BASE_REF=${{ github.event.inputs.base_ref }}" >> "$GITHUB_ENV"
+            echo "HEAD_REF=${{ github.event.inputs.target_ref }}" >> "$GITHUB_ENV"
+          fi
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # Figure out which commits to compare.
-      # PRs: base.sha vs head.sha
-      # Schedule: main vs develop
-      # Manual: user-provided base_ref vs current SHA
-      - name: Set refs
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "BASE_REF=${{ github.event.pull_request.base.sha }}" >> $GITHUB_ENV
-            echo "HEAD_REF=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
-          elif [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "BASE_REF=main" >> $GITHUB_ENV
-            echo "HEAD_REF=develop" >> $GITHUB_ENV
-          else
-            echo "BASE_REF=${{ github.event.inputs.base_ref || 'develop' }}" >> $GITHUB_ENV
-            echo "HEAD_REF=${{ github.sha }}" >> $GITHUB_ENV
-          fi
-
       # Both run on the same machine so the comparison is fair.
       - name: Build and benchmark base
         run: |
-          git checkout $BASE_REF
+          git checkout "$BASE_REF"
           cmake --preset production -DPRECICE_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
           cmake --build build --target precice-bench
           cd build
           ./precice-bench --benchmark_out=base.json --benchmark_out_format=json --benchmark_repetitions=3
 
-      - name: Build and benchmark head
+      - name: Build and benchmark target
         run: |
-          git checkout $HEAD_REF
+          git checkout "$HEAD_REF"
           cmake --preset production -DPRECICE_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
           cmake --build build --target precice-bench
           cd build
-          ./precice-bench --benchmark_out=head.json --benchmark_out_format=json --benchmark_repetitions=3
+          ./precice-bench --benchmark_out=target.json --benchmark_out_format=json --benchmark_repetitions=3
 
       - name: Compare results
         run: |
-          pip install scipy
-          python3 /usr/share/googlebenchmark/tools/compare.py benchmarks build/base.json build/head.json | tee comparison.txt
+          python3 -m venv venv
+          venv/bin/pip install numpy scipy
+          venv/bin/python3 /usr/share/googlebenchmark/tools/compare.py benchmarks build/base.json build/target.json | tee comparison.txt
 
       - name: Job summary
         if: always()
         run: |
-          echo "## Benchmark comparison" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat comparison.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Benchmark comparison"
+            echo '```'
+            cat comparison.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/upload-artifact@v4
         if: always()
@@ -93,5 +100,5 @@ jobs:
           name: benchmark-results
           path: |
             build/base.json
-            build/head.json
+            build/target.json
             comparison.txt


### PR DESCRIPTION
## Main changes of this PR

I added the github workflow for performance regression testing which runs test on precise-bench on base and PR branch, and also compares the result and reports them in Github action  jobs summary

## Motivation and additional information
Addressed this issue based on feedback from @MakisH :
-Trigers manually by label or from weekly schedule
-Reused the existing precise bench  (Google Benchmark) suite
-Compares base vs head on same runner for fair comparson
-Reports job summary result only, no pass/fail output

## Author's checklist

* [x] I used the `pre-commit` hook
* [ ] I added a changelog file — N/A (CI-only change, not user-observable)
* [ ] I added a test — N/A (workflow file)
* [ ] For breaking changes — N/A
* [x] I stuck to C++17 features
* [x] I stuck to CMake version 3.22.1
* [x] I squashed all commits
* [ ] I ran the systemtests — skipping (CI-only change)
