### PR TITLE
Simplify mapping sanity checks in ParticipantConfiguration

### DIFF
--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -441,10 +441,6 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     // sanity checks
     if (confMapping.direction == mapping::MappingConfiguration::Direction::READ) {
       // A read mapping maps from received to provided
-      PRECICE_CHECK(participant->isMeshReceived(fromMesh) || confMapping.toMesh->isJustInTime() || participant->isMeshProvided(toMesh),
-                    "A read mapping of participant \"{}\" needs to map from a received to a provided mesh, but in this case they are swapped. "
-                    "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a write mapping instead?",
-                    participant->getName(), confMapping.toMesh->getName(), confMapping.fromMesh->getName());
       PRECICE_CHECK(participant->isMeshReceived(fromMesh),
                     "Participant \"{}\" has a read mapping from mesh \"{}\", without receiving it. "
                     "Please add a receive-mesh tag with name=\"{}\"",
@@ -456,10 +452,6 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                     participant->getName(), toMesh, toMesh);
     } else {
       // A write mapping maps from provided to received
-      PRECICE_CHECK(confMapping.fromMesh->isJustInTime() || participant->isMeshProvided(fromMesh) || participant->isMeshReceived(toMesh),
-                    "A write mapping of participant \"{}\" needs to map from a provided to a received mesh, but in this case they are swapped. "
-                    "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a read mapping instead?",
-                    participant->getName(), confMapping.toMesh->getName(), confMapping.fromMesh->getName());
       // The just-in-time mesh cannot be on the "to" mesh, as only the combinations read-consistent and write-conservative are allowed
       PRECICE_CHECK(confMapping.fromMesh->isJustInTime() || participant->isMeshProvided(fromMesh),
                     "Participant \"{}\" has a write mapping from mesh \"{}\", without providing it. "


### PR DESCRIPTION
## Main changes of this PR

- Removed the redundant "swapped mapping" sanity checks in `ParticipantConfiguration::finishParticipantConfiguration` (the ones that said "needs to map from received to provided / provided to received, but they are swapped").
- Left the specific checks as-is — they already fail with clearer messages like "without receiving it" / "without providing it" and tell you which tag to add.

## Motivation and additional information

Closes #2156.

The issue pointed out that after #2124 the first check in each branch (read vs write) was effectively dead: if that check would fail, one of the two following checks would already have failed with a better message. So we're just deleting the redundant part. Behavior is unchanged — invalid configs still fail, same messages for the user, less code to maintain.

## Author's checklist

* [x] I used the pre-commit hook and ran `pre-commit run --all` on the branch.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes.
* [ ] I added a test to cover the proposed changes.
* [ ] For breaking changes: I documented them in the porting guide.
* [x] I stuck to C++17 and CMake 3.22.1.
* [x] Single commit, squashed.
* [ ] I ran systemtests (or skipped for this minor change).

## Reviewers' checklist

* [ ] Changelog makes sense (if any).
* [ ] Code changes are clear.