### PR TITLE
Make Participant API thread-safe via a single coarse-grained mutex

### DIFF
--- a/src/precice/Participant.cpp
+++ b/src/precice/Participant.cpp
@@ -45,73 +45,87 @@ Participant::~Participant() = default;
 
 void Participant::initialize()
 {
+  std::scoped_lock lock{_mutex};
   _impl->initialize();
 }
 
 void Participant::advance(
     double computedTimeStepSize)
 {
+  std::scoped_lock lock{_mutex};
   _impl->advance(computedTimeStepSize);
 }
 
 void Participant::finalize()
 {
+  std::scoped_lock lock{_mutex};
   return _impl->finalize();
 }
 
 int Participant::getMeshDimensions(::precice::string_view meshName) const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->getMeshDimensions(toSV(meshName));
 }
 
 int Participant::getDataDimensions(::precice::string_view meshName, ::precice::string_view dataName) const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->getDataDimensions(toSV(meshName), toSV(dataName));
 }
 
 bool Participant::isCouplingOngoing() const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->isCouplingOngoing();
 }
 
 bool Participant::isTimeWindowComplete() const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->isTimeWindowComplete();
 }
 
 double Participant::getMaxTimeStepSize() const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->getMaxTimeStepSize();
 }
 
 bool Participant::requiresInitialData()
 {
+  std::scoped_lock lock{_mutex};
   return _impl->requiresInitialData();
 }
 
 bool Participant::requiresReadingCheckpoint()
 {
+  std::scoped_lock lock{_mutex};
   return _impl->requiresReadingCheckpoint();
 }
 
 bool Participant::requiresWritingCheckpoint()
 {
+  std::scoped_lock lock{_mutex};
   return _impl->requiresWritingCheckpoint();
 }
 
 bool Participant::requiresMeshConnectivityFor(::precice::string_view meshName) const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->requiresMeshConnectivityFor(toSV(meshName));
 }
 
 void Participant::resetMesh(::precice::string_view meshName)
 {
+  std::scoped_lock lock{_mutex};
   return _impl->resetMesh(toSV(meshName));
 }
 
 bool Participant::requiresGradientDataFor(::precice::string_view meshName,
                                           ::precice::string_view dataName) const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->requiresGradientDataFor(toSV(meshName), toSV(dataName));
 }
 
@@ -119,12 +133,14 @@ VertexID Participant::setMeshVertex(
     ::precice::string_view        meshName,
     ::precice::span<const double> coordinates)
 {
+  std::scoped_lock lock{_mutex};
   return _impl->setMeshVertex(toSV(meshName), coordinates);
 }
 
 int Participant::getMeshVertexSize(
     ::precice::string_view meshName) const
 {
+  std::scoped_lock lock{_mutex};
   return _impl->getMeshVertexSize(toSV(meshName));
 }
 
@@ -133,6 +149,7 @@ void Participant::setMeshVertices(
     ::precice::span<const double> coordinates,
     ::precice::span<VertexID>     ids)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshVertices(toSV(meshName), coordinates, ids);
 }
 
@@ -141,6 +158,7 @@ void Participant::setMeshEdge(
     VertexID               first,
     VertexID               second)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshEdge(toSV(meshName), first, second);
 }
 
@@ -148,6 +166,7 @@ void Participant::setMeshEdges(
     ::precice::string_view          meshName,
     ::precice::span<const VertexID> ids)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshEdges(toSV(meshName), ids);
 }
 
@@ -157,6 +176,7 @@ void Participant::setMeshTriangle(
     VertexID               second,
     VertexID               third)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshTriangle(toSV(meshName), first, second, third);
 }
 
@@ -164,6 +184,7 @@ void Participant::setMeshTriangles(
     ::precice::string_view          meshName,
     ::precice::span<const VertexID> ids)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshTriangles(toSV(meshName), ids);
 }
 
@@ -174,6 +195,7 @@ void Participant::setMeshQuad(
     VertexID               third,
     VertexID               fourth)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshQuad(toSV(meshName), first, second, third, fourth);
 }
 
@@ -181,6 +203,7 @@ void Participant::setMeshQuads(
     ::precice::string_view          meshName,
     ::precice::span<const VertexID> ids)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshQuads(toSV(meshName), ids);
 }
 
@@ -191,6 +214,7 @@ void Participant::setMeshTetrahedron(
     VertexID               third,
     VertexID               fourth)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshTetrahedron(toSV(meshName), first, second, third, fourth);
 }
 
@@ -198,6 +222,7 @@ void Participant::setMeshTetrahedra(
     ::precice::string_view          meshName,
     ::precice::span<const VertexID> ids)
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshTetrahedra(toSV(meshName), ids);
 }
 
