### PR TITLE
Added configurable cutoff threshold to Gaussian RBF

### DIFF
--- a/docs/changelog/2480.md
+++ b/docs/changelog/2480.md
@@ -1,0 +1,1 @@
+- Added a configurable `cutoff-threshold` to the Gaussian RBF mapping configuration.

--- a/src/mapping/config/MappingConfiguration.cpp
+++ b/src/mapping/config/MappingConfiguration.cpp
@@ -110,7 +110,7 @@ PtrMapping instantiateRBFMapping(mapping::Mapping::Constraint &constraint, int d
 }
 
 // Constructs the RBF function based on the functionType
-rbf_variant_t constructRBF(BasisFunction functionType, double supportRadius, double shapeParameter)
+rbf_variant_t constructRBF(BasisFunction functionType, double supportRadius, double shapeParameter, double cutoffThreshold)
 {
   try {
     switch (functionType) {
@@ -145,7 +145,7 @@ rbf_variant_t constructRBF(BasisFunction functionType, double supportRadius, dou
       return mapping::InverseMultiquadrics(shapeParameter);
     }
     case BasisFunction::Gaussian: {
-      return mapping::Gaussian(shapeParameter);
+      return mapping::Gaussian(shapeParameter, std::numeric_limits<double>::infinity(), cutoffThreshold);
     }
     default:
       PRECICE_UNREACHABLE("No instantiation was found for the selected basis function.");
@@ -161,10 +161,10 @@ rbf_variant_t constructRBF(BasisFunction functionType, double supportRadius, dou
 // constructor arguments are just forwarded. The first argument (BasisFunction) indicates then the actual instantiation to return.
 template <RBFBackend T, typename... Args>
 PtrMapping getRBFMapping(BasisFunction functionType, mapping::Mapping::Constraint &constraint, int dimension, double supportRadius, double shapeParameter,
-                         Args &&...args)
+                         double cutoffThreshold, Args &&...args)
 {
   // First, construct the RBF function
-  auto functionVariant = constructRBF(functionType, supportRadius, shapeParameter);
+  auto functionVariant = constructRBF(functionType, supportRadius, shapeParameter, cutoffThreshold);
   // ... and instantiate the corresponding RBF mapping class
   return std::visit([&](auto &&func) { return instantiateRBFMapping<T>(constraint, dimension, func, std::forward<Args>(args)...); }, functionVariant);
 }
@@ -373,10 +373,13 @@ MappingConfiguration::MappingConfiguration(
 
   // For the Gaussian, we need default values as the user can pass a support radius or a shape parameter
   std::list<XMLTag> GaussRBF{
-      XMLTag{*this, RBF_GAUSSIAN, once, SUBTAG_BASIS_FUNCTION}.setDocumentation("Gaussian basis function accepting a support radius or a shape parameter.")};
+      XMLTag{*this, RBF_GAUSSIAN, once, SUBTAG_BASIS_FUNCTION}.setDocumentation("Gaussian basis function accepting a support radius or a shape parameter, with an optional cut-off threshold.")};
   attrShapeParam.setDefaultValue(std::numeric_limits<double>::quiet_NaN());
   attrSupportRadius.setDefaultValue(std::numeric_limits<double>::quiet_NaN());
-  addAttributes(GaussRBF, {attrShapeParam, attrSupportRadius});
+  auto attrCutoffThreshold = XMLAttribute<double>(ATTR_CUTOFF_THRESHOLD)
+                                 .setDefaultValue(Gaussian::cutoffThreshold)
+                                 .setDocumentation("Cut-off threshold for the Gaussian RBF. Determines the support radius from the shape parameter or vice versa. Defaults to 1e-9.");
+  addAttributes(GaussRBF, {attrShapeParam, attrSupportRadius, attrCutoffThreshold});
   addSubtagsToParents(GaussRBF, rbfIterativeTags);
   addSubtagsToParents(GaussRBF, rbfDirectTags);
   addSubtagsToParents(GaussRBF, pumDirectTags);
@@ -503,21 +506,26 @@ void MappingConfiguration::xmlTagCallback(
                                                             "from mesh \"{}\" to mesh \"{}\".",
                   _mappings.back().fromMesh->getName(), _mappings.back().toMesh->getName());
 
-    std::string basisFctName   = tag.getName();
-    double      supportRadius  = tag.getDoubleAttributeValue(ATTR_SUPPORT_RADIUS, 0.);
-    double      shapeParameter = tag.getDoubleAttributeValue(ATTR_SHAPE_PARAM, 0.);
+    std::string basisFctName    = tag.getName();
+    double      supportRadius   = tag.getDoubleAttributeValue(ATTR_SUPPORT_RADIUS, 0.);
+    double      shapeParameter  = tag.getDoubleAttributeValue(ATTR_SHAPE_PARAM, 0.);
+    double      cutoffThreshold = tag.getDoubleAttributeValue(ATTR_CUTOFF_THRESHOLD, Gaussian::cutoffThreshold);
 
     _rbfConfig.basisFunction        = parseBasisFunctions(basisFctName);
     _rbfConfig.basisFunctionDefined = true;
     // The Gaussian RBF is always treated as a shape-parameter RBF. Hence, we have to convert the support radius, if necessary
     if (_rbfConfig.basisFunction == BasisFunction::Gaussian) {
-      const bool exactlyOneSet = (std::isfinite(supportRadius) && !std::isfinite(shapeParameter)) ||
-                                 (std::isfinite(shapeParameter) && !std::isfinite(supportRadius));
+      const bool hasShape      = std::isfinite(shapeParameter);
+      const bool hasRadius     = std::isfinite(supportRadius);
+      const bool exactlyOneSet = hasShape != hasRadius;
       PRECICE_CHECK(exactlyOneSet, "The specified parameters for the Gaussian RBF mapping are invalid. Please specify either a \"shape-parameter\" or a \"support-radius\".");
+      PRECICE_CHECK(cutoffThreshold > 0 && cutoffThreshold < 1,
+                    "The \"cutoff-threshold\" for the Gaussian RBF must be between 0 and 1 (exclusive). Received: {}.", cutoffThreshold);
 
-      if (std::isfinite(supportRadius) && !std::isfinite(shapeParameter)) {
-        shapeParameter = std::sqrt(-std::log(Gaussian::cutoffThreshold)) / supportRadius;
+      if (hasRadius) {
+        shapeParameter = std::sqrt(-std::log(cutoffThreshold)) / supportRadius;
       }
+      _rbfConfig.cutoffThreshold = cutoffThreshold;
     }
 
     _rbfConfig.supportRadius  = supportRadius;
@@ -841,20 +849,20 @@ void MappingConfiguration::finishRBFConfiguration()
   // 1. the CPU executor
   if (_executorConfig->executor == ExecutorConfiguration::Executor::CPU) {
     if (_rbfConfig.solver == RBFConfiguration::SystemSolver::GlobalDirect) {
-      mapping.mapping = getRBFMapping<RBFBackend::Eigen>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.deadAxis, _rbfConfig.polynomial);
+      mapping.mapping = getRBFMapping<RBFBackend::Eigen>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.cutoffThreshold, _rbfConfig.deadAxis, _rbfConfig.polynomial);
     } else if (_rbfConfig.solver == RBFConfiguration::SystemSolver::GlobalIterative) {
 #ifndef PRECICE_NO_PETSC
       // for petsc initialization
       utils::Petsc::initialize(utils::Parallel::current()->comm);
 
-      mapping.mapping = getRBFMapping<RBFBackend::PETSc>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.deadAxis, _rbfConfig.solverRtol, _rbfConfig.polynomial);
+      mapping.mapping = getRBFMapping<RBFBackend::PETSc>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.cutoffThreshold, _rbfConfig.deadAxis, _rbfConfig.solverRtol, _rbfConfig.polynomial);
 #else
       PRECICE_ERROR("The global-iterative RBF solver on a CPU requires a preCICE build with PETSc enabled.");
 #endif
     } else if (_rbfConfig.solver == RBFConfiguration::SystemSolver::PUMDirect) {
       _ginkgoParameter          = GinkgoParameter();
       _ginkgoParameter.executor = "cpu";
-      mapping.mapping           = getRBFMapping<RBFBackend::PUM>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.polynomial, _rbfConfig.verticesPerCluster, _rbfConfig.relativeOverlap, _rbfConfig.projectToInput, _ginkgoParameter);
+      mapping.mapping           = getRBFMapping<RBFBackend::PUM>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.cutoffThreshold, _rbfConfig.polynomial, _rbfConfig.verticesPerCluster, _rbfConfig.relativeOverlap, _rbfConfig.projectToInput, _ginkgoParameter);
     } else {
       PRECICE_UNREACHABLE("Unknown RBF solver.");
     }
