### PR TITLE
Split Communication into IntraCommunication and InterCommunication

### DIFF
--- a/docs/changelog/2447.md
+++ b/docs/changelog/2447.md
@@ -1,0 +1,1 @@
+- Split intra-participant communication into a standalone `IntraCommunication` interface with flat `MPIIntraComm` and `SocketIntraComm` implementations, reducing abstraction layers by not inheriting from `Communication`. `MPIIntraComm` uses native MPI collectives directly. Closes #2447.

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -7,7 +7,7 @@
 
 #include "acceleration/impl/Preconditioner.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "io/TXTTableWriter.hpp"

--- a/src/acceleration/IQNILSAcceleration.cpp
+++ b/src/acceleration/IQNILSAcceleration.cpp
@@ -8,7 +8,7 @@
 #include "acceleration/impl/Preconditioner.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
 #include "acceleration/impl/SharedPointer.hpp"
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "cplscheme/CouplingData.hpp"
 #include "cplscheme/SharedPointer.hpp"

--- a/src/acceleration/impl/ParallelMatrixOperations.hpp
+++ b/src/acceleration/impl/ParallelMatrixOperations.hpp
@@ -8,7 +8,7 @@
 #include <string>
 #include <vector>
 
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "com/Request.hpp"
 #include "com/SharedPointer.hpp"

--- a/src/acceleration/impl/QRFactorization.cpp
+++ b/src/acceleration/impl/QRFactorization.cpp
@@ -10,7 +10,7 @@
 
 #include "acceleration/Acceleration.hpp"
 #include "acceleration/impl/QRFactorization.hpp"
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "precice/impl/Types.hpp"

--- a/src/com/Extra.cpp
+++ b/src/com/Extra.cpp
@@ -5,72 +5,72 @@
 
 namespace precice::com {
 
-void sendMesh(Communication &communication, int rankReceiver, const mesh::Mesh &mesh)
+void sendMesh(IntraCommunication &communication, int rankReceiver, const mesh::Mesh &mesh)
 {
   serialize::SerializedMesh::serialize(mesh).send(communication, rankReceiver);
 }
 
-void receiveMesh(Communication &communication, int rankSender, mesh::Mesh &mesh)
+void receiveMesh(IntraCommunication &communication, int rankSender, mesh::Mesh &mesh)
 {
   serialize::SerializedMesh::receive(communication, rankSender).addToMesh(mesh);
 }
 
-void broadcastSendMesh(Communication &communication, const mesh::Mesh &mesh)
+void broadcastSendMesh(IntraCommunication &communication, const mesh::Mesh &mesh)
 {
   serialize::SerializedMesh::serialize(mesh).broadcastSend(communication);
 }
 
-void broadcastReceiveMesh(Communication &communication, mesh::Mesh &mesh)
+void broadcastReceiveMesh(IntraCommunication &communication, mesh::Mesh &mesh)
 {
   serialize::SerializedMesh::broadcastReceive(communication).addToMesh(mesh);
 }
 
-void sendConnectionMap(Communication &communication, int rankReceiver, const mesh::Mesh::ConnectionMap &cm)
+void sendConnectionMap(IntraCommunication &communication, int rankReceiver, const mesh::Mesh::ConnectionMap &cm)
 {
   serialize::SerializedConnectionMap::serialize(cm).send(communication, rankReceiver);
 }
 
-void receiveConnectionMap(Communication &communication, int rankSender, mesh::Mesh::ConnectionMap &cm)
+void receiveConnectionMap(IntraCommunication &communication, int rankSender, mesh::Mesh::ConnectionMap &cm)
 {
   cm = serialize::SerializedConnectionMap::receive(communication, rankSender).toConnectionMap();
 }
 
-void broadcastSendConnectionMap(Communication &communication, const mesh::Mesh::ConnectionMap &cm)
+void broadcastSendConnectionMap(IntraCommunication &communication, const mesh::Mesh::ConnectionMap &cm)
 {
   serialize::SerializedConnectionMap::serialize(cm).broadcastSend(communication);
 }
 
-void broadcastReceiveConnectionMap(Communication &communication, mesh::Mesh::ConnectionMap &cm)
+void broadcastReceiveConnectionMap(IntraCommunication &communication, mesh::Mesh::ConnectionMap &cm)
 {
   cm = serialize::SerializedConnectionMap::broadcastReceive(communication).toConnectionMap();
 }
 
-void sendBoundingBox(Communication &communication, int rankReceiver, const mesh::BoundingBox &bb)
+void sendBoundingBox(IntraCommunication &communication, int rankReceiver, const mesh::BoundingBox &bb)
 {
   serialize::SerializedBoundingBox::serialize(bb).send(communication, rankReceiver);
 }
 
-void receiveBoundingBox(Communication &communication, int rankSender, mesh::BoundingBox &bb)
+void receiveBoundingBox(IntraCommunication &communication, int rankSender, mesh::BoundingBox &bb)
 {
   bb = serialize::SerializedBoundingBox::receive(communication, rankSender).toBoundingBox();
 }
 
-void sendBoundingBoxMap(Communication &communication, int rankReceiver, const mesh::Mesh::BoundingBoxMap &bbm)
+void sendBoundingBoxMap(IntraCommunication &communication, int rankReceiver, const mesh::Mesh::BoundingBoxMap &bbm)
 {
   serialize::SerializedBoundingBoxMap::serialize(bbm).send(communication, rankReceiver);
 }
 
-void receiveBoundingBoxMap(Communication &communication, int rankSender, mesh::Mesh::BoundingBoxMap &bbm)
+void receiveBoundingBoxMap(IntraCommunication &communication, int rankSender, mesh::Mesh::BoundingBoxMap &bbm)
 {
   bbm = serialize::SerializedBoundingBoxMap::receive(communication, rankSender).toBoundingBoxMap();
 }
 
-void broadcastSendBoundingBoxMap(Communication &communication, const mesh::Mesh::BoundingBoxMap &bbm)
+void broadcastSendBoundingBoxMap(IntraCommunication &communication, const mesh::Mesh::BoundingBoxMap &bbm)
 {
   serialize::SerializedBoundingBoxMap::serialize(bbm).broadcastSend(communication);
 }
 
-void broadcastReceiveBoundingBoxMap(Communication &communication, mesh::Mesh::BoundingBoxMap &bbm)
+void broadcastReceiveBoundingBoxMap(IntraCommunication &communication, mesh::Mesh::BoundingBoxMap &bbm)
 {
   bbm = serialize::SerializedBoundingBoxMap::broadcastReceive(communication).toBoundingBoxMap();
 }

--- a/src/com/Extra.hpp
+++ b/src/com/Extra.hpp
@@ -1,36 +1,36 @@
 #pragma once
 
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "mesh/Mesh.hpp"
 
 namespace precice::com {
 
-void sendMesh(Communication &communication, int rankReceiver, const mesh::Mesh &mesh);
+void sendMesh(IntraCommunication &communication, int rankReceiver, const mesh::Mesh &mesh);
 
-void receiveMesh(Communication &communication, int rankSender, mesh::Mesh &mesh);
+void receiveMesh(IntraCommunication &communication, int rankSender, mesh::Mesh &mesh);
 
-void broadcastSendMesh(Communication &communication, const mesh::Mesh &mesh);
+void broadcastSendMesh(IntraCommunication &communication, const mesh::Mesh &mesh);
 
-void broadcastReceiveMesh(Communication &communication, mesh::Mesh &mesh);
+void broadcastReceiveMesh(IntraCommunication &communication, mesh::Mesh &mesh);
 
-void sendConnectionMap(Communication &communication, int rankReceiver, const mesh::Mesh::ConnectionMap &cm);
+void sendConnectionMap(IntraCommunication &communication, int rankReceiver, const mesh::Mesh::ConnectionMap &cm);
 
-void receiveConnectionMap(Communication &communication, int rankSender, mesh::Mesh::ConnectionMap &cm);
+void receiveConnectionMap(IntraCommunication &communication, int rankSender, mesh::Mesh::ConnectionMap &cm);
 
-void broadcastSendConnectionMap(Communication &communication, const mesh::Mesh::ConnectionMap &cm);
+void broadcastSendConnectionMap(IntraCommunication &communication, const mesh::Mesh::ConnectionMap &cm);
 
-void broadcastReceiveConnectionMap(Communication &communication, mesh::Mesh::ConnectionMap &cm);
+void broadcastReceiveConnectionMap(IntraCommunication &communication, mesh::Mesh::ConnectionMap &cm);
 
-void sendBoundingBox(Communication &communication, int rankReceiver, const mesh::BoundingBox &bb);
+void sendBoundingBox(IntraCommunication &communication, int rankReceiver, const mesh::BoundingBox &bb);
 
-void receiveBoundingBox(Communication &communication, int rankSender, mesh::BoundingBox &bb);
+void receiveBoundingBox(IntraCommunication &communication, int rankSender, mesh::BoundingBox &bb);
 
-void sendBoundingBoxMap(Communication &communication, int rankReceiver, const mesh::Mesh::BoundingBoxMap &bbm);
+void sendBoundingBoxMap(IntraCommunication &communication, int rankReceiver, const mesh::Mesh::BoundingBoxMap &bbm);
 
-void receiveBoundingBoxMap(Communication &communication, int rankSender, mesh::Mesh::BoundingBoxMap &bbm);
+void receiveBoundingBoxMap(IntraCommunication &communication, int rankSender, mesh::Mesh::BoundingBoxMap &bbm);
 
-void broadcastSendBoundingBoxMap(Communication &communication, const mesh::Mesh::BoundingBoxMap &bbm);
+void broadcastSendBoundingBoxMap(IntraCommunication &communication, const mesh::Mesh::BoundingBoxMap &bbm);
 
-void broadcastReceiveBoundingBoxMap(Communication &communication, mesh::Mesh::BoundingBoxMap &bbm);
+void broadcastReceiveBoundingBoxMap(IntraCommunication &communication, mesh::Mesh::BoundingBoxMap &bbm);
 
 } // namespace precice::com

--- a/src/com/IntraCommunication.cpp
+++ b/src/com/IntraCommunication.cpp
@@ -1,0 +1,50 @@
+#include "com/IntraCommunication.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice::com {
+
+void IntraCommunication::sendRange(precice::span<const double> itemsToSend, Rank rankReceiver)
+{
+  int size = itemsToSend.size();
+  send(size, rankReceiver);
+  if (size > 0) {
+    send(itemsToSend, rankReceiver);
+  }
+}
+
+void IntraCommunication::sendRange(precice::span<const int> itemsToSend, Rank rankReceiver)
+{
+  int size = itemsToSend.size();
+  send(size, rankReceiver);
+  if (size > 0) {
+    send(itemsToSend, rankReceiver);
+  }
+}
+
+std::vector<int> IntraCommunication::receiveRange(Rank rankSender, AsVectorTag<int>)
+{
+  int size{-1};
+  receive(size, rankSender);
+  PRECICE_ASSERT(size >= 0);
+  std::vector<int> result;
+  if (size > 0) {
+    result.resize(size);
+    receive(result, rankSender);
+  }
+  return result;
+}
+
+std::vector<double> IntraCommunication::receiveRange(Rank rankSender, AsVectorTag<double>)
+{
+  int size{-1};
+  receive(size, rankSender);
+  PRECICE_ASSERT(size >= 0);
+  std::vector<double> result;
+  if (size > 0) {
+    result.resize(size);
+    receive(result, rankSender);
+  }
+  return result;
+}
+
+} // namespace precice::com

