### PR TITLE
Prevent duplicate coupling schemes between identical participants

### DIFF
--- a/src/cplscheme/CompositionalCouplingScheme.cpp
+++ b/src/cplscheme/CompositionalCouplingScheme.cpp
@@ -54,15 +54,13 @@ void CompositionalCouplingScheme::addCouplingScheme(
   PRECICE_TRACE();
 
   // Check for duplicate coupling partners
-  auto newPartners = couplingScheme->getCouplingPartners();
-  for (const auto &scheme : allSchemes()) {
-    auto existingPartners = scheme->getCouplingPartners();
-    for (const auto &newPartner : newPartners) {
-      PRECICE_CHECK(std::find(existingPartners.begin(), existingPartners.end(), newPartner) == existingPartners.end(),
-                    "A coupling scheme with participant \"{}\" already exists in this compositional coupling scheme. "
-                    "Please make sure that only one coupling scheme exists between any two participants.",
-                    newPartner);
-    }
+  auto existingPartners = getCouplingPartners();
+  auto newPartners      = couplingScheme->getCouplingPartners();
+  for (const auto &newPartner : newPartners) {
+    PRECICE_CHECK(std::find(existingPartners.begin(), existingPartners.end(), newPartner) == existingPartners.end(),
+                  "A coupling scheme between participants \"{}\" and \"{}\" already exists in this compositional coupling scheme. "
+                  "Please make sure that only one coupling scheme exists between any two participants.",
+                  couplingScheme->localParticipant(), newPartner);
   }
 
   if (!couplingScheme->isImplicitCouplingScheme()) {

--- a/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
+++ b/src/cplscheme/tests/CompositionalCouplingSchemeTest.cpp
@@ -453,13 +453,15 @@ BOOST_AUTO_TEST_CASE(testDuplicateCouplingPartnerIsRejected)
   PRECICE_TEST();
   int                         numberIterations = 1;
   int                         maxTimeWindows   = 10;
-  PtrCouplingScheme           scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows, "SamePartner"));
-  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows, "SamePartner"));
+  PtrCouplingScheme           scheme1(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows, "SamePartner", "LocalSolver"));
+  PtrCouplingScheme           scheme2(new tests::DummyCouplingScheme(numberIterations, maxTimeWindows, "SamePartner", "LocalSolver"));
   CompositionalCouplingScheme composition;
   composition.addCouplingScheme(scheme1);
   BOOST_CHECK_EXCEPTION(composition.addCouplingScheme(scheme2), ::precice::Error,
                         [](const ::precice::Error &e) {
-                          return std::string(e.what()).find("SamePartner") != std::string::npos;
+                          auto msg = std::string(e.what());
+                          return msg.find("LocalSolver") != std::string::npos &&
+                                 msg.find("SamePartner") != std::string::npos;
                         });
 }
 

--- a/src/cplscheme/tests/DummyCouplingScheme.cpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.cpp
@@ -8,8 +8,10 @@ namespace precice::cplscheme::tests {
 DummyCouplingScheme::DummyCouplingScheme(
     int                numberIterations,
     int                maxTimeWindows,
-    const std::string &couplingPartner)
+    const std::string &couplingPartner,
+    const std::string &localParticipant)
     : _couplingPartner(couplingPartner),
+      _localParticipant(localParticipant),
       _numberIterations(numberIterations),
       _maxTimeWindows(maxTimeWindows)
 {

--- a/src/cplscheme/tests/DummyCouplingScheme.hpp
+++ b/src/cplscheme/tests/DummyCouplingScheme.hpp
@@ -23,7 +23,8 @@ public:
   DummyCouplingScheme(
       int                numberIterations,
       int                maxTimeWindows,
-      const std::string &couplingPartner = "");
+      const std::string &couplingPartner  = "",
+      const std::string &localParticipant = "");
 
   /**
    * @brief Destructor, empty.
@@ -85,8 +86,7 @@ public:
 
   std::string localParticipant() const final override
   {
-    PRECICE_ASSERT(false);
-    return "unknown";
+    return _localParticipant;
   }
 
   /**
@@ -223,6 +223,9 @@ private:
 
   /// @brief Name of the coupling partner
   std::string _couplingPartner;
+
+  /// @brief Name of the local participant
+  std::string _localParticipant;
 
   /// @brief Number of iterations performed per time window. 1 --> explicit.
   int _numberIterations;

--- a/tests/config/duplicate-coupling-multi-explicit.xml
+++ b/tests/config/duplicate-coupling-multi-explicit.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataAB" />
+  <data:scalar name="DataBA" />
+  <data:scalar name="DataAC" />
+  <data:scalar name="DataCA" />
+  <data:scalar name="DataExtra" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+    <use-data name="DataAC" />
+    <use-data name="DataCA" />
+    <use-data name="DataExtra" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="DataAB" />
+    <use-data name="DataBA" />
+    <use-data name="DataExtra" />
+  </mesh>
+
+  <mesh name="MeshC" dimensions="2">
+    <use-data name="DataAC" />
+    <use-data name="DataCA" />
+  </mesh>
+
+  <participant name="SolverA">
+    <provide-mesh name="MeshA" />
+    <write-data name="DataAB" mesh="MeshA" />
+    <read-data name="DataBA" mesh="MeshA" />
+    <write-data name="DataAC" mesh="MeshA" />
+    <read-data name="DataCA" mesh="MeshA" />
+    <read-data name="DataExtra" mesh="MeshA" />
+  </participant>
+
+  <participant name="SolverB">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <provide-mesh name="MeshB" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB" to="MeshA" constraint="conservative" />
+    <write-data name="DataBA" mesh="MeshB" />
+    <read-data name="DataAB" mesh="MeshB" />
+    <write-data name="DataExtra" mesh="MeshB" />
+  </participant>
+
+  <participant name="SolverC">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <provide-mesh name="MeshC" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshC" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshC" to="MeshA" constraint="conservative" />
+    <write-data name="DataCA" mesh="MeshC" />
+    <read-data name="DataAC" mesh="MeshC" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+  <m2n:sockets acceptor="SolverA" connector="SolverC" />
+
+  <coupling-scheme:multi>
+    <participant name="SolverA" control="yes" />
+    <participant name="SolverB" />
+    <participant name="SolverC" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <max-iterations value="2" />
+    <exchange data="DataBA" mesh="MeshA" from="SolverB" to="SolverA" />
+    <exchange data="DataAB" mesh="MeshA" from="SolverA" to="SolverB" />
+    <exchange data="DataCA" mesh="MeshA" from="SolverC" to="SolverA" />
+    <exchange data="DataAC" mesh="MeshA" from="SolverA" to="SolverC" />
+    <relative-convergence-measure data="DataBA" mesh="MeshA" limit="1e-4" />
+    <relative-convergence-measure data="DataCA" mesh="MeshA" limit="1e-4" />
+  </coupling-scheme:multi>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverA" second="SolverB" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="DataExtra" mesh="MeshA" from="SolverB" to="SolverA" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/config/duplicate-coupling-same.xml
+++ b/tests/config/duplicate-coupling-same.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data1" />
+  <data:scalar name="Data2" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverA">
+    <provide-mesh name="MeshA" />
+    <write-data name="Data1" mesh="MeshA" />
+    <read-data name="Data2" mesh="MeshA" />
+  </participant>
+
+  <participant name="SolverB">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <provide-mesh name="MeshB" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB" to="MeshA" constraint="conservative" />
+    <write-data name="Data2" mesh="MeshB" />
+    <read-data name="Data1" mesh="MeshB" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverA" second="SolverB" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="Data1" mesh="MeshA" from="SolverA" to="SolverB" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverA" second="SolverB" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="Data2" mesh="MeshA" from="SolverB" to="SolverA" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/config/duplicate-coupling-swapped.xml
+++ b/tests/config/duplicate-coupling-swapped.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="Data1" />
+  <data:scalar name="Data2" />
+
+  <mesh name="MeshA" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <mesh name="MeshB" dimensions="2">
+    <use-data name="Data1" />
+    <use-data name="Data2" />
+  </mesh>
+
+  <participant name="SolverA">
+    <provide-mesh name="MeshA" />
+    <write-data name="Data1" mesh="MeshA" />
+    <read-data name="Data2" mesh="MeshA" />
+  </participant>
+
+  <participant name="SolverB">
+    <receive-mesh name="MeshA" from="SolverA" />
+    <provide-mesh name="MeshB" />
+    <mapping:nearest-neighbor direction="read" from="MeshA" to="MeshB" constraint="consistent" />
+    <mapping:nearest-neighbor direction="write" from="MeshB" to="MeshA" constraint="conservative" />
+    <write-data name="Data2" mesh="MeshB" />
+    <read-data name="Data1" mesh="MeshB" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverA" connector="SolverB" />
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverA" second="SolverB" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="Data1" mesh="MeshA" from="SolverA" to="SolverB" />
+  </coupling-scheme:parallel-explicit>
+
+  <coupling-scheme:parallel-explicit>
+    <participants first="SolverB" second="SolverA" />
+    <max-time-windows value="10" />
+    <time-window-size value="1.0" />
+    <exchange data="Data2" mesh="MeshA" from="SolverB" to="SolverA" />
+  </coupling-scheme:parallel-explicit>
+</precice-configuration>

--- a/tests/config/tests.cmake
+++ b/tests/config/tests.cmake
@@ -13,3 +13,7 @@ precice_test_config_valid(unidirectional.xml Fluid 1)
 precice_test_config_invalid(unidirectional.xml "only the mapping combinations read-consistent and write-conservative" Fluid 2)
 precice_test_config_valid(unidirectional.xml Transport 1)
 precice_test_config_valid(unidirectional.xml Transport 2)
+
+precice_test_config_invalid(duplicate-coupling-same.xml "already exists in this compositional coupling scheme")
+precice_test_config_invalid(duplicate-coupling-swapped.xml "already exists in this compositional coupling scheme")
+precice_test_config_invalid(duplicate-coupling-multi-explicit.xml "already exists in this compositional coupling scheme")


### PR DESCRIPTION
## Main changes of this PR
Adds a check in CompositionalCouplingScheme::addCouplingScheme() that rejects 
coupling schemes whose coupling partners already exist in the composition, 
raising a clear error instead of silently allowing misconfiguration.

## Motivation and additional information
Closes #1695
<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