@@ -888,7 +896,7 @@ void MappingConfiguration::finishRBFConfiguration()
     if (_rbfConfig.solver == RBFConfiguration::SystemSolver::GlobalDirect) {
 #ifndef PRECICE_NO_GINKGO
       _ginkgoParameter.solver = "qr-solver";
-      mapping.mapping         = getRBFMapping<RBFBackend::Ginkgo>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.deadAxis, _rbfConfig.polynomial, _ginkgoParameter);
+      mapping.mapping         = getRBFMapping<RBFBackend::Ginkgo>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.cutoffThreshold, _rbfConfig.deadAxis, _rbfConfig.polynomial, _ginkgoParameter);
 #else
       PRECICE_ERROR("The selected direct solver for the global RBF mapping on executor {} from mesh {} to mesh {} requires a preCICE build with Ginkgo enabled.", _ginkgoParameter.executor, mapping.fromMesh->getName(), mapping.toMesh->getName());
 #endif
@@ -896,14 +904,14 @@ void MappingConfiguration::finishRBFConfiguration()
 #ifndef PRECICE_NO_GINKGO
       _ginkgoParameter.solver       = "cg-solver";
       _ginkgoParameter.residualNorm = _rbfConfig.solverRtol;
-      mapping.mapping               = getRBFMapping<RBFBackend::Ginkgo>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.deadAxis, _rbfConfig.polynomial, _ginkgoParameter);
+      mapping.mapping               = getRBFMapping<RBFBackend::Ginkgo>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.cutoffThreshold, _rbfConfig.deadAxis, _rbfConfig.polynomial, _ginkgoParameter);
 #else
       PRECICE_ERROR("The selected iterative solver for the global RBF mapping on executor {} from mesh {} to mesh {} requires a preCICE build with Ginkgo enabled.", _ginkgoParameter.executor, mapping.fromMesh->getName(), mapping.toMesh->getName());
 #endif
     } else if (_rbfConfig.solver == RBFConfiguration::SystemSolver::PUMDirect) {
 #ifndef PRECICE_NO_KOKKOS_KERNELS
       PRECICE_CHECK(!(mapping.fromMesh->isJustInTime() || mapping.toMesh->isJustInTime()), "Executor \"{}\" is not implemented as just-in-time mapping.", _ginkgoParameter.executor);
-      mapping.mapping = getRBFMapping<RBFBackend::PUM>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.polynomial, _rbfConfig.verticesPerCluster, _rbfConfig.relativeOverlap, _rbfConfig.projectToInput, _ginkgoParameter, _executorConfig->computeEvaluationOffline);
+      mapping.mapping = getRBFMapping<RBFBackend::PUM>(_rbfConfig.basisFunction, constraintValue, mapping.fromMesh->getDimensions(), _rbfConfig.supportRadius, _rbfConfig.shapeParameter, _rbfConfig.cutoffThreshold, _rbfConfig.polynomial, _rbfConfig.verticesPerCluster, _rbfConfig.relativeOverlap, _rbfConfig.projectToInput, _ginkgoParameter, _executorConfig->computeEvaluationOffline);
 #else
       PRECICE_ERROR("The selected pu-rbf solver using executor \"{}\" for the mapping from mesh {} to mesh {} requires a preCICE build with Kokkos-kernels enabled.", _ginkgoParameter.executor, mapping.fromMesh->getName(), mapping.toMesh->getName());
 #endif

--- a/src/mapping/config/MappingConfiguration.hpp
+++ b/src/mapping/config/MappingConfiguration.hpp
@@ -96,6 +96,7 @@ public:
     BasisFunction       basisFunction{};
     double              supportRadius{};
     double              shapeParameter{};
+    double              cutoffThreshold{1e-9};
     bool                basisFunctionDefined = false;
   };
 
@@ -193,8 +194,9 @@ private:
   const std::string RBF_CPOLYNOMIAL_C8    = "compact-polynomial-c8";
 
   // Attributes for the subtag
-  const std::string ATTR_SHAPE_PARAM    = "shape-parameter";
-  const std::string ATTR_SUPPORT_RADIUS = "support-radius";
+  const std::string ATTR_SHAPE_PARAM      = "shape-parameter";
+  const std::string ATTR_SUPPORT_RADIUS   = "support-radius";
+  const std::string ATTR_CUTOFF_THRESHOLD = "cutoff-threshold";
 
   // Attributes for geometric multiscale
   const std::string ATTR_GEOMETRIC_MULTISCALE_DIMENSION                  = "multiscale-dimension";

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -237,7 +237,7 @@ private:
 class Gaussian : public CompactSupportBase,
                  public DefiniteFunction<true> {
 public:
-  Gaussian(const double shape, const double supportRadius = std::numeric_limits<double>::infinity())
+  Gaussian(const double shape, const double supportRadius = std::numeric_limits<double>::infinity(), const double threshold = cutoffThreshold)
       : _shape(shape),
         _supportRadius(supportRadius)
   {
@@ -250,11 +250,11 @@ public:
           "Support radius for radial-basis-function gaussian has to be larger than zero. Please update the \"support-radius\" attribute."};
     }
 
