### PR TITLE
Add expression templates for default filter and formatter 

### DIFF
--- a/src/logging/LogConfiguration.cpp
+++ b/src/logging/LogConfiguration.cpp
@@ -166,6 +166,38 @@ const std::string BackendConfiguration::default_formatter = "(%Rank%) %TimeStamp
 const std::string BackendConfiguration::default_type      = "stream";
 const std::string BackendConfiguration::default_output    = "stdout";
 
+static boost::log::formatter createDefaultFormatter()
+{
+  namespace expr    = boost::log::expressions;
+  namespace trivial = boost::log::trivial;
+  auto severity     = expr::attr<trivial::severity_level>("Severity");
+  return expr::stream
+         << "("
+         << expr::attr<int>("Rank")
+         << ") "
+         << expr::format_date_time<boost::posix_time::ptime>("TimeStamp", "%H:%M:%S")
+         << " ["
+         << expr::attr<std::string>("Module")
+         << "]:"
+         << expr::attr<int>("Line")
+         << " in "
+         << expr::attr<std::string>("Function")
+         << ": "
+         << expr::if_(severity == trivial::error)[expr::stream << "\033[31mERROR: "]
+         << expr::if_(severity == trivial::warning)[expr::stream << "\033[36mWARNING: ]"]
+         << "\033[0m"
+         << expr::smessage;
+}
+
+static boost::log::filter createDefaultFilter()
+{
+  namespace expr    = boost::log::expressions;
+  namespace trivial = boost::log::trivial;
+  auto severity     = trivial::severity;
+  auto rank         = expr::attr<int>("Rank");
+  return expr::has_attr("preCICE") && expr::attr<bool>("preCICE") && (severity > trivial::debug) && !((severity == trivial::info) && (rank != 0));
+}
+
 void BackendConfiguration::setOption(std::string key, std::string value)
 {
   boost::algorithm::to_lower(key);
@@ -263,10 +295,19 @@ void setupLogging(LoggingConfiguration configs, bool enabled)
 
     // Setup sink
     auto sink = boost::make_shared<boost::log::sinks::synchronous_sink<StreamBackend>>(backend);
-    sink->set_formatter(boost::log::parse_formatter(config.format));
 
+    // Set formatter
+    if (config.format == BackendConfiguration::default_formatter) {
+      sink->set_formatter(createDefaultFormatter());
+    } else {
+      sink->set_formatter(boost::log::parse_formatter(config.format));
+    }
+
+    // Set filter
     if (config.filter.empty()) {
       sink->set_filter(boost::log::expressions::attr<bool>("preCICE") == true);
+    } else if (config.filter == BackendConfiguration::default_filter) {
+      sink->set_filter(createDefaultFilter());
     } else {
       // We extend the filter here to filter all log entries not originating from preCICE.
       sink->set_filter(boost::log::parse_filter("%preCICE% & ( " + config.filter + " )"));


### PR DESCRIPTION
## Main changes of this PR
- Added createDefaultFormatter(), createDefaultFilter() using Boost.Log expression templates to replicate existing formatter, filter strings.
- Updated sink to use expression based implementations when configured filter, formatter equals default.
- Runtime parsing for all custom user defined filter, formatters is unchanged.

## Motivation and additional information
Expression templates perform better than string parsed filters, formatters, since type are known at compile time and no runtime parsing is required.
Closes #1428 

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
