### PR TITLE
2454 : m2n: detect large data transfers for future compression

### DIFF
--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -265,6 +265,25 @@ void M2N::send(
     int                         meshID,
     int                         valueDimension)
 {
+  // compute data size in bytes (exact)
+  const std::size_t dataSizeBytes =
+      itemsToSend.size() * sizeof(double);
+
+  // temporary compression threshold (1 MB)
+  const std::size_t compressionThreshold =
+      1 * 1024 * 1024;
+
+  // compression decision (NO compression yet)
+  const bool shouldCompress =
+      dataSizeBytes >= compressionThreshold;
+
+  // log decision (for verification only)
+  PRECICE_DEBUG(
+      "M2N::send decision: size={} bytes, threshold={} → {}",
+      dataSizeBytes,
+      compressionThreshold,
+      shouldCompress ? "COMPRESS" : "RAW");
+      
   if (not _useOnlyPrimaryCom) {
     PRECICE_ASSERT(_areSecondaryRanksConnected);
     PRECICE_ASSERT(_distComs.find(meshID) != _distComs.end());


### PR DESCRIPTION
This PR adds a small preparatory change in `M2N::send` to detect exceptionally large data transfers.

It computes the exact size of the data being sent, compares it against a temporary hard-coded threshold,
and logs whether the data would be sent raw or marked for compression.

No compression is applied yet. The goal of this change is only to establish the correct location
and decision logic before introducing actual compression.

If this approach looks okay, I will proceed with implementing the compression step in a follow-up change.
Fixes #2454 