-    double threshold   = std::sqrt(-std::log(cutoffThreshold)) / shape;
-    _supportRadius     = std::min(supportRadius, threshold);
-    _params.parameter1 = _shape;
-    _params.parameter2 = _supportRadius;
-    _params.parameter3 = _deltaY;
+    double cutoffRadius = std::sqrt(-std::log(threshold)) / shape;
+    _supportRadius      = std::min(supportRadius, cutoffRadius);
+    _params.parameter1  = _shape;
+    _params.parameter2  = _supportRadius;
+    _params.parameter3  = _deltaY;
     if (supportRadius < std::numeric_limits<double>::infinity()) {
       _deltaY            = evaluate(supportRadius);
       _params.parameter3 = _deltaY;

--- a/src/mapping/tests/MappingConfigurationTest.cpp
+++ b/src/mapping/tests/MappingConfigurationTest.cpp
@@ -476,5 +476,37 @@ BOOST_AUTO_TEST_CASE(RBFPUMOpenMPConfiguration)
 #endif
 #endif
 
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(GaussianCutoffThresholdConfiguration)
+{
+  PRECICE_TEST();
+
+  std::string pathToTests = testing::getPathToSources() + "/mapping/tests/";
+  std::string file(pathToTests + "mapping-rbf-gaussian-cutoff-config.xml");
+  using xml::XMLTag;
+  XMLTag                        tag = xml::getRootTag();
+  mesh::PtrDataConfiguration    dataConfig(new mesh::DataConfiguration(tag));
+  mesh::PtrMeshConfiguration    meshConfig(new mesh::MeshConfiguration(tag, dataConfig));
+  mapping::MappingConfiguration mappingConfig(tag, meshConfig);
+  xml::configure(tag, xml::ConfigurationContext{}, file);
+
+  BOOST_TEST(meshConfig->meshes().size() == 5);
+  BOOST_TEST(mappingConfig.mappings().size() == 4);
+  for (unsigned int i = 0; i < mappingConfig.mappings().size(); ++i) {
+    BOOST_TEST(mappingConfig.mappings().at(i).mapping != nullptr);
+    BOOST_TEST(mappingConfig.mappings().at(i).fromMesh == meshConfig->meshes().at(i + 1));
+    BOOST_TEST(mappingConfig.mappings().at(i).toMesh == meshConfig->meshes().at(i));
+    BOOST_TEST(mappingConfig.mappings().at(i).direction == MappingConfiguration::READ);
+    BOOST_TEST(mappingConfig.mappings().at(i).requiresBasisFunction == true);
+  }
+  {
+    // last configured RBF: Gaussian with shape-parameter and custom cutoff-threshold
+    bool solverSelection = mappingConfig.rbfConfig().solver == MappingConfiguration::RBFConfiguration::SystemSolver::GlobalDirect;
+    BOOST_TEST(solverSelection);
+    BOOST_TEST(mappingConfig.rbfConfig().cutoffThreshold == 1e-6);
+    BOOST_TEST(mappingConfig.rbfConfig().shapeParameter == 4.55);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/mapping/tests/mapping-rbf-gaussian-cutoff-config.xml
+++ b/src/mapping/tests/mapping-rbf-gaussian-cutoff-config.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+  <mesh name="TestMeshA" dimensions="3" />
+  <mesh name="TestMeshB" dimensions="3" />
+  <mesh name="TestMeshC" dimensions="3" />
+  <mesh name="TestMeshD" dimensions="3" />
+  <mesh name="TestMeshE" dimensions="3" />
+
+  <mapping:rbf-global-direct
+    direction="read"
+    from="TestMeshB"
+    to="TestMeshA"
+    constraint="consistent">
+    <basis-function:gaussian shape-parameter="4.55" />
+  </mapping:rbf-global-direct>
+
+  <mapping:rbf-global-direct
+    direction="read"
+    from="TestMeshC"
+    to="TestMeshB"
+    constraint="consistent">
+    <basis-function:gaussian support-radius="1.5" />
+  </mapping:rbf-global-direct>
+
+  <mapping:rbf-global-direct
+    direction="read"
+    from="TestMeshD"
+    to="TestMeshC"
+    constraint="consistent">
+    <basis-function:gaussian support-radius="1.5" cutoff-threshold="1e-6" />
+  </mapping:rbf-global-direct>
+
+  <mapping:rbf-global-direct
+    direction="read"
+    from="TestMeshE"
+    to="TestMeshD"
+    constraint="consistent">
+    <basis-function:gaussian shape-parameter="4.55" cutoff-threshold="1e-6" />
+  </mapping:rbf-global-direct>
+
+</configuration>


### PR DESCRIPTION
## Main changes of this PR
Added a configurable XML attribute to the Gaussian RBF basis function that was hardcoded 1e-9.

## Motivation and additional information
Closes #1265 

The Gaussian RBF values are inter related. PR #1163 added support-radius as an alternative to shape-parameter, but the conversion between them used a hardcoded threshold of 1e-9. This pr makes it user configurable, default to 1e-9 for backward compatibility.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
