### PR TITLE
export: support mesh filtering in export configuration

### DIFF
--- a/src/io/ExportContext.hpp
+++ b/src/io/ExportContext.hpp
@@ -2,6 +2,7 @@
 #define PRECICE_IO_EXPORTCONTEXT_HPP_
 
 #include <string>
+#include <vector>
 #include "io/SharedPointer.hpp"
 
 namespace precice::io {
@@ -27,6 +28,9 @@ struct ExportContext {
 
   // @brief type of the exporter (e.g. vtk).
   std::string type;
+
+  // @brief List of meshes to export (Optional).
+  std::vector<std::string> selectedMeshes;
 };
 
 } // namespace precice::io

--- a/src/io/config/ExportConfiguration.cpp
+++ b/src/io/config/ExportConfiguration.cpp
@@ -1,4 +1,6 @@
 #include "ExportConfiguration.hpp"
+#include <sstream>
+#include "logging/LogMacros.hpp"
 #include "xml/ConfigParser.hpp"
 #include "xml/XMLAttribute.hpp"
 #include "xml/XMLTag.hpp"
@@ -44,11 +46,19 @@ ExportConfiguration::ExportConfiguration(xml::XMLTag &parent)
   auto attrUpdateSeries = makeXMLAttribute(ATTR_UPDATE_SERIES, false)
                               .setDocumentation("Update the series file after every export instead of at the end of the simulation.");
 
+  auto attrMesh = makeXMLAttribute("mesh", std::string(""))
+                      .setDocumentation("Export only a specific mesh.");
+
+  auto attrMeshes = makeXMLAttribute("meshes", std::string(""))
+                        .setDocumentation("Export multiple meshes separated by ':'");
+
   for (XMLTag &tag : tags) {
     tag.addAttribute(attrLocation);
     tag.addAttribute(attrEveryNTimeWindows);
     tag.addAttribute(attrEveryIteration);
     tag.addAttribute(attrUpdateSeries);
+    tag.addAttribute(attrMesh);
+    tag.addAttribute(attrMeshes);
     parent.addSubtag(tag);
   }
 }
@@ -64,6 +74,29 @@ void ExportConfiguration::xmlTagCallback(
     econtext.everyIteration    = tag.getBooleanAttributeValue(ATTR_EVERY_ITERATION);
     econtext.updateSeries      = tag.getBooleanAttributeValue(ATTR_UPDATE_SERIES);
     econtext.type              = tag.getName();
+
+    std::string meshAttr   = tag.getStringAttributeValue("mesh");
+    std::string meshesAttr = tag.getStringAttributeValue("meshes");
+
+    // Both mesh and meshes can't be present at the same time.
+    if (!meshAttr.empty() && !meshesAttr.empty()) {
+      PRECICE_ERROR("<export:vtu> cannot define both \"mesh\" and \"meshes\" attributes.");
+    }
+
+    if (!meshAttr.empty()) {
+      econtext.selectedMeshes.push_back(meshAttr);
+    }
+
+    if (!meshesAttr.empty()) {
+      std::stringstream ss(meshesAttr);
+      std::string       item;
+      while (std::getline(ss, item, ':')) {
+        if (!item.empty()) {
+          econtext.selectedMeshes.push_back(item);
+        }
+      }
+    }
+
     _contexts.push_back(econtext);
   }
 }

--- a/src/io/tests/ExportConfigurationTest.cpp
+++ b/src/io/tests/ExportConfigurationTest.cpp
@@ -40,5 +40,56 @@ BOOST_AUTO_TEST_CASE(VTKLocation)
   BOOST_TEST(econtext.location == "somepath");
 }
 
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(VTUSingleMesh)
+{
+  PRECICE_TEST();
+  using xml::XMLTag;
+  XMLTag                  tag = xml::getRootTag();
+  io::ExportConfiguration config(tag);
+
+  xml::configure(tag, xml::ConfigurationContext{},
+                 testing::getPathToSources() + "/io/tests/config3.xml");
+
+  BOOST_TEST(config.exportContexts().size() == 1);
+  const io::ExportContext &econtext = config.exportContexts().front();
+
+  BOOST_TEST(econtext.type == "vtu");
+  BOOST_TEST(econtext.selectedMeshes.size() == 1);
+  BOOST_TEST(econtext.selectedMeshes.front() == "SolidMesh");
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(VTUMultipleMeshes)
+{
+  PRECICE_TEST();
+  using xml::XMLTag;
+  XMLTag                  tag = xml::getRootTag();
+  io::ExportConfiguration config(tag);
+
+  xml::configure(tag, xml::ConfigurationContext{},
+                 testing::getPathToSources() + "/io/tests/config4.xml");
+
+  const io::ExportContext &econtext = config.exportContexts().front();
+
+  BOOST_TEST(econtext.selectedMeshes.size() == 2);
+  BOOST_TEST(econtext.selectedMeshes[0] == "SolidMesh");
+  BOOST_TEST(econtext.selectedMeshes[1] == "FluidMesh");
+}
+
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(VTUBothMeshAttributes)
+{
+  PRECICE_TEST();
+  using xml::XMLTag;
+  XMLTag                  tag = xml::getRootTag();
+  io::ExportConfiguration config(tag);
+
+  BOOST_CHECK_THROW(
+      xml::configure(tag, xml::ConfigurationContext{},
+                     testing::getPathToSources() + "/io/tests/config5.xml"),
+      std::exception);
+}
+
 BOOST_AUTO_TEST_SUITE_END() // Configuration
 BOOST_AUTO_TEST_SUITE_END() // IOTests

--- a/src/io/tests/config3.xml
+++ b/src/io/tests/config3.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <export:vtu mesh="SolidMesh" />
+</configuration>

--- a/src/io/tests/config4.xml
+++ b/src/io/tests/config4.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <export:vtu meshes="SolidMesh:FluidMesh" />
+</configuration>

--- a/src/io/tests/config5.xml
+++ b/src/io/tests/config5.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <export:vtu mesh="A" meshes="B" />
+</configuration>

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -728,14 +728,32 @@ void ParticipantConfiguration::finishParticipantConfiguration(
       _participants.back()->addExportContext(exportContext);
     };
 
-    // Create one exporter per provided mesh
-    for (const auto &meshContext : participant->providedMeshContexts()) {
-      createExporter(meshContext);
+    for (const auto &meshName : exportContext.selectedMeshes) {
+      PRECICE_CHECK(participant->isMeshUsed(meshName),
+                    "Participant \"{}\" defines export for mesh \"{}\" which is not used.",
+                    participant->getName(), meshName);
     }
 
-    // Create one exporter per received mesh
+    auto shouldExport = [&](const impl::MeshContext &meshContext) {
+      // Default: export all
+      if (exportContext.selectedMeshes.empty()) {
+        return true;
+      }
+      return std::find(exportContext.selectedMeshes.begin(), exportContext.selectedMeshes.end(),
+                       meshContext.mesh->getName()) != exportContext.selectedMeshes.end();
+    };
+
+    // Create exporters for only selected meshes
+    for (const auto &meshContext : participant->providedMeshContexts()) {
+      if (shouldExport(meshContext)) {
+        createExporter(meshContext);
+      }
+    }
+
     for (const auto &meshContext : participant->receivedMeshContexts()) {
-      createExporter(meshContext);
+      if (shouldExport(meshContext)) {
+        createExporter(meshContext);
+      }
     }
 
     PRECICE_WARN_IF(exportContext.everyNTimeWindows > 1 && exportContext.everyIteration,


### PR DESCRIPTION
## Main changes of this PR
- This PR introduces optional `mesh` and `meshes` attributes to restrict exports to specific meshes.
- If neither attributes are defined, all meshes are exported.
- Defining both attributes simultaneously results in configuration error.
- Includes tests for: single mesh selection, multiple mesh selection, conflict detection.

## Motivation and additional information
Exports become excessively large when multiple meshes and many time steps are written.
Closes: #1888 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