@@ -207,6 +232,7 @@ void Participant::writeData(
     ::precice::span<const VertexID> ids,
     ::precice::span<const double>   values)
 {
+  std::scoped_lock lock{_mutex};
   _impl->writeData(toSV(meshName), toSV(dataName), ids, values);
 }
 
@@ -217,6 +243,7 @@ void Participant::readData(
     double                          relativeReadTime,
     ::precice::span<double>         values) const
 {
+  std::scoped_lock lock{_mutex};
   _impl->readData(toSV(meshName), toSV(dataName), ids, relativeReadTime, values);
 }
 
@@ -227,6 +254,7 @@ void Participant::mapAndReadData(
     double                        relativeReadTime,
     ::precice::span<double>       values) const
 {
+  std::scoped_lock lock{_mutex};
   _impl->mapAndReadData(toSV(meshName), toSV(dataName), coordinates, relativeReadTime, values);
 }
 
@@ -236,12 +264,14 @@ void Participant::writeAndMapData(
     ::precice::span<const double> coordinates,
     ::precice::span<const double> values)
 {
+  std::scoped_lock lock{_mutex};
   _impl->writeAndMapData(toSV(meshName), toSV(dataName), coordinates, values);
 }
 
 void Participant::setMeshAccessRegion(::precice::string_view        meshName,
                                       ::precice::span<const double> boundingBox) const
 {
+  std::scoped_lock lock{_mutex};
   _impl->setMeshAccessRegion(toSV(meshName), boundingBox);
 }
 
@@ -249,6 +279,7 @@ void Participant::getMeshVertexIDsAndCoordinates(::precice::string_view    meshN
                                                  ::precice::span<VertexID> ids,
                                                  ::precice::span<double>   coordinates) const
 {
+  std::scoped_lock lock{_mutex};
   _impl->getMeshVertexIDsAndCoordinates(toSV(meshName), ids, coordinates);
 }
 

--- a/src/precice/Participant.hpp
+++ b/src/precice/Participant.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <precice/Version.h>
 #include <precice/export.h>
 #include <precice/span.hpp>
@@ -1212,6 +1213,9 @@ public:
 private:
   /// Pointer to implementation of Participant.
   std::unique_ptr<impl::ParticipantImpl> _impl;
+
+  /// Internal lock to make API calls thread-safe.
+  mutable std::mutex _mutex;
 
   // @brief To allow white box tests.
   friend struct testing::WhiteboxAccessor;


### PR DESCRIPTION
## Summary

This PR addresses issue #2407 by introducing a coarse-grained `std::mutex` at the public `Participant` API boundary, making all API calls safe to call from multiple threads without risking data races or undefined behaviour.

## Motivation

preCICE is often embedded in parallel solver codes that may call the `Participant` API from multiple threads — for example, when different solver components (e.g. fluid and thermal) are managed on separate threads but share a single `Participant` instance. Without synchronisation, concurrent calls to methods like `writeData`, `readData`, `advance`, or any mesh-manipulation routines can produce data races on the internal `ParticipantImpl` state.

## What changed

**`src/precice/Participant.hpp`**
- Added `#include <mutex>` to the header.
- Added a `mutable std::mutex _mutex` to the private section of the `Participant` class.
  Using `mutable` allows const-qualified methods (e.g. `readData`, `isCouplingOngoing`) to acquire the lock without removing their `const` qualification.

**`src/precice/Participant.cpp`**
- Added `std::scoped_lock lock{_mutex};` as the first line of every non-constructor, non-destructor public method.
  `std::scoped_lock` is RAII, exception-safe, and available since C++17 (which preCICE already requires).

## Design notes

- **Granularity**: A single mutex at the API boundary is the simplest correct approach. It serialises all concurrent API calls, which is safe and has negligible overhead in practice — the actual computation is in the solver, not here. Finer-grained locking (e.g. per-mesh or per-data locks) would require invasive changes across `ParticipantImpl`, `ReadDataContext`, `WriteDataContext`, and `Mesh`, and would be a larger, separate effort.
- **`readData` / `writeData`**: These methods are locked just like the rest. They access internal waveform storage and coupling-scheme time state, which can be modified concurrently by `advance()`. Leaving them unprotected would introduce subtle time-dependent bugs.
- **Constructors / Destructor**: Not locked — it is the caller's responsibility to ensure a `Participant` object is not used from multiple threads while still being constructed or destroyed (standard C++ rule).

## Testing

Compiled and ran the full test suite locally (1290 tests, covering unit, integration, and parallel MPI scenarios). All tests pass.

```
100% tests passed, 0 tests failed out of 1290
```

Closes #2407