### PR TITLE
Precompute hwloc topology

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -251,6 +251,15 @@ jobs:
       run: brew install --overwrite --quiet eigen libxml2 boost petsc openmpi ninja
     - name: Generate build directory
       run: mkdir -p build
+    - name: Precompute hwloc topology
+      run: |
+        lstopo --of xml topo.xml
+        TOPO="$(readlink -f topo.xml)"
+        echo "TOPO file $TOPO"
+        echo "HWLOC_XMLFILE=$TOPO" >> "$GITHUB_ENV"
+        echo "::group::Content"
+        cat "$TOPO"
+        echo "::endgroup::"
     - name: Configure
       working-directory: build
       env:


### PR DESCRIPTION
## Main changes of this PR

This PR precomputes the hwloc topology in the CI and defines it using HWLOC_XMLFILE.

## Motivation and additional information

It should reduce the startup time per test by around 100ms.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
