### PR TITLE
Include the data name in preconditioner warnings

### DIFF
--- a/docs/changelog/2473.md
+++ b/docs/changelog/2473.md
@@ -1,0 +1,1 @@
+* Added the data name to preconditioner warnings to help identify which sub-vector caused the issue.

--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -52,7 +52,9 @@ void AitkenAcceleration::initialize(const DataMap &cplData)
   _values       = Eigen::VectorXd::Zero(entries);
   _oldValues    = Eigen::VectorXd::Zero(entries);
   if (_primaryDataIDs.size() > 1) {
-    _preconditioner->initialize(subVectorSizes);
+    std::vector<std::string> subVectorNames;
+    std::transform(_primaryDataIDs.cbegin(), _primaryDataIDs.cend(), std::back_inserter(subVectorNames), [&cplData](const auto &d) { return cplData.at(d)->getDataName(); });
+    _preconditioner->initialize(std::move(subVectorSizes), std::move(subVectorNames));
   }
 }
 

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -746,7 +746,9 @@ void BaseQNAcceleration::initializeVectorsAndPreconditioner(const DataMap &cplDa
 
   std::vector<size_t> subVectorSizes; // needed for preconditioner
   std::transform(_primaryDataIDs.cbegin(), _primaryDataIDs.cend(), std::back_inserter(subVectorSizes), [&cplData, windowStart, this](const auto &d) { return _primaryTimeGrids.value().getTimeGridAfter(d, windowStart).size() * cplData.at(d)->getSize(); });
-  _preconditioner->initialize(subVectorSizes);
+  std::vector<std::string> subVectorNames;
+  std::transform(_primaryDataIDs.cbegin(), _primaryDataIDs.cend(), std::back_inserter(subVectorNames), [&cplData](const auto &d) { return cplData.at(d)->getDataName(); });
+  _preconditioner->initialize(std::move(subVectorSizes), std::move(subVectorNames));
 
   specializedInitializeVectorsAndPreconditioner(cplData);
 }

--- a/src/acceleration/impl/ConstantPreconditioner.cpp
+++ b/src/acceleration/impl/ConstantPreconditioner.cpp
@@ -13,10 +13,10 @@ ConstantPreconditioner::ConstantPreconditioner(std::vector<double> factors)
 {
 }
 
-void ConstantPreconditioner::initialize(std::vector<size_t> &svs)
+void ConstantPreconditioner::initialize(std::vector<size_t> svs, std::vector<std::string> svNames)
 {
   PRECICE_TRACE();
-  Preconditioner::initialize(svs);
+  Preconditioner::initialize(std::move(svs), std::move(svNames));
 
   // is always constant by definition
   _frozen = true;

--- a/src/acceleration/impl/ConstantPreconditioner.hpp
+++ b/src/acceleration/impl/ConstantPreconditioner.hpp
@@ -19,7 +19,7 @@ public:
    */
   ~ConstantPreconditioner() override = default;
 
-  void initialize(std::vector<size_t> &svs) override;
+  void initialize(std::vector<size_t> svs, std::vector<std::string> svNames) override;
 
 private:
   /**

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -2,6 +2,7 @@
 
 #include <Eigen/Core>
 #include <numeric>
+#include <string>
 #include <vector>
 
 #include "cplscheme/SharedPointer.hpp"
@@ -32,13 +33,16 @@ public:
 
   /**
    * @brief initialize the preconditioner
-   * @param size of the pp system (e.g. rows of V)
+   * @param svs sizes of each sub-vector
+   * @param svNames names of the coupling data corresponding to each sub-vector
    */
-  virtual void initialize(std::vector<size_t> &svs)
+  virtual void initialize(std::vector<size_t> svs, std::vector<std::string> svNames)
   {
     PRECICE_TRACE();
+    PRECICE_ASSERT(svs.size() == svNames.size());
 
-    _subVectorSizes = svs;
+    _subVectorSizes = std::move(svs);
+    _subVectorNames = std::move(svNames);
 
     // Compute offsets of each subvector
     _subVectorOffsets.resize(_subVectorSizes.size(), 0);
@@ -220,6 +224,9 @@ protected:
 
   /// Sizes of each sub-vector, i.e. each coupling data
   std::vector<size_t> _subVectorSizes;
+
+  /// Names of the coupling data corresponding to each sub-vector
+  std::vector<std::string> _subVectorNames;
 
   /// Offsets of each sub-vector in concatenated data, i.e. each coupling data
   std::vector<size_t> _subVectorOffsets;

--- a/src/acceleration/impl/ResidualPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualPreconditioner.cpp
@@ -26,10 +26,11 @@ void ResidualPreconditioner::_update_(bool                   timeWindowComplete,
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
-        PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
+        PRECICE_WARN("The sub-vector of data \"{}\" in the residual preconditioner became numerically zero. "
                      "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
                      "check if the coupling data values of one solver is zero in the first iteration. "
-                     "The preconditioner scaling factors were not applied for this iteration.");
+                     "The preconditioner scaling factors were not applied for this iteration.",
+                     _subVectorNames[k]);
       } else {
         for (size_t i = 0; i < _subVectorSizes[k]; i++) {
           PRECICE_ASSERT(norms[k] > 0.0);

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -16,10 +16,10 @@ ResidualSumPreconditioner::ResidualSumPreconditioner(
 {
 }
 
-void ResidualSumPreconditioner::initialize(std::vector<size_t> &svs)
+void ResidualSumPreconditioner::initialize(std::vector<size_t> svs, std::vector<std::string> svNames)
 {
   PRECICE_TRACE();
-  Preconditioner::initialize(svs);
+  Preconditioner::initialize(std::move(svs), std::move(svNames));
 
   _residualSum.resize(_subVectorSizes.size(), 0.0);
   _previousResidualSum.resize(_subVectorSizes.size(), 0.0);
@@ -61,12 +61,12 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
 
     PRECICE_WARN_IF(
         math::equals(_residualSum[k], 0.0),
-        "A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = {}). "
+        "The sub-vector of data \"{}\" in the residual-sum preconditioner became numerically zero ( sub-vector = {}). "
         "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
         "check if the coupling data values of one solver is zero in the first iteration. "
         "The preconditioner scaling factors were not updated for this iteration and the scaling factors "
         "determined in the previous iteration were used.",
-        _residualSum[k]);
+        _subVectorNames[k], _residualSum[k]);
   }
 
   // Determine if weights needs to be reset

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -21,7 +21,7 @@ public:
    */
   ~ResidualSumPreconditioner() override = default;
 
-  void initialize(std::vector<size_t> &svs) override;
+  void initialize(std::vector<size_t> svs, std::vector<std::string> svNames) override;
 
 private:
   /**

--- a/src/acceleration/impl/ValuePreconditioner.cpp
+++ b/src/acceleration/impl/ValuePreconditioner.cpp
@@ -30,10 +30,11 @@ void ValuePreconditioner::_update_(bool                   timeWindowComplete,
 
   for (size_t k = 0; k < _subVectorSizes.size(); k++) {
     if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
-      PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
+      PRECICE_WARN("The sub-vector of data \"{}\" in the value preconditioner became numerically zero. "
                    "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
                    "check if the coupling data values of one solver is zero in the first iteration. "
-                   "The preconditioner scaling factors were not applied for this iteration.");
+                   "The preconditioner scaling factors were not applied for this iteration.",
+                   _subVectorNames[k]);
     } else {
       for (size_t i = 0; i < _subVectorSizes[k]; i++) {
         PRECICE_ASSERT(norms[k] > 0.0);

--- a/src/acceleration/test/PreconditionerTest.cpp
+++ b/src/acceleration/test/PreconditionerTest.cpp
@@ -145,14 +145,9 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testResPreconditioner)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(2);
-  svs.push_back(4);
-  svs.push_back(2);
-
   ResidualPreconditioner precond(-1);
 
-  precond.initialize(svs);
+  precond.initialize({2, 4, 2}, {"Data0", "Data1", "Data2"});
   Eigen::VectorXd backup = _data;
 
   // should change
@@ -177,14 +172,9 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testResSumPreconditioner)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(2);
-  svs.push_back(4);
-  svs.push_back(2);
-
   ResidualSumPreconditioner precond(-1, false);
 
-  precond.initialize(svs);
+  precond.initialize({2, 4, 2}, {"Data0", "Data1", "Data2"});
   Eigen::VectorXd backup = _data;
 
   // should change, update twice to really test the summation
@@ -211,14 +201,9 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testResSumPreconditionerUpdate)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(2);
-  svs.push_back(4);
-  svs.push_back(2);
-
   ResidualSumPreconditioner precond(-1, true);
 
-  precond.initialize(svs);
+  precond.initialize({2, 4, 2}, {"Data0", "Data1", "Data2"});
   Eigen::VectorXd backup = _data;
 
   // should change, update twice to really test the summation
@@ -274,14 +259,9 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testValuePreconditioner)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(2);
-  svs.push_back(4);
-  svs.push_back(2);
-
   ValuePreconditioner precond(-1);
 
-  precond.initialize(svs);
+  precond.initialize({2, 4, 2}, {"Data0", "Data1", "Data2"});
   Eigen::VectorXd backup = _data;
 
   // should change, since this is the first time window
@@ -311,11 +291,6 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testConstPreconditioner)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(2);
-  svs.push_back(4);
-  svs.push_back(2);
-
   std::vector<double> factors;
   factors.push_back(1e3);
   factors.push_back(2.0);
@@ -323,7 +298,7 @@ BOOST_AUTO_TEST_CASE(testConstPreconditioner)
 
   ConstantPreconditioner precond(factors);
 
-  precond.initialize(svs); // new weights already computed here
+  precond.initialize({2, 4, 2}, {"Data0", "Data1", "Data2"}); // new weights already computed here
   Eigen::VectorXd backup = _data;
 
   // should have no effect
@@ -347,14 +322,9 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testPreconditionerLargerDataSize)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(2);
-  svs.push_back(4);
-  svs.push_back(2);
-
   ResidualSumPreconditioner precond(-1, false);
 
-  precond.initialize(svs);
+  precond.initialize({2, 4, 2}, {"Data0", "Data1", "Data2"});
   Eigen::VectorXd backup = _dataLargerSize;
 
   // should change, update twice to really test the summation
@@ -381,14 +351,9 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testPreconditionerLargerResSize)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(2);
-  svs.push_back(4);
-  svs.push_back(2);
-
   ResidualSumPreconditioner precond(-1, false);
 
-  precond.initialize(svs);
+  precond.initialize({2, 4, 2}, {"Data0", "Data1", "Data2"});
   Eigen::VectorXd backup = _dataSmallerSize;
 
   // should change, update twice to really test the summation
@@ -415,13 +380,9 @@ PRECICE_TEST_SETUP(1_rank)
 BOOST_AUTO_TEST_CASE(testMultilpleMeshes)
 {
   PRECICE_TEST();
-  std::vector<size_t> svs;
-  svs.push_back(3);
-  svs.push_back(5);
-
   ResidualSumPreconditioner precond(-1, false);
 
-  precond.initialize(svs);
+  precond.initialize({3, 5}, {"Data0", "Data1"});
   Eigen::VectorXd backup = _data;
 
   // should change
@@ -506,11 +467,8 @@ BOOST_AUTO_TEST_CASE(testParallelMatrixScaling)
   M_back = M;
   x_back = x;
 
-  std::vector<size_t> svs;
-  svs.push_back(localN);
-
   ValuePreconditioner precond(-1);
-  precond.initialize(svs);
+  precond.initialize({static_cast<size_t>(localN)}, {"Data0"});
   precond.update(true, x, x);
   BOOST_TEST(precond.requireNewQR());
 


### PR DESCRIPTION
## Main changes of this PR
Include the data names in precondition warnings (applied across all three types)

## Motivation and additional information
When exchanging multiple data values, the preconditioner warning fires once per zero sub-vector but doesn't tell the name. closes #1515 

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