--- a/src/com/IntraCommunication.hpp
+++ b/src/com/IntraCommunication.hpp
@@ -1,0 +1,199 @@
+#pragma once
+
+#include <stddef.h>
+#include <string>
+#include <vector>
+
+#include "com/Request.hpp"
+#include "com/SharedPointer.hpp"
+#include "logging/Logger.hpp"
+#include "precice/impl/Types.hpp"
+#include "precice/span.hpp"
+
+namespace precice::com {
+
+/**
+ * @brief Interface for intra-participant communication (primary-secondary).
+ *
+ * This is a standalone interface that replaces the use of the generic
+ * Communication class for intra-participant communication. It provides:
+ * - Efficient collective operations (broadcast, reduce, allreduce)
+ * - Point-to-point send/receive for partition data exchange
+ * - Simplified connection setup for primary-secondary topology
+ *
+ * Rank convention: rank 0 is the primary, ranks 1..N-1 are secondaries.
+ * No rank offset adjustment is needed.
+ *
+ * @see MPIIntraComm for an MPI-based implementation using native collectives.
+ * @see SocketIntraComm for a socket-based implementation.
+ */
+class IntraCommunication {
+public:
+  IntraCommunication &operator=(IntraCommunication &&) = delete;
+
+  virtual ~IntraCommunication() = default;
+
+  /// @name Connection Setup
+  /// @{
+
+  /// Returns true if a connection has been established.
+  virtual bool isConnected() = 0;
+
+  /**
+   * @brief Returns the number of secondary ranks in the intra-communicator.
+   *
+   * For MPI, this is the communicator size minus 1 (excluding primary).
+   * For sockets, this is the number of connected secondaries.
+   *
+   * @pre A connection has been set up via connectIntraComm().
+   */
+  virtual size_t getRemoteCommunicatorSize() = 0;
+
+  /**
+   * @brief Establishes the intra-participant communication.
+   *
+   * Sets up communication between the primary rank (rank 0) and all
+   * secondary ranks (1..size-1).
+   *
+   * @param[in] participantName Name of the participant.
+   * @param[in] tag Tag for establishing this connection.
+   * @param[in] rank The current rank in the participant (0 = primary).
+   * @param[in] size Total number of ranks in the participant.
+   */
+  virtual void connectIntraComm(std::string const &participantName,
+                                std::string const &tag,
+                                int                rank,
+                                int                size) = 0;
+
+  /// Closes the intra-participant communication.
+  virtual void closeConnection() = 0;
+
+  /// @}
+
+  /// @name Reduction
+  /// @{
+
+  /// Performs a reduce summation on the primary rank. Called by the primary.
+  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) = 0;
+
+  /// Performs a reduce summation, sending to the given primary rank. Called by secondaries.
+  virtual void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) = 0;
+
+  /// Performs a reduce summation of a single int on the primary rank.
+  virtual void reduceSum(int itemToSend, int &itemToReceive) = 0;
+
+  /// Performs a reduce summation of a single int, sending to the given primary rank.
+  virtual void reduceSum(int itemToSend, int &itemToReceive, Rank primaryRank) = 0;
+
+  /// Performs an allreduce summation on the primary rank, then distributes result.
+  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) = 0;
+
+  /// Performs an allreduce summation, for secondary ranks.
+  virtual void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) = 0;
+
+  /// Performs an allreduce summation of a single double on the primary rank.
+  virtual void allreduceSum(double itemToSend, double &itemToReceive) = 0;
+
+  /// Performs an allreduce summation of a single double, for secondary ranks.
+  virtual void allreduceSum(double itemToSend, double &itemToReceive, Rank primaryRank) = 0;
+
+  /// Performs an allreduce summation of a single int on the primary rank.
+  virtual void allreduceSum(int itemToSend, int &itemToReceive) = 0;
+
+  /// Performs an allreduce summation of a single int, for secondary ranks.
+  virtual void allreduceSum(int itemToSend, int &itemToReceive, Rank primaryRank) = 0;
+
+  /// @}
+
+  /// @name Broadcast
+  /// @{
+
+  virtual void broadcast(precice::span<const int> itemsToSend) = 0;
+  virtual void broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster) = 0;
+
+  virtual void broadcast(int itemToSend) = 0;
+  virtual void broadcast(int &itemToReceive, Rank rankBroadcaster) = 0;
+
+  virtual void broadcast(precice::span<const double> itemsToSend) = 0;
+  virtual void broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster) = 0;
+
+  virtual void broadcast(double itemToSend) = 0;
+  virtual void broadcast(double &itemToReceive, Rank rankBroadcaster) = 0;
+
+  virtual void broadcast(bool itemToSend) = 0;
+  virtual void broadcast(bool &itemToReceive, Rank rankBroadcaster) = 0;
+
+  virtual void broadcast(std::vector<int> const &v) = 0;
+  virtual void broadcast(std::vector<int> &v, Rank rankBroadcaster) = 0;
+
+  virtual void broadcast(std::vector<double> const &v) = 0;
+  virtual void broadcast(std::vector<double> &v, Rank rankBroadcaster) = 0;
+
+  /// @}
+
+  /// @name Send
+  /// @{
+
+  virtual void send(std::string const &itemToSend, Rank rankReceiver) = 0;
+  virtual void send(precice::span<const int> itemsToSend, Rank rankReceiver) = 0;
+  virtual PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) = 0;
+  virtual void send(precice::span<const double> itemsToSend, Rank rankReceiver) = 0;
+  virtual PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) = 0;
+  virtual void send(double itemToSend, Rank rankReceiver) = 0;
+  virtual PtrRequest aSend(const double &itemToSend, Rank rankReceiver) = 0;
+  virtual void send(int itemToSend, Rank rankReceiver) = 0;
+  virtual PtrRequest aSend(const int &itemToSend, Rank rankReceiver) = 0;
+  virtual void send(bool itemToSend, Rank rankReceiver) = 0;
+  virtual PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) = 0;
+
+  /// @}
+
+  /// @name Receive
+  /// @{
+
+  virtual void receive(std::string &itemToReceive, Rank rankSender) = 0;
+  virtual void receive(precice::span<int> itemsToReceive, Rank rankSender) = 0;
+  virtual void receive(precice::span<double> itemsToReceive, Rank rankSender) = 0;
+  virtual PtrRequest aReceive(precice::span<double> itemsToReceive, int rankSender) = 0;
+  virtual void receive(double &itemToReceive, Rank rankSender) = 0;
+  virtual PtrRequest aReceive(double &itemToReceive, Rank rankSender) = 0;
+  virtual void receive(int &itemToReceive, Rank rankSender) = 0;
+  virtual PtrRequest aReceive(int &itemToReceive, Rank rankSender) = 0;
+  virtual void receive(bool &itemToReceive, Rank rankSender) = 0;
+  virtual PtrRequest aReceive(bool &itemToReceive, Rank rankSender) = 0;
+
+  /// @}
+
+  /// @name Range communication
+  /// @{
+
+  /** Tag used to specify which type of vector to return.
+   * @see receiveRange()
+   */
+  template <typename T>
+  struct AsVectorTag {
+  };
+
+  /// Sends a range of doubles (size + content)
+  void sendRange(precice::span<const double> itemsToSend, Rank rankReceiver);
+
+  /// Sends a range of ints (size + content)
+  void sendRange(precice::span<const int> itemsToSend, Rank rankReceiver);
+
+  /// Receives a range of ints as a vector<int>
+  std::vector<int> receiveRange(Rank rankSender, AsVectorTag<int>);
+
+  /// Receives a range of doubles as a vector<double>
+  std::vector<double> receiveRange(Rank rankSender, AsVectorTag<double>);
+
+  /// @}
+
+protected:
+  bool _isConnected = false;
+};
+
+/// Allows to use @ref IntraCommunication::AsVectorTag in a less verbose way.
+template <typename T>
+inline constexpr auto intraAsVector = IntraCommunication::AsVectorTag<T>{};
+
+} // namespace precice::com

--- a/src/com/MPIIntraComm.cpp
+++ b/src/com/MPIIntraComm.cpp
@@ -1,0 +1,424 @@
+#ifndef PRECICE_NO_MPI
+
+#include "com/MPIIntraComm.hpp"
+#include "com/MPIRequest.hpp"
+#include "logging/LogMacros.hpp"
+#include "precice/impl/Types.hpp"
+#include "utils/Parallel.hpp"
+#include "utils/assertion.hpp"
+#include "utils/span_tools.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <ostream>
+
+template <size_t>
+struct MPI_Select_unsigned_integer_datatype_intra;
+
+template <>
+struct MPI_Select_unsigned_integer_datatype_intra<1> {
+  static MPI_Datatype datatype;
+};
+MPI_Datatype MPI_Select_unsigned_integer_datatype_intra<1>::datatype = MPI_UNSIGNED_CHAR;
+
+template <>
+struct MPI_Select_unsigned_integer_datatype_intra<2> {
+  static MPI_Datatype datatype;
+};
+MPI_Datatype MPI_Select_unsigned_integer_datatype_intra<2>::datatype = MPI_UNSIGNED_SHORT;
+
+template <>
+struct MPI_Select_unsigned_integer_datatype_intra<4> {
+  static MPI_Datatype datatype;
+};
+MPI_Datatype MPI_Select_unsigned_integer_datatype_intra<4>::datatype = MPI_UNSIGNED;
+
+template <>
+struct MPI_Select_unsigned_integer_datatype_intra<8> {
+  static MPI_Datatype datatype;
+};
+MPI_Datatype MPI_Select_unsigned_integer_datatype_intra<8>::datatype = MPI_UNSIGNED_LONG;
+
+#define MPI_BOOL_INTRA MPI_Select_unsigned_integer_datatype_intra<sizeof(bool)>::datatype
+
+namespace precice::com {
+
+MPIIntraComm::MPIIntraComm()
+    : _commState(utils::Parallel::current())
+{
+}
+
+MPIIntraComm::~MPIIntraComm()
+{
+  PRECICE_TRACE(_isConnected);
+  closeConnection();
+}
+
+bool MPIIntraComm::isConnected()
+{
+  return _isConnected;
+}
+
+size_t MPIIntraComm::getRemoteCommunicatorSize()
+{
+  PRECICE_TRACE();
+  PRECICE_ASSERT(isConnected());
+  // In intra-comm, remote = secondaries = size - 1
+  return static_cast<size_t>(_commState->size() - 1);
+}
+
+void MPIIntraComm::connectIntraComm(std::string const &participantName,
+                                    std::string const &tag,
+                                    int                rank,
+                                    int                size)
+{
+  PRECICE_TRACE(participantName, rank, size);
+  if (size == 1)
+    return;
+
+  // For MPI direct, the communicator is already set up by Parallel::splitCommunicator.
+  // Just store the current communicator state.
+  _commState   = utils::Parallel::current();
+  _isConnected = true;
+
+  PRECICE_DEBUG("Connected MPIIntraComm for participant {}, rank {}/{}", participantName, rank, size);
+}
+
+void MPIIntraComm::closeConnection()
+{
+  PRECICE_TRACE();
+  if (not isConnected())
+    return;
+  _isConnected = false;
+}
+
+// ==========================================================================
+// Reduction — directly using MPI_Reduce / MPI_Allreduce
+// ==========================================================================
+
+void MPIIntraComm::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+  Rank myRank = _commState->rank();
+  MPI_Reduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(),
+             itemsToSend.size(), MPI_DOUBLE, MPI_SUM, myRank, _commState->comm);
+}
+
+void MPIIntraComm::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+  MPI_Reduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(),
+             itemsToSend.size(), MPI_DOUBLE, MPI_SUM, primaryRank, _commState->comm);
+}
+
+void MPIIntraComm::reduceSum(int itemToSend, int &itemToReceive)
+{
+  PRECICE_TRACE();
+  Rank myRank = _commState->rank();
+  MPI_Reduce(&itemToSend, &itemToReceive, 1, MPI_INT, MPI_SUM, myRank, _commState->comm);
+}
+
+void MPIIntraComm::reduceSum(int itemToSend, int &itemToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE();
+  MPI_Reduce(&itemToSend, &itemToReceive, 1, MPI_INT, MPI_SUM, primaryRank, _commState->comm);
+}
+
+void MPIIntraComm::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+  MPI_Allreduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(),
+                itemsToSend.size(), MPI_DOUBLE, MPI_SUM, _commState->comm);
+}
+
+void MPIIntraComm::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+  // MPI_Allreduce is collective, primaryRank parameter is unused but kept for interface compatibility
+  MPI_Allreduce(const_cast<double *>(itemsToSend.data()), itemsToReceive.data(),
+                itemsToReceive.size(), MPI_DOUBLE, MPI_SUM, _commState->comm);
+}
+
+void MPIIntraComm::allreduceSum(double itemToSend, double &itemToReceive)
+{
+  PRECICE_TRACE();
+  MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_DOUBLE, MPI_SUM, _commState->comm);
+}
+
+void MPIIntraComm::allreduceSum(double itemToSend, double &itemToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE();
+  MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_DOUBLE, MPI_SUM, _commState->comm);
+}
+
+void MPIIntraComm::allreduceSum(int itemToSend, int &itemToReceive)
+{
+  PRECICE_TRACE();
+  MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_INT, MPI_SUM, _commState->comm);
+}
+
+void MPIIntraComm::allreduceSum(int itemToSend, int &itemToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE();
+  MPI_Allreduce(&itemToSend, &itemToReceive, 1, MPI_INT, MPI_SUM, _commState->comm);
+}
+
+// ==========================================================================
+// Broadcast — directly using MPI_Bcast
+// ==========================================================================
+
+void MPIIntraComm::broadcast(precice::span<const int> itemsToSend)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Bcast(const_cast<int *>(itemsToSend.data()), itemsToSend.size(), MPI_INT, 0, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE(itemsToReceive.size());
+  MPI_Bcast(itemsToReceive.data(), itemsToReceive.size(), MPI_INT, rankBroadcaster, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(int itemToSend)
+{
+  PRECICE_TRACE();
+  MPI_Bcast(&itemToSend, 1, MPI_INT, 0, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(int &itemToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE();
+  MPI_Bcast(&itemToReceive, 1, MPI_INT, rankBroadcaster, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(precice::span<const double> itemsToSend)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Bcast(const_cast<double *>(itemsToSend.data()), itemsToSend.size(), MPI_DOUBLE, 0, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE(itemsToReceive.size());
+  MPI_Bcast(itemsToReceive.data(), itemsToReceive.size(), MPI_DOUBLE, rankBroadcaster, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(double itemToSend)
+{
+  PRECICE_TRACE();
+  MPI_Bcast(&itemToSend, 1, MPI_DOUBLE, 0, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(double &itemToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE();
+  MPI_Bcast(&itemToReceive, 1, MPI_DOUBLE, rankBroadcaster, _commState->comm);
+}
+
+void MPIIntraComm::broadcast(bool itemToSend)
+{
+  PRECICE_TRACE();
+  int item = itemToSend;
+  broadcast(item);
+}
+
+void MPIIntraComm::broadcast(bool &itemToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE();
+  int item;
+  broadcast(item, rankBroadcaster);
+  itemToReceive = item;
+}
+
+void MPIIntraComm::broadcast(std::vector<int> const &v)
+{
+  broadcast(static_cast<int>(v.size()));
+  broadcast(precice::span<const int>{v});
+}
+
+void MPIIntraComm::broadcast(std::vector<int> &v, Rank rankBroadcaster)
+{
+  int size = 0;
+  broadcast(size, rankBroadcaster);
+  v.clear();
+  v.resize(size);
+  broadcast(precice::span<int>{v}, rankBroadcaster);
+}
+
+void MPIIntraComm::broadcast(std::vector<double> const &v)
+{
+  broadcast(static_cast<int>(v.size()));
+  broadcast(precice::span<const double>{v});
+}
+
+void MPIIntraComm::broadcast(std::vector<double> &v, Rank rankBroadcaster)
+{
+  int size = 0;
+  broadcast(size, rankBroadcaster);
+  v.clear();
+  v.resize(size);
+  broadcast(precice::span<double>{v}, rankBroadcaster);
+}
+
+// ==========================================================================
+// Point-to-point — directly using MPI_Send / MPI_Recv / MPI_Isend / MPI_Irecv
+// No rank adjustment needed. Ranks are participant ranks directly.
+// ==========================================================================
+
+void MPIIntraComm::send(std::string const &itemToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemToSend, rankReceiver);
+  MPI_Send(const_cast<char *>(itemToSend.c_str()),
+           itemToSend.size(), MPI_CHAR, rankReceiver, 0, _commState->comm);
+}
+
+void MPIIntraComm::send(precice::span<const int> itemsToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Send(const_cast<int *>(itemsToSend.data()),
+           itemsToSend.size(), MPI_INT, rankReceiver, 0, _commState->comm);
+}
+
+PtrRequest MPIIntraComm::aSend(precice::span<const int> itemsToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Request request;
+  MPI_Isend(const_cast<int *>(itemsToSend.data()),
+            itemsToSend.size(), MPI_INT, rankReceiver, 0, _commState->comm, &request);
+  return PtrRequest(new MPIRequest(request));
+}
+
+void MPIIntraComm::send(precice::span<const double> itemsToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  MPI_Send(const_cast<double *>(itemsToSend.data()),
+           itemsToSend.size(), MPI_DOUBLE, rankReceiver, 0, _commState->comm);
+}
+
+PtrRequest MPIIntraComm::aSend(precice::span<const double> itemsToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemsToSend.size(), rankReceiver);
+  MPI_Request request;
+  MPI_Isend(const_cast<double *>(itemsToSend.data()),
+            itemsToSend.size(), MPI_DOUBLE, rankReceiver, 0, _commState->comm, &request);
+  return PtrRequest(new MPIRequest(request));
+}
+
+void MPIIntraComm::send(double itemToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemToSend, rankReceiver);
+  MPI_Send(&itemToSend, 1, MPI_DOUBLE, rankReceiver, 0, _commState->comm);
+}
+
+PtrRequest MPIIntraComm::aSend(const double &itemToSend, Rank rankReceiver)
+{
+  return aSend(precice::refToSpan<const double>(itemToSend), rankReceiver);
+}
+
+void MPIIntraComm::send(int itemToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemToSend, rankReceiver);
+  MPI_Send(&itemToSend, 1, MPI_INT, rankReceiver, 0, _commState->comm);
+}
+
+PtrRequest MPIIntraComm::aSend(const int &itemToSend, Rank rankReceiver)
+{
+  return aSend(precice::refToSpan<const int>(itemToSend), rankReceiver);
+}
+
+void MPIIntraComm::send(bool itemToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE(itemToSend, rankReceiver);
+  MPI_Send(&itemToSend, 1, MPI_BOOL_INTRA, rankReceiver, 0, _commState->comm);
+}
+
+PtrRequest MPIIntraComm::aSend(const bool &itemToSend, Rank rankReceiver)
+{
+  PRECICE_TRACE();
+  MPI_Request request;
+  MPI_Isend(const_cast<bool *>(&itemToSend),
+            1, MPI_BOOL_INTRA, rankReceiver, 0, _commState->comm, &request);
+  return PtrRequest(new MPIRequest(request));
+}
+
+void MPIIntraComm::receive(std::string &itemToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(rankSender);
+  int        length;
+  MPI_Status status;
+  MPI_Probe(rankSender, 0, _commState->comm, &status);
+  MPI_Get_count(&status, MPI_CHAR, &length);
+  itemToReceive = std::string(length, '\0');
+  MPI_Recv(const_cast<char *>(itemToReceive.data()),
+           length, MPI_CHAR, rankSender, 0, _commState->comm, MPI_STATUS_IGNORE);
+}
+
+void MPIIntraComm::receive(precice::span<int> itemsToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(itemsToReceive.size());
+  MPI_Recv(itemsToReceive.data(),
+           itemsToReceive.size(), MPI_INT, rankSender, 0, _commState->comm, MPI_STATUS_IGNORE);
+}
+
+void MPIIntraComm::receive(precice::span<double> itemsToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(itemsToReceive.size());
+  MPI_Recv(itemsToReceive.data(),
+           itemsToReceive.size(), MPI_DOUBLE, rankSender, 0, _commState->comm, MPI_STATUS_IGNORE);
+}
+
+PtrRequest MPIIntraComm::aReceive(precice::span<double> itemsToReceive, int rankSender)
+{
+  PRECICE_TRACE(itemsToReceive.size());
+  MPI_Request request;
+  MPI_Irecv(itemsToReceive.data(),
+            itemsToReceive.size(), MPI_DOUBLE, rankSender, 0, _commState->comm, &request);
+  return PtrRequest(new MPIRequest(request));
+}
+
+void MPIIntraComm::receive(double &itemToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(rankSender);
+  MPI_Recv(&itemToReceive, 1, MPI_DOUBLE, rankSender, 0, _commState->comm, MPI_STATUS_IGNORE);
+}
+
+PtrRequest MPIIntraComm::aReceive(double &itemToReceive, Rank rankSender)
+{
+  return aReceive(precice::refToSpan<double>(itemToReceive), rankSender);
+}
+
+void MPIIntraComm::receive(int &itemToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(rankSender);
+  MPI_Recv(&itemToReceive, 1, MPI_INT, rankSender, 0, _commState->comm, MPI_STATUS_IGNORE);
+}
+
+PtrRequest MPIIntraComm::aReceive(int &itemToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(rankSender);
+  MPI_Request request;
+  MPI_Irecv(&itemToReceive, 1, MPI_INT, rankSender, 0, _commState->comm, &request);
+  return PtrRequest(new MPIRequest(request));
+}
+
+void MPIIntraComm::receive(bool &itemToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(rankSender);
+  MPI_Recv(&itemToReceive, 1, MPI_BOOL_INTRA, rankSender, 0, _commState->comm, MPI_STATUS_IGNORE);
+}
+
+PtrRequest MPIIntraComm::aReceive(bool &itemToReceive, Rank rankSender)
+{
+  PRECICE_TRACE(rankSender);
+  MPI_Request request;
+  MPI_Irecv(&itemToReceive, 1, MPI_BOOL_INTRA, rankSender, 0, _commState->comm, &request);
+  return PtrRequest(new MPIRequest(request));
+}
+
+} // namespace precice::com
+
+#endif // not PRECICE_NO_MPI

--- a/src/com/MPIIntraComm.hpp
+++ b/src/com/MPIIntraComm.hpp
@@ -1,0 +1,110 @@
+#ifndef PRECICE_NO_MPI
+
+#pragma once
+
+#include <mpi.h>
+#include <string>
+
+#include "com/IntraCommunication.hpp"
+#include "logging/Logger.hpp"
+#include "precice/impl/Types.hpp"
+#include "utils/Parallel.hpp"
+
+namespace precice::com {
+
+/**
+ * @brief Flat MPI-based implementation of IntraCommunication.
+ *
+ * Directly uses an MPI communicator for all operations:
+ * - Collectives use MPI_Bcast, MPI_Reduce, MPI_Allreduce
+ * - Point-to-point uses MPI_Send/MPI_Recv
+ *
+ * No intermediate abstraction layers. This is the most efficient
+ * backend for intra-participant communication when MPI is available.
+ */
+class MPIIntraComm : public IntraCommunication {
+public:
+  MPIIntraComm();
+
+  ~MPIIntraComm() override;
+
+  /// @name Connection
+  /// @{
+  bool isConnected() override;
+  size_t getRemoteCommunicatorSize() override;
+  void connectIntraComm(std::string const &participantName,
+                        std::string const &tag,
+                        int                rank,
+                        int                size) override;
+  void closeConnection() override;
+  /// @}
+
+  /// @name Reduction (MPI_Reduce / MPI_Allreduce)
+  /// @{
+  void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
+  void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
+  void reduceSum(int itemToSend, int &itemToReceive) override;
+  void reduceSum(int itemToSend, int &itemToReceive, Rank primaryRank) override;
+
+  void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
+  void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
+  void allreduceSum(double itemToSend, double &itemToReceive) override;
+  void allreduceSum(double itemToSend, double &itemToReceive, Rank primaryRank) override;
+  void allreduceSum(int itemToSend, int &itemToReceive) override;
+  void allreduceSum(int itemToSend, int &itemToReceive, Rank primaryRank) override;
+  /// @}
+
+  /// @name Broadcast (MPI_Bcast)
+  /// @{
+  void broadcast(precice::span<const int> itemsToSend) override;
+  void broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster) override;
+  void broadcast(int itemToSend) override;
+  void broadcast(int &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(precice::span<const double> itemsToSend) override;
+  void broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster) override;
+  void broadcast(double itemToSend) override;
+  void broadcast(double &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(bool itemToSend) override;
+  void broadcast(bool &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(std::vector<int> const &v) override;
+  void broadcast(std::vector<int> &v, Rank rankBroadcaster) override;
+  void broadcast(std::vector<double> const &v) override;
+  void broadcast(std::vector<double> &v, Rank rankBroadcaster) override;
+  /// @}
+
+  /// @name Point-to-point (MPI_Send / MPI_Recv)
+  /// @{
+  void send(std::string const &itemToSend, Rank rankReceiver) override;
+  void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  void send(double itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
+  void send(int itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
+  void send(bool itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
+
+  void receive(std::string &itemToReceive, Rank rankSender) override;
+  void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
+  void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
+  PtrRequest aReceive(precice::span<double> itemsToReceive, int rankSender) override;
+  void receive(double &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
+  void receive(int &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
+  void receive(bool &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
+  /// @}
+
+private:
+  logging::Logger _log{"com::MPIIntraComm"};
+
+  /// The MPI communicator state, directly used for all operations.
+  utils::Parallel::CommStatePtr _commState;
+};
+
+} // namespace precice::com
+
+#endif // not PRECICE_NO_MPI

--- a/src/com/SerializedMesh.cpp
+++ b/src/com/SerializedMesh.cpp
@@ -1,7 +1,7 @@
 #include <algorithm>
 #include <map>
 
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SerializedMesh.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/Vertex.hpp"
@@ -47,7 +47,7 @@ void SerializedMesh ::assertValid() const
   }
 }
 
-void SerializedMesh::send(Communication &communication, int rankReceiver)
+void SerializedMesh::send(IntraCommunication &communication, int rankReceiver)
 {
   communication.sendRange(sizes, rankReceiver);
   if (sizes[1] > 0) {
@@ -56,21 +56,21 @@ void SerializedMesh::send(Communication &communication, int rankReceiver)
   }
 }
 
-SerializedMesh SerializedMesh::receive(Communication &communication, int rankSender)
+SerializedMesh SerializedMesh::receive(IntraCommunication &communication, int rankSender)
 {
   SerializedMesh sm;
-  sm.sizes = communication.receiveRange(rankSender, asVector<int>);
+  sm.sizes = communication.receiveRange(rankSender, intraAsVector<int>);
   PRECICE_ASSERT(sm.sizes.size() == 5);
   auto nVertices = sm.sizes[1];
   if (nVertices > 0) {
-    sm.coords = communication.receiveRange(rankSender, asVector<double>);
-    sm.ids    = communication.receiveRange(rankSender, asVector<int>);
+    sm.coords = communication.receiveRange(rankSender, intraAsVector<double>);
+    sm.ids    = communication.receiveRange(rankSender, intraAsVector<int>);
   }
   sm.assertValid();
   return sm;
 }
 
-void SerializedMesh::broadcastSend(Communication &communication)
+void SerializedMesh::broadcastSend(IntraCommunication &communication)
 {
   communication.broadcast(sizes);
   if (sizes[1] > 0) {
@@ -79,7 +79,7 @@ void SerializedMesh::broadcastSend(Communication &communication)
   }
 }
 
-SerializedMesh SerializedMesh::broadcastReceive(Communication &communication)
+SerializedMesh SerializedMesh::broadcastReceive(IntraCommunication &communication)
 {
   constexpr int  broadcasterRank{0};
   SerializedMesh sm;

--- a/src/com/SerializedMesh.hpp
+++ b/src/com/SerializedMesh.hpp
@@ -7,7 +7,7 @@ namespace mesh {
 class Mesh;
 } // namespace mesh
 namespace com {
-class Communication;
+class IntraCommunication;
 
 namespace serialize {
 
@@ -29,15 +29,15 @@ public:
   /// asserts the content for correctness
   void assertValid() const;
 
-  void send(Communication &communication, int rankReceiver);
+  void send(IntraCommunication &communication, int rankReceiver);
 
   /// receives a SerializedMesh and calls assertValid before returning
-  static SerializedMesh receive(Communication &communication, int rankSender);
+  static SerializedMesh receive(IntraCommunication &communication, int rankSender);
 
-  void broadcastSend(Communication &communication);
+  void broadcastSend(IntraCommunication &communication);
 
   /// receives a SerializedMesh and calls assertValid before returning
-  static SerializedMesh broadcastReceive(Communication &communication);
+  static SerializedMesh broadcastReceive(IntraCommunication &communication);
 
 private:
   SerializedMesh() = default;

--- a/src/com/SerializedPartitioning.cpp
+++ b/src/com/SerializedPartitioning.cpp
@@ -4,7 +4,7 @@
 #include <numeric>
 #include <utility>
 
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SerializedPartitioning.hpp"
 #include "utils/assertion.hpp"
 
@@ -93,25 +93,25 @@ void SerializedConnectionMap::assertValid() const
   PRECICE_ASSERT(consumed == totalSize, "Not everything consumed");
 }
 
-void SerializedConnectionMap::send(Communication &communication, int rankReceiver) const
+void SerializedConnectionMap::send(IntraCommunication &communication, int rankReceiver) const
 {
   communication.sendRange(content, rankReceiver);
 }
 
-SerializedConnectionMap SerializedConnectionMap::receive(Communication &communication, int rankSender)
+SerializedConnectionMap SerializedConnectionMap::receive(IntraCommunication &communication, int rankSender)
 {
   SerializedConnectionMap scm;
-  scm.content = communication.receiveRange(rankSender, asVector<int>);
+  scm.content = communication.receiveRange(rankSender, intraAsVector<int>);
   scm.assertValid();
   return scm;
 }
 
-void SerializedConnectionMap::broadcastSend(Communication &communication) const
+void SerializedConnectionMap::broadcastSend(IntraCommunication &communication) const
 {
   communication.broadcast(content);
 }
 
-SerializedConnectionMap SerializedConnectionMap::broadcastReceive(Communication &communication)
+SerializedConnectionMap SerializedConnectionMap::broadcastReceive(IntraCommunication &communication)
 {
   SerializedConnectionMap scm;
   communication.broadcast(scm.content, 0);
@@ -168,15 +168,15 @@ void SerializedBoundingBox::assertValid() const
   PRECICE_ASSERT(coords.size() == 1 + dims * 2);
 }
 
-void SerializedBoundingBox::send(Communication &communication, int rankReceiver)
+void SerializedBoundingBox::send(IntraCommunication &communication, int rankReceiver)
 {
   communication.sendRange(coords, rankReceiver);
 }
 
-SerializedBoundingBox SerializedBoundingBox::receive(Communication &communication, int rankSender)
+SerializedBoundingBox SerializedBoundingBox::receive(IntraCommunication &communication, int rankSender)
 {
   SerializedBoundingBox sbb;
-  sbb.coords = communication.receiveRange(rankSender, asVector<double>);
+  sbb.coords = communication.receiveRange(rankSender, intraAsVector<double>);
   sbb.assertValid();
   return sbb;
 }
@@ -269,7 +269,7 @@ void SerializedBoundingBoxMap::assertValid() const
   }
 }
 
-void SerializedBoundingBoxMap::send(Communication &communication, int rankReceiver)
+void SerializedBoundingBoxMap::send(IntraCommunication &communication, int rankReceiver)
 {
   communication.sendRange(info, rankReceiver);
   if (info.size() > 1) {
@@ -277,18 +277,18 @@ void SerializedBoundingBoxMap::send(Communication &communication, int rankReceiv
   }
 }
 
-SerializedBoundingBoxMap SerializedBoundingBoxMap::receive(Communication &communication, int rankSender)
+SerializedBoundingBoxMap SerializedBoundingBoxMap::receive(IntraCommunication &communication, int rankSender)
 {
   SerializedBoundingBoxMap sbbm;
-  sbbm.info = communication.receiveRange(rankSender, asVector<int>);
+  sbbm.info = communication.receiveRange(rankSender, intraAsVector<int>);
   if (sbbm.info.size() > 1) {
-    sbbm.coords = communication.receiveRange(rankSender, asVector<double>);
+    sbbm.coords = communication.receiveRange(rankSender, intraAsVector<double>);
   }
   sbbm.assertValid();
   return sbbm;
 }
 
-void SerializedBoundingBoxMap::broadcastSend(Communication &communication)
+void SerializedBoundingBoxMap::broadcastSend(IntraCommunication &communication)
 {
   communication.broadcast(info);
   if (info.size() > 1) {
@@ -296,7 +296,7 @@ void SerializedBoundingBoxMap::broadcastSend(Communication &communication)
   }
 }
 
-SerializedBoundingBoxMap SerializedBoundingBoxMap::broadcastReceive(Communication &communication)
+SerializedBoundingBoxMap SerializedBoundingBoxMap::broadcastReceive(IntraCommunication &communication)
 {
   SerializedBoundingBoxMap sbbm;
   communication.broadcast(sbbm.info, 0);

--- a/src/com/SerializedPartitioning.hpp
+++ b/src/com/SerializedPartitioning.hpp
@@ -7,7 +7,7 @@
 #include "mesh/Mesh.hpp"
 
 namespace precice::com {
-class Communication;
+class IntraCommunication;
 
 namespace serialize {
 
@@ -28,15 +28,15 @@ public:
   /// asserts the content for correctness
   void assertValid() const;
 
-  void send(Communication &communication, int rankReceiver) const;
+  void send(IntraCommunication &communication, int rankReceiver) const;
 
   /// receives a SerializedConnectionMap and calls assertValid before returning
-  static SerializedConnectionMap receive(Communication &communication, int rankSender);
+  static SerializedConnectionMap receive(IntraCommunication &communication, int rankSender);
 
-  void broadcastSend(Communication &communication) const;
+  void broadcastSend(IntraCommunication &communication) const;
 
   /// receives a SerializedConnectionMap and calls assertValid before returning
-  static SerializedConnectionMap broadcastReceive(Communication &communication);
+  static SerializedConnectionMap broadcastReceive(IntraCommunication &communication);
 
 private:
   SerializedConnectionMap() = default;
@@ -61,10 +61,10 @@ public:
   /// asserts the content for correctness
   void assertValid() const;
 
-  void send(Communication &communication, int rankReceiver);
+  void send(IntraCommunication &communication, int rankReceiver);
 
   /// receives a SerializedBoundingBox and calls assertValid before returning
-  static SerializedBoundingBox receive(Communication &communication, int rankSender);
+  static SerializedBoundingBox receive(IntraCommunication &communication, int rankSender);
 
 private:
   SerializedBoundingBox() = default;
@@ -93,15 +93,15 @@ public:
   /// asserts the content for correctness
   void assertValid() const;
 
-  void send(Communication &communication, int rankReceiver);
+  void send(IntraCommunication &communication, int rankReceiver);
 
   /// receives a SerializedBoundingBoxMap and calls assertValid before returning
-  static SerializedBoundingBoxMap receive(Communication &communication, int rankSender);
+  static SerializedBoundingBoxMap receive(IntraCommunication &communication, int rankSender);
 
-  void broadcastSend(Communication &communication);
+  void broadcastSend(IntraCommunication &communication);
 
   /// receives a SerializedBoundingBoxMap and calls assertValid before returning
-  static SerializedBoundingBoxMap broadcastReceive(Communication &communication);
+  static SerializedBoundingBoxMap broadcastReceive(IntraCommunication &communication);
 
 private:
   SerializedBoundingBoxMap() = default;

--- a/src/com/SharedPointer.hpp
+++ b/src/com/SharedPointer.hpp
@@ -6,9 +6,11 @@ namespace precice::com {
 
 class Communication;
 class CommunicationFactory;
+class IntraCommunication;
 class Request;
 
 using PtrCommunication        = std::shared_ptr<Communication>;
 using PtrCommunicationFactory = std::shared_ptr<CommunicationFactory>;
+using PtrIntraCommunication   = std::shared_ptr<IntraCommunication>;
 using PtrRequest              = std::shared_ptr<Request>;
 } // namespace precice::com

--- a/src/com/SocketIntraComm.cpp
+++ b/src/com/SocketIntraComm.cpp
@@ -1,0 +1,429 @@
+#include "com/SocketIntraComm.hpp"
+#include "com/SocketCommunication.hpp"
+#include "logging/LogMacros.hpp"
+#include "precice/impl/Types.hpp"
+#include "utils/assertion.hpp"
+#include "utils/networking.hpp"
+#include "utils/span_tools.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <ostream>
+#include <vector>
+
+namespace precice::com {
+
+SocketIntraComm::SocketIntraComm(unsigned short portNumber,
+                                 bool           reuseAddress,
+                                 std::string    networkName,
+                                 std::string    addressDirectory)
+    : _socketComm(std::make_unique<SocketCommunication>(
+          portNumber, reuseAddress,
+          networkName.empty() ? utils::networking::loopbackInterfaceName() : std::move(networkName),
+          std::move(addressDirectory)))
+{
+}
+
+SocketIntraComm::~SocketIntraComm()
+{
+  PRECICE_TRACE(_isConnected);
+  closeConnection();
+}
+
+bool SocketIntraComm::isConnected()
+{
+  return _isConnected;
+}
+
+size_t SocketIntraComm::getRemoteCommunicatorSize()
+{
+  PRECICE_TRACE();
+  PRECICE_ASSERT(isConnected());
+  return _remoteCommunicatorSize;
+}
+
+void SocketIntraComm::connectIntraComm(std::string const &participantName,
+                                       std::string const &tag,
+                                       int                rank,
+                                       int                size)
+{
+  PRECICE_TRACE(participantName, rank, size);
+  if (size == 1)
+    return;
+
+  // Delegate connection establishment to the internal SocketCommunication
+  // using the same pattern as Communication::connectIntraComm
+  std::string primaryName   = participantName + "Primary";
+  std::string secondaryName = participantName + "Secondary";
+
+  int secondaryRanksSize = size - RANK_OFFSET;
+  if (rank == 0) {
+    PRECICE_INFO("Connecting Primary rank to {} Secondary ranks via sockets", secondaryRanksSize);
+    _socketComm->prepareEstablishment(primaryName, secondaryName);
+    _socketComm->acceptConnection(primaryName, secondaryName, tag, rank, RANK_OFFSET);
+    _socketComm->cleanupEstablishment(primaryName, secondaryName);
+  } else {
+    int secondaryRank = rank - RANK_OFFSET;
+    PRECICE_INFO("Connecting Secondary rank #{} to Primary rank via sockets", secondaryRank);
+    _socketComm->requestConnection(primaryName, secondaryName, tag, secondaryRank, secondaryRanksSize);
+  }
+
+  _remoteCommunicatorSize = _socketComm->getRemoteCommunicatorSize();
+  _isConnected            = true;
+}
+
+void SocketIntraComm::closeConnection()
+{
+  PRECICE_TRACE();
+  if (not isConnected())
+    return;
+  _socketComm->closeConnection();
+  _isConnected = false;
+}
+
+// ==========================================================================
+// Reduction — built from point-to-point socket operations
+// ==========================================================================
+
+void SocketIntraComm::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+
+  std::copy(itemsToSend.begin(), itemsToSend.end(), itemsToReceive.begin());
+
+  std::vector<double> received(itemsToReceive.size());
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    auto request = _socketComm->aReceive(received, static_cast<int>(rank) + RANK_OFFSET);
+    request->wait();
+    for (size_t i = 0; i < itemsToReceive.size(); i++) {
+      itemsToReceive[i] += received[i];
+    }
+  }
+}
+
+void SocketIntraComm::reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+  // Secondary side: primaryRank maps directly to _sockets[0] (no offset needed)
+  auto request = _socketComm->aSend(itemsToSend, primaryRank);
+  request->wait();
+}
+
+void SocketIntraComm::reduceSum(int itemToSend, int &itemToReceive)
+{
+  PRECICE_TRACE();
+  itemToReceive = itemToSend;
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    auto request = _socketComm->aReceive(itemToSend, static_cast<int>(rank) + RANK_OFFSET);
+    request->wait();
+    itemToReceive += itemToSend;
+  }
+}
+
+void SocketIntraComm::reduceSum(int itemToSend, int &itemToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE();
+  auto request = _socketComm->aSend(precice::refToSpan<const int>(itemToSend), primaryRank);
+  request->wait();
+}
+
+void SocketIntraComm::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+
+  reduceSum(itemsToSend, itemsToReceive);
+
+  std::vector<PtrRequest> requests;
+  requests.reserve(_remoteCommunicatorSize);
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    requests.push_back(_socketComm->aSend(itemsToReceive, static_cast<int>(rank) + RANK_OFFSET));
+  }
+  Request::wait(requests);
+}
+
+void SocketIntraComm::allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  PRECICE_ASSERT(itemsToSend.size() == itemsToReceive.size());
+
+  reduceSum(itemsToSend, itemsToReceive, primaryRank);
+  _socketComm->receive(itemsToReceive, primaryRank);
+}
+
+void SocketIntraComm::allreduceSum(double itemToSend, double &itemToReceive)
+{
+  PRECICE_TRACE();
+  itemToReceive = itemToSend;
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    auto request = _socketComm->aReceive(itemToSend, static_cast<int>(rank) + RANK_OFFSET);
+    request->wait();
+    itemToReceive += itemToSend;
+  }
+  std::vector<PtrRequest> requests(_remoteCommunicatorSize);
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    requests[rank] = _socketComm->aSend(itemToReceive, static_cast<int>(rank) + RANK_OFFSET);
+  }
+  Request::wait(requests);
+}
+
+void SocketIntraComm::allreduceSum(double itemToSend, double &itemToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE();
+  auto request = _socketComm->aSend(itemToSend, primaryRank);
+  request->wait();
+  _socketComm->receive(itemToReceive, primaryRank);
+}
+
+void SocketIntraComm::allreduceSum(int itemToSend, int &itemToReceive)
+{
+  PRECICE_TRACE();
+  itemToReceive = itemToSend;
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    auto request = _socketComm->aReceive(itemToSend, static_cast<int>(rank) + RANK_OFFSET);
+    request->wait();
+    itemToReceive += itemToSend;
+  }
+  std::vector<PtrRequest> requests(_remoteCommunicatorSize);
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    requests[rank] = _socketComm->aSend(itemToReceive, static_cast<int>(rank) + RANK_OFFSET);
+  }
+  Request::wait(requests);
+}
+
+void SocketIntraComm::allreduceSum(int itemToSend, int &itemToReceive, Rank primaryRank)
+{
+  PRECICE_TRACE();
+  auto request = _socketComm->aSend(precice::refToSpan<const int>(itemToSend), primaryRank);
+  request->wait();
+  _socketComm->receive(itemToReceive, primaryRank);
+}
+
+// ==========================================================================
+// Broadcast — built from point-to-point socket operations
+// ==========================================================================
+
+void SocketIntraComm::broadcast(precice::span<const int> itemsToSend)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  std::vector<PtrRequest> requests(_remoteCommunicatorSize);
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    requests[rank] = _socketComm->aSend(itemsToSend, static_cast<int>(rank) + RANK_OFFSET);
+  }
+  Request::wait(requests);
+}
+
+void SocketIntraComm::broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE(itemsToReceive.size());
+  _socketComm->receive(itemsToReceive, rankBroadcaster);
+}
+
+void SocketIntraComm::broadcast(int itemToSend)
+{
+  PRECICE_TRACE();
+  std::vector<PtrRequest> requests(_remoteCommunicatorSize);
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    requests[rank] = _socketComm->aSend(itemToSend, static_cast<int>(rank) + RANK_OFFSET);
+  }
+  Request::wait(requests);
+}
+
+void SocketIntraComm::broadcast(int &itemToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE();
+  _socketComm->receive(itemToReceive, rankBroadcaster);
+}
+
+void SocketIntraComm::broadcast(precice::span<const double> itemsToSend)
+{
+  PRECICE_TRACE(itemsToSend.size());
+  std::vector<PtrRequest> requests(_remoteCommunicatorSize);
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    requests[rank] = _socketComm->aSend(itemsToSend, static_cast<int>(rank) + RANK_OFFSET);
+  }
+  Request::wait(requests);
+}
+
+void SocketIntraComm::broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE(itemsToReceive.size());
+  _socketComm->receive(itemsToReceive, rankBroadcaster);
+}
+
+void SocketIntraComm::broadcast(double itemToSend)
+{
+  PRECICE_TRACE();
+  std::vector<PtrRequest> requests(_remoteCommunicatorSize);
+  for (size_t rank = 0; rank < _remoteCommunicatorSize; ++rank) {
+    requests[rank] = _socketComm->aSend(itemToSend, static_cast<int>(rank) + RANK_OFFSET);
+  }
+  Request::wait(requests);
+}
+
+void SocketIntraComm::broadcast(double &itemToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE();
+  _socketComm->receive(itemToReceive, rankBroadcaster);
+}
+
+void SocketIntraComm::broadcast(bool itemToSend)
+{
+  PRECICE_TRACE();
+  int item = itemToSend;
+  broadcast(item);
+}
+
+void SocketIntraComm::broadcast(bool &itemToReceive, Rank rankBroadcaster)
+{
+  PRECICE_TRACE();
+  int item;
+  broadcast(item, rankBroadcaster);
+  itemToReceive = item;
+}
+
+void SocketIntraComm::broadcast(std::vector<int> const &v)
+{
+  broadcast(static_cast<int>(v.size()));
+  broadcast(precice::span<const int>{v});
+}
+
+void SocketIntraComm::broadcast(std::vector<int> &v, Rank rankBroadcaster)
+{
+  int size = 0;
+  broadcast(size, rankBroadcaster);
+  v.clear();
+  v.resize(size);
+  broadcast(precice::span<int>{v}, rankBroadcaster);
+}
+
+void SocketIntraComm::broadcast(std::vector<double> const &v)
+{
+  broadcast(static_cast<int>(v.size()));
+  broadcast(precice::span<const double>{v});
+}
+
+void SocketIntraComm::broadcast(std::vector<double> &v, Rank rankBroadcaster)
+{
+  int size = 0;
+  broadcast(size, rankBroadcaster);
+  v.clear();
+  v.resize(size);
+  broadcast(precice::span<double>{v}, rankBroadcaster);
+}
+
+// ==========================================================================
+// Point-to-point — delegated to internal SocketCommunication
+// Rank adjustment: IntraCommunication ranks are direct participant ranks
+// (0=primary, 1..N-1=secondaries). The internal SocketCommunication uses
+// per-rank offset, so we delegate directly.
+// ==========================================================================
+
+void SocketIntraComm::send(std::string const &itemToSend, Rank rankReceiver)
+{
+  _socketComm->send(itemToSend, rankReceiver);
+}
+
+void SocketIntraComm::send(precice::span<const int> itemsToSend, Rank rankReceiver)
+{
+  _socketComm->send(itemsToSend, rankReceiver);
+}
+
+PtrRequest SocketIntraComm::aSend(precice::span<const int> itemsToSend, Rank rankReceiver)
+{
+  return _socketComm->aSend(itemsToSend, rankReceiver);
+}
+
+void SocketIntraComm::send(precice::span<const double> itemsToSend, Rank rankReceiver)
+{
+  _socketComm->send(itemsToSend, rankReceiver);
+}
+
+PtrRequest SocketIntraComm::aSend(precice::span<const double> itemsToSend, Rank rankReceiver)
+{
+  return _socketComm->aSend(itemsToSend, rankReceiver);
+}
+
+void SocketIntraComm::send(double itemToSend, Rank rankReceiver)
+{
+  _socketComm->send(itemToSend, rankReceiver);
+}
+
+PtrRequest SocketIntraComm::aSend(const double &itemToSend, Rank rankReceiver)
+{
+  return _socketComm->aSend(itemToSend, rankReceiver);
+}
+
+void SocketIntraComm::send(int itemToSend, Rank rankReceiver)
+{
+  _socketComm->send(itemToSend, rankReceiver);
+}
+
+PtrRequest SocketIntraComm::aSend(const int &itemToSend, Rank rankReceiver)
+{
+  return _socketComm->aSend(itemToSend, rankReceiver);
+}
+
+void SocketIntraComm::send(bool itemToSend, Rank rankReceiver)
+{
+  _socketComm->send(itemToSend, rankReceiver);
+}
+
+PtrRequest SocketIntraComm::aSend(const bool &itemToSend, Rank rankReceiver)
+{
+  return _socketComm->aSend(itemToSend, rankReceiver);
+}
+
+void SocketIntraComm::receive(std::string &itemToReceive, Rank rankSender)
+{
+  _socketComm->receive(itemToReceive, rankSender);
+}
+
+void SocketIntraComm::receive(precice::span<int> itemsToReceive, Rank rankSender)
+{
+  _socketComm->receive(itemsToReceive, rankSender);
+}
+
+void SocketIntraComm::receive(precice::span<double> itemsToReceive, Rank rankSender)
+{
+  _socketComm->receive(itemsToReceive, rankSender);
+}
+
+PtrRequest SocketIntraComm::aReceive(precice::span<double> itemsToReceive, int rankSender)
+{
+  return _socketComm->aReceive(itemsToReceive, rankSender);
+}
+
+void SocketIntraComm::receive(double &itemToReceive, Rank rankSender)
+{
+  _socketComm->receive(itemToReceive, rankSender);
+}
+
+PtrRequest SocketIntraComm::aReceive(double &itemToReceive, Rank rankSender)
+{
+  return _socketComm->aReceive(itemToReceive, rankSender);
+}
+
+void SocketIntraComm::receive(int &itemToReceive, Rank rankSender)
+{
+  _socketComm->receive(itemToReceive, rankSender);
+}
+
+PtrRequest SocketIntraComm::aReceive(int &itemToReceive, Rank rankSender)
+{
+  return _socketComm->aReceive(itemToReceive, rankSender);
+}
+
+void SocketIntraComm::receive(bool &itemToReceive, Rank rankSender)
+{
+  _socketComm->receive(itemToReceive, rankSender);
+}
+
+PtrRequest SocketIntraComm::aReceive(bool &itemToReceive, Rank rankSender)
+{
+  return _socketComm->aReceive(itemToReceive, rankSender);
+}
+
+} // namespace precice::com

--- a/src/com/SocketIntraComm.hpp
+++ b/src/com/SocketIntraComm.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "com/IntraCommunication.hpp"
+#include "logging/Logger.hpp"
+#include "precice/impl/Types.hpp"
+
+namespace precice::com {
+
+class SocketCommunication;
+
+/**
+ * @brief Socket-based implementation of IntraCommunication.
+ *
+ * Uses TCP sockets for all operations. Collective operations (broadcast,
+ * reduce, allreduce) are built from point-to-point socket communication.
+ *
+ * Internally composes a SocketCommunication for the actual socket I/O,
+ * but does NOT inherit from Communication. The public interface is purely
+ * IntraCommunication.
+ */
+class SocketIntraComm : public IntraCommunication {
+public:
+  SocketIntraComm(unsigned short portNumber       = 0,
+                  bool           reuseAddress     = false,
+                  std::string    networkName      = {},
+                  std::string    addressDirectory = ".");
+
+  ~SocketIntraComm() override;
+
+  /// @name Connection
+  /// @{
+  bool isConnected() override;
+  size_t getRemoteCommunicatorSize() override;
+  void connectIntraComm(std::string const &participantName,
+                        std::string const &tag,
+                        int                rank,
+                        int                size) override;
+  void closeConnection() override;
+  /// @}
+
+  /// @name Reduction (built from point-to-point)
+  /// @{
+  void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
+  void reduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
+  void reduceSum(int itemToSend, int &itemToReceive) override;
+  void reduceSum(int itemToSend, int &itemToReceive, Rank primaryRank) override;
+
+  void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive) override;
+  void allreduceSum(precice::span<double const> itemsToSend, precice::span<double> itemsToReceive, Rank primaryRank) override;
+  void allreduceSum(double itemToSend, double &itemToReceive) override;
+  void allreduceSum(double itemToSend, double &itemToReceive, Rank primaryRank) override;
+  void allreduceSum(int itemToSend, int &itemToReceive) override;
+  void allreduceSum(int itemToSend, int &itemToReceive, Rank primaryRank) override;
+  /// @}
+
+  /// @name Broadcast (built from point-to-point)
+  /// @{
+  void broadcast(precice::span<const int> itemsToSend) override;
+  void broadcast(precice::span<int> itemsToReceive, Rank rankBroadcaster) override;
+  void broadcast(int itemToSend) override;
+  void broadcast(int &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(precice::span<const double> itemsToSend) override;
+  void broadcast(precice::span<double> itemsToReceive, Rank rankBroadcaster) override;
+  void broadcast(double itemToSend) override;
+  void broadcast(double &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(bool itemToSend) override;
+  void broadcast(bool &itemToReceive, Rank rankBroadcaster) override;
+  void broadcast(std::vector<int> const &v) override;
+  void broadcast(std::vector<int> &v, Rank rankBroadcaster) override;
+  void broadcast(std::vector<double> const &v) override;
+  void broadcast(std::vector<double> &v, Rank rankBroadcaster) override;
+  /// @}
+
+  /// @name Point-to-point (socket-based)
+  /// @{
+  void send(std::string const &itemToSend, Rank rankReceiver) override;
+  void send(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const int> itemsToSend, Rank rankReceiver) override;
+  void send(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  PtrRequest aSend(precice::span<const double> itemsToSend, Rank rankReceiver) override;
+  void send(double itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const double &itemToSend, Rank rankReceiver) override;
+  void send(int itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const int &itemToSend, Rank rankReceiver) override;
+  void send(bool itemToSend, Rank rankReceiver) override;
+  PtrRequest aSend(const bool &itemToSend, Rank rankReceiver) override;
+
+  void receive(std::string &itemToReceive, Rank rankSender) override;
+  void receive(precice::span<int> itemsToReceive, Rank rankSender) override;
+  void receive(precice::span<double> itemsToReceive, Rank rankSender) override;
+  PtrRequest aReceive(precice::span<double> itemsToReceive, int rankSender) override;
+  void receive(double &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(double &itemToReceive, Rank rankSender) override;
+  void receive(int &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(int &itemToReceive, Rank rankSender) override;
+  void receive(bool &itemToReceive, Rank rankSender) override;
+  PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
+  /// @}
+
+private:
+  logging::Logger _log{"com::SocketIntraComm"};
+
+  /// Internal socket communication used for the actual I/O.
+  std::unique_ptr<SocketCommunication> _socketComm;
+
+  /// Number of secondary ranks
+  size_t _remoteCommunicatorSize = 0;
+
+  /// The rank offset used by the internal SocketCommunication
+  static constexpr int RANK_OFFSET = 1;
+
+  /// Helper to iterate over remote communicator ranks
+  size_t remoteSize() const { return _remoteCommunicatorSize; }
+};
+
+} // namespace precice::com

--- a/src/com/config/CommunicationConfiguration.cpp
+++ b/src/com/config/CommunicationConfiguration.cpp
@@ -2,18 +2,20 @@
 #include <memory>
 #include <ostream>
 #include "com/MPIDirectCommunication.hpp"
+#include "com/MPIIntraComm.hpp"
 #include "com/MPIPortsCommunication.hpp"
 #include "com/SocketCommunication.hpp"
+#include "com/SocketIntraComm.hpp"
 #include "logging/LogMacros.hpp"
 #include "utils/Helpers.hpp"
 #include "utils/assertion.hpp"
 #include "xml/XMLTag.hpp"
 
 namespace precice::com {
-PtrCommunication CommunicationConfiguration::createCommunication(
+PtrIntraCommunication CommunicationConfiguration::createIntraCommunication(
     const xml::XMLTag &tag) const
 {
-  com::PtrCommunication com;
+  PtrIntraCommunication comm;
   if (tag.getName() == "sockets") {
     std::string network = tag.getStringAttributeValue("network");
     int         port    = tag.getIntAttributeValue("port");
@@ -24,18 +26,17 @@ PtrCommunication CommunicationConfiguration::createCommunication(
                   port);
 
     std::string dir = tag.getStringAttributeValue("exchange-directory");
-    com             = std::make_shared<com::SocketCommunication>(port, false, network, dir);
+    comm            = std::make_shared<com::SocketIntraComm>(port, false, network, dir);
   } else if (tag.getName() == "mpi") {
-    std::string dir = tag.getStringAttributeValue("exchange-directory");
 #ifdef PRECICE_NO_MPI
     PRECICE_ERROR("Communication type \"mpi\" can only be used if preCICE was compiled with MPI support enabled. "
                   "Either switch to a \"sockets\" communication or recompile preCICE with \"PRECICE_MPICommunication=ON\".");
 #else
-    com = std::make_shared<com::MPIPortsCommunication>(dir);
+    comm = std::make_shared<com::MPIIntraComm>();
 #endif
   }
-  PRECICE_ASSERT(com != nullptr);
-  return com;
+  PRECICE_ASSERT(comm != nullptr);
+  return comm;
 }
 
 } // namespace precice::com

--- a/src/com/config/CommunicationConfiguration.hpp
+++ b/src/com/config/CommunicationConfiguration.hpp
@@ -20,8 +20,8 @@ class CommunicationConfiguration {
 public:
   virtual ~CommunicationConfiguration() = default;
 
-  /// Returns a communication object of given type.
-  PtrCommunication createCommunication(const xml::XMLTag &tag) const;
+  /// Returns an IntraCommunication object of given type.
+  PtrIntraCommunication createIntraCommunication(const xml::XMLTag &tag) const;
 
 private:
   mutable logging::Logger _log{"com::CommunicationConfiguration"};

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -1,6 +1,6 @@
 #include <memory>
 
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/BoundM2N.hpp"

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -7,6 +7,7 @@
 
 #include "GatherScatterCommunication.hpp"
 #include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/DistributedCommunication.hpp"
 #include "mesh/Mesh.hpp"
@@ -156,7 +157,7 @@ void GatherScatterCommunication::receive(precice::span<double> itemsToReceive, i
   // Secondary ranks receive scattered data
   if (utils::IntraComm::isSecondary()) { // Secondary rank
     if (!itemsToReceive.empty()) {
-      auto received = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<double>);
+      auto received = utils::IntraComm::getCommunication()->receiveRange(0, com::intraAsVector<double>);
       PRECICE_ASSERT(!received.empty());
       PRECICE_DEBUG("Received scattered data starting with {}", received[0]);
       std::copy(received.begin(), received.end(), itemsToReceive.begin());

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -15,6 +15,7 @@
 #include "com/Communication.hpp"
 #include "com/CommunicationFactory.hpp"
 #include "com/Extra.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/Request.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/DistributedCommunication.hpp"
@@ -58,8 +59,8 @@ void receive(mesh::Mesh::VertexDistribution &m,
   }
 }
 
-void broadcastSend(mesh::Mesh::VertexDistribution const &m,
-                   const com::PtrCommunication          &communication = utils::IntraComm::getCommunication())
+void broadcastSend(mesh::Mesh::VertexDistribution const    &m,
+                   const com::PtrIntraCommunication          &communication = utils::IntraComm::getCommunication())
 {
   communication->broadcast(static_cast<int>(m.size()));
 
@@ -72,8 +73,8 @@ void broadcastSend(mesh::Mesh::VertexDistribution const &m,
 }
 
 void broadcastReceive(mesh::Mesh::VertexDistribution &m,
-                      int                             rankBroadcaster,
-                      const com::PtrCommunication    &communication = utils::IntraComm::getCommunication())
+                      int                              rankBroadcaster,
+                      const com::PtrIntraCommunication &communication = utils::IntraComm::getCommunication())
 {
   m.clear();
   int size = 0;

--- a/src/mapping/PartitionOfUnityMapping.hpp
+++ b/src/mapping/PartitionOfUnityMapping.hpp
@@ -3,7 +3,7 @@
 #include <Eigen/Core>
 #include <numeric>
 
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "io/ExportVTU.hpp"
 #include "mapping/BatchedRBFSolver.hpp"
 #include "mapping/impl/CreateClustering.hpp"

--- a/src/mapping/RadialBasisFctMapping.hpp
+++ b/src/mapping/RadialBasisFctMapping.hpp
@@ -3,8 +3,8 @@
 #include <Eigen/Cholesky>
 #include <Eigen/Core>
 
-#include "com/Communication.hpp"
 #include "com/Extra.hpp"
+#include "com/IntraCommunication.hpp"
 #include "config/MappingConfiguration.hpp"
 #include "mapping/RadialBasisFctBaseMapping.hpp"
 #include "mesh/Filter.hpp"
@@ -244,7 +244,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
     {
       int secondaryOutputValueSize;
       for (Rank rank : utils::IntraComm::allSecondaryRanks()) {
-        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<double>);
+        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, com::intraAsVector<double>);
         globalInValues.insert(globalInValues.end(), secondaryBuffer.begin(), secondaryBuffer.end());
 
         utils::IntraComm::getCommunication()->receive(secondaryOutputValueSize, rank);
@@ -291,7 +291,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConservative(const time::Sampl
     }
   }
   if (utils::IntraComm::isSecondary()) {
-    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<double>);
+    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, com::intraAsVector<double>);
 
     const int valueDim = inData.dataDims;
 
@@ -343,7 +343,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConsistent(const time::Sample 
       int secondaryOutDataSize{0};
 
       for (Rank rank : utils::IntraComm::allSecondaryRanks()) {
-        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<double>);
+        std::vector<double> secondaryBuffer = utils::IntraComm::getCommunication()->receiveRange(rank, com::intraAsVector<double>);
         std::copy(secondaryBuffer.begin(), secondaryBuffer.end(), globalInValues.begin() + inputSizeCounter);
         inputSizeCounter += secondaryBuffer.size();
 
@@ -383,7 +383,7 @@ void RadialBasisFctMapping<SOLVER_T, Args...>::mapConsistent(const time::Sample 
     }
   }
   if (utils::IntraComm::isSecondary()) {
-    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<double>);
+    std::vector<double> receivedValues = utils::IntraComm::getCommunication()->receiveRange(0, com::intraAsVector<double>);
     outData                            = Eigen::Map<Eigen::VectorXd>(receivedValues.data(), receivedValues.size());
   }
 }

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -6,8 +6,8 @@
 #include <utility>
 #include <vector>
 
-#include "com/Communication.hpp"
 #include "com/Extra.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/M2N.hpp"

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -6,8 +6,8 @@
 #include <utility>
 #include <vector>
 
-#include "com/Communication.hpp"
 #include "com/Extra.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/M2N.hpp"
@@ -219,7 +219,7 @@ void ReceivedPartition::compute()
 
       for (int secondaryRank : utils::IntraComm::allSecondaryRanks()) {
         PRECICE_DEBUG("Receive partition feedback from the secondary rank {}", secondaryRank);
-        vertexDistribution[secondaryRank] = utils::IntraComm::getCommunication()->receiveRange(secondaryRank, com::asVector<VertexID>);
+        vertexDistribution[secondaryRank] = utils::IntraComm::getCommunication()->receiveRange(secondaryRank, com::intraAsVector<VertexID>);
       }
       PRECICE_ASSERT(_mesh->getVertexDistribution().empty());
       _mesh->setVertexDistribution(std::move(vertexDistribution));
@@ -445,7 +445,7 @@ void ReceivedPartition::compareBoundingBoxes()
 
     // receive connected ranks from secondary ranks and add them to the connection map
     for (int rank : utils::IntraComm::allSecondaryRanks()) {
-      std::vector<Rank> secondaryConnectedRanks = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<Rank>);
+      std::vector<Rank> secondaryConnectedRanks = utils::IntraComm::getCommunication()->receiveRange(rank, com::intraAsVector<Rank>);
       if (!secondaryConnectedRanks.empty()) {
         connectedRanksList.push_back(rank);
         connectionMap.emplace(rank, std::move(secondaryConnectedRanks));
@@ -770,7 +770,7 @@ void ReceivedPartition::createOwnerInformation()
         utils::IntraComm::getCommunication()->send(atInterface, 0);
 
         PRECICE_DEBUG("Receive owner information");
-        std::vector<VertexID> ownerVec = utils::IntraComm::getCommunication()->receiveRange(0, com::asVector<VertexID>);
+        std::vector<VertexID> ownerVec = utils::IntraComm::getCommunication()->receiveRange(0, com::intraAsVector<VertexID>);
         PRECICE_DEBUG("My owner information: {}", ownerVec);
         PRECICE_ASSERT(ownerVec.size() == static_cast<std::size_t>(numberOfVertices));
         setOwnerInformation(ownerVec);
@@ -817,8 +817,8 @@ void ReceivedPartition::createOwnerInformation()
 
         if (localNumberOfVertices != 0) {
           PRECICE_DEBUG("Receive tags from secondary rank {}", rank);
-          secondaryTags[rank]      = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<int>);
-          secondaryGlobalIDs[rank] = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<VertexID>);
+          secondaryTags[rank]      = utils::IntraComm::getCommunication()->receiveRange(rank, com::intraAsVector<int>);
+          secondaryGlobalIDs[rank] = utils::IntraComm::getCommunication()->receiveRange(rank, com::intraAsVector<VertexID>);
           PRECICE_DEBUG("Rank {} has tags {}", rank, secondaryTags[rank]);
           PRECICE_DEBUG("Rank {} has global IDs {}", rank, secondaryGlobalIDs[rank]);
           bool atInterface = false;

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -37,9 +37,9 @@
 #include "xml/XMLAttribute.hpp"
 
 #ifdef PRECICE_NO_MPI
-#include "com/SocketCommunication.hpp"
+#include "com/SocketIntraComm.hpp"
 #else
-#include "com/MPIDirectCommunication.hpp"
+#include "com/MPIIntraComm.hpp"
 #endif
 
 namespace precice::config {
@@ -338,7 +338,7 @@ void ParticipantConfiguration::xmlTagCallback(
       return;
     }
     com::CommunicationConfiguration comConfig;
-    utils::IntraComm::getCommunication() = comConfig.createCommunication(tag);
+    utils::IntraComm::getCommunication() = comConfig.createIntraCommunication(tag);
     _isIntraCommDefined                  = true;
     _participants.back()->setUsePrimaryRank(true);
   }
@@ -793,9 +793,9 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     PRECICE_INFO("Implicit intra-participant communications for parallel participants using preCICE without MPI defaults to a sockets intracomm using the default loopback device {}. "
                  "Define your own <intra-comm:sockets ... /> to modify these defaults.",
                  lo);
-    utils::IntraComm::getCommunication() = std::make_shared<com::SocketCommunication>(0, false, lo, ".");
+    utils::IntraComm::getCommunication() = std::make_shared<com::SocketIntraComm>(0, false, lo, ".");
 #else
-    utils::IntraComm::getCommunication() = std::make_shared<com::MPIDirectCommunication>();
+    utils::IntraComm::getCommunication() = std::make_shared<com::MPIIntraComm>();
 #endif
     participant->setUsePrimaryRank(true);
   }

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -17,7 +17,7 @@
 
 #include "ParticipantImpl.hpp"
 #include "action/SharedPointer.hpp"
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "cplscheme/Constants.hpp"
 #include "cplscheme/CouplingScheme.hpp"

--- a/src/precice/impl/WatchPoint.cpp
+++ b/src/precice/impl/WatchPoint.cpp
@@ -6,7 +6,7 @@
 #include <utility>
 
 #include "WatchPoint.hpp"
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "mapping/Polation.hpp"

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -56,10 +56,14 @@ target_sources(preciceCore
     src/com/ConnectionInfoPublisher.hpp
     src/com/Extra.cpp
     src/com/Extra.hpp
+    src/com/IntraCommunication.cpp
+    src/com/IntraCommunication.hpp
     src/com/MPICommunication.cpp
     src/com/MPICommunication.hpp
     src/com/MPIDirectCommunication.cpp
     src/com/MPIDirectCommunication.hpp
+    src/com/MPIIntraComm.cpp
+    src/com/MPIIntraComm.hpp
     src/com/MPIPortsCommunication.cpp
     src/com/MPIPortsCommunication.hpp
     src/com/MPIPortsCommunicationFactory.cpp
@@ -83,6 +87,8 @@ target_sources(preciceCore
     src/com/SocketCommunication.hpp
     src/com/SocketCommunicationFactory.cpp
     src/com/SocketCommunicationFactory.hpp
+    src/com/SocketIntraComm.cpp
+    src/com/SocketIntraComm.hpp
     src/com/SocketRequest.cpp
     src/com/SocketRequest.hpp
     src/com/SocketSendQueue.cpp

--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -6,11 +6,12 @@
 #include <ostream>
 #include <utility>
 
-#include "com/Communication.hpp"
-#include "com/MPIDirectCommunication.hpp"
+#include "com/IntraCommunication.hpp"
+#include "com/MPIIntraComm.hpp"
 #include "com/SharedPointer.hpp"
 #include "com/SocketCommunication.hpp"
 #include "com/SocketCommunicationFactory.hpp"
+#include "com/SocketIntraComm.hpp"
 #include "logging/LogConfiguration.hpp"
 #include "m2n/DistributedComFactory.hpp"
 #include "m2n/GatherScatterComFactory.hpp"
@@ -203,9 +204,9 @@ void TestContext::initializeIntraComm()
     return;
 
 #ifndef PRECICE_NO_MPI
-  precice::com::PtrCommunication intraComm = precice::com::PtrCommunication(new precice::com::MPIDirectCommunication());
+  precice::com::PtrIntraCommunication intraComm = precice::com::PtrIntraCommunication(new precice::com::MPIIntraComm());
 #else
-  precice::com::PtrCommunication intraComm = precice::com::PtrCommunication(new precice::com::SocketCommunication());
+  precice::com::PtrIntraCommunication intraComm = precice::com::PtrIntraCommunication(new precice::com::SocketIntraComm());
 #endif
 
   intraComm->connectIntraComm(name, "", rank, size);

--- a/src/testing/tests/ExampleTests.cpp
+++ b/src/testing/tests/ExampleTests.cpp
@@ -1,6 +1,6 @@
 #include <Eigen/Core>
 #include <memory>
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "m2n/M2N.hpp"
 #include "math/constants.hpp"

--- a/src/utils/IntraComm.cpp
+++ b/src/utils/IntraComm.cpp
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "IntraComm.hpp"
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "logging/LogMacros.hpp"
 #include "logging/Logger.hpp"
 #include "precice/impl/Types.hpp"
@@ -24,7 +24,7 @@ Rank                  IntraComm::_rank            = -1;
 int                   IntraComm::_size            = -1;
 bool                  IntraComm::_isPrimaryRank   = false;
 bool                  IntraComm::_isSecondaryRank = false;
-com::PtrCommunication IntraComm::_communication;
+com::PtrIntraCommunication IntraComm::_communication;
 
 logging::Logger IntraComm::_log("utils::IntraComm");
 

--- a/src/utils/IntraComm.hpp
+++ b/src/utils/IntraComm.hpp
@@ -28,7 +28,7 @@ public:
   static int getSize();
 
   /// Intra-participant communication.
-  static com::PtrCommunication &getCommunication()
+  static com::PtrIntraCommunication &getCommunication()
   {
     return _communication;
   }
@@ -112,7 +112,7 @@ private:
   static bool _isSecondaryRank;
 
   /// Intra-participant communication.
-  static com::PtrCommunication _communication;
+  static com::PtrIntraCommunication _communication;
 };
 
 } // namespace utils

--- a/src/utils/tests/ParallelTest.cpp
+++ b/src/utils/tests/ParallelTest.cpp
@@ -1,7 +1,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include "com/Communication.hpp"
+#include "com/IntraCommunication.hpp"
 #include "com/SharedPointer.hpp"
 #include "testing/TestContext.hpp"
 #include "testing/Testing.hpp"


### PR DESCRIPTION
### Main changes of this PR

This PR splits the monolithic `Communication` class into `IntraCommunication` (primary-secondary within a participant) and `InterCommunication` (participant-participant) interfaces. `utils::IntraComm` now uses `PtrIntraCommunication`, and all consumer files have been migrated.

### Motivation and additional information

Related to #2447

The existing `Communication` class handles both intra-participant and inter-participant communication, making the API unclear and mixing concerns. Splitting it into two dedicated interfaces improves type safety, clarifies intent at each call site, and enables future independent evolution of both communication paths. 

### Author's checklist

- [x] I used the pre-commit hook to prevent dirty commits and used `pre-commit run --all` to format old commits.
- [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
- [ ] I added a test to cover the proposed changes in our test suite.
- [ ] For breaking changes: I documented the changes in the appropriate porting guide.
- [x] I stuck to C++17 features.
- [x] I stuck to CMake version 3.22.1.
- [ ] I squashed / am about to squash all commits that should be seen as one.
- [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

### GSoC 2026
This is my contribution for GSoC 2026 application.