### PR TITLE
Remove obsolete Time.cpp

### DIFF
--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -299,7 +299,6 @@ target_sources(preciceCore
     src/time/Sample.hpp
     src/time/SampleResult.hpp
     src/time/Stample.hpp
-    src/time/Time.cpp
     src/time/Time.hpp
     src/time/TimeGrids.cpp
     src/time/TimeGrids.hpp

--- a/src/time/Time.cpp
+++ b/src/time/Time.cpp
@@ -1,9 +1,0 @@
-#include "Time.hpp"
-
-namespace precice::time {
-
-const int Time::DEFAULT_WAVEFORM_DEGREE = 1;
-
-const int Time::MIN_WAVEFORM_DEGREE = 0;
-
-} // namespace precice::time

--- a/src/time/Time.hpp
+++ b/src/time/Time.hpp
@@ -5,10 +5,10 @@ namespace precice::time {
 class Time {
 public:
   /// To be used, when the interpolation degree is not defined.
-  static const int DEFAULT_WAVEFORM_DEGREE;
+  inline static const int DEFAULT_WAVEFORM_DEGREE = 1;
 
   /// The minimum required interpolation degree.
-  static const int MIN_WAVEFORM_DEGREE;
+  inline static const int MIN_WAVEFORM_DEGREE = 0;
 };
 
 } // namespace precice::time


### PR DESCRIPTION
## Main changes of this PR

I was just reading through the source tree and managed to read `Time.cpp` which served no other purpose than to initialize the `Time` struct's static members.

There is no need to create a separate cpp file just to initialize `Time::DEFAULT_WAVEFORM_DEGREE` and `Time::MIN_WAVEFORM_DEGREE`, can simply inline it in the header itself and decl the init vals in `Time.hpp` itself.

Can confirm after the changes the build and all tests are passing

## Motivation and additional information

nil (rational is explained in commit description and explanation for the changes made.)

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
