### PR TITLE
Fix inconsistent naming in mesh Fortran API

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -232,7 +232,7 @@ jobs:
     - name: Install pip packages
       run: pip3 install numpy polars
     - name: Install preCICE dependencies
-      run: brew install --overwrite --quiet eigen libxml2 boost petsc openmpi ninja
+      run: brew install --build-from-source --only-dependencies --overwrite precice
     - name: Generate build directory
       run: mkdir -p build
     - name: Configure

--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -33,7 +33,7 @@ set(CPACK_PACKAGE_VERSION "${preCICE_VERSION}")
 set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${CPACK_PACKAGE_VERSION}_${CPACK_SYSTEM_NAME}")
 set(CPACK_PACKAGE_VENDOR "precice.org")
 set(CPACK_PACKAGE_CONTACT "The precice developers <precice@mailman.informatik.uni-stuttgart.de>")
-set(CPACK_PACKAGE_DESCRIPTION "preCICE (Precise Code Interaction Coupling Environment) is a coupling library for partitioned multi-physics simulations, including, but not restricted to fluid-structure interaction and conjugate heat transfer simulations. Partitioned means that preCICE couples existing programs (solvers) capable of simulating a subpart of the complete physics involved in a simulation. This allows for the high flexibility that is needed to keep a decent time-to-solution for complex multi-physics scenarios.")
+set(CPACK_PACKAGE_DESCRIPTION "preCICE (Precise Code Interaction Coupling Environment) is a coupling library and ecosystem for general partitioned multi-physics and multi-scale simulations, including surface and volume coupling. Partitioned means that preCICE couples existing programs (solvers) capable of simulating a subpart of the complete physics involved in a simulation. This allows for the high flexibility that is needed to keep a decent time-to-solution for complex coupled problems. This package provides the core library.")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Precise Code Interaction Coupling Environment")
 set(CPACK_PACKAGE_EXECUTABLES "testprecice;precice-tools")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://precice.org")
@@ -77,13 +77,13 @@ set(CPACK_DEBIAN_PACKAGE_RECOMMENDS "python3")
 
 set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "\
- preCICE is a coupling library for partitioned multi-physics simulations,\n\
- including, but not restricted to fluid-structure interaction and\n\
- conjugate heat transfer simulations.\n\
+ preCICE is a coupling library and ecosystem for general partitioned multi-physics\n\
+ and multi-scale simulations, including surface and volume coupling.\n\
  Partitioned means that preCICE couples existing programs (solvers) capable of\n\
  simulating a subpart of the complete physics involved in a simulation.\n\
  This allows for the high flexibility that is needed to keep a decent\n\
- time-to-solution for complex multi-physics scenarios.\
+ time-to-solution for complex coupled problems.\n\
+ This package provides the core library.\
 ")
 set(CPACK_DEBIAN_PACKAGE_CONTROL_STRUCT_PERMISSION TRUE)
 set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${preCICE_SOURCE_DIR}/tools/releasing/packaging/debian/triggers")

--- a/docs/changelog/2446.md
+++ b/docs/changelog/2446.md
@@ -1,0 +1,1 @@
+- Fixed a race condition in the two-way initialization process that can cause a crash

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -688,12 +688,16 @@ void ReceivedPartition::createOwnerInformation()
     // Exchange list of shared vertices with the neighbor
     // to store send requests.
     std::vector<com::PtrRequest> vertexListRequests;
+    vertexListRequests.reserve(2 * sharedVerticesSendMap.size());
+    // to keep all send buffers alive until the async sends are complete
+    std::vector<int> vertexListSizeSendBuffers;
+    vertexListSizeSendBuffers.reserve(sharedVerticesSendMap.size()); // make sure there are no reallocations
 
     for (auto &receivingRank : sharedVerticesSendMap) {
-      int  sendSize = receivingRank.second.size();
-      auto request  = utils::IntraComm::getCommunication()->aSend(sendSize, receivingRank.first);
+      vertexListSizeSendBuffers.push_back(static_cast<int>(receivingRank.second.size()));
+      auto request = utils::IntraComm::getCommunication()->aSend(vertexListSizeSendBuffers.back(), receivingRank.first);
       vertexListRequests.push_back(request);
-      if (sendSize != 0) {
+      if (vertexListSizeSendBuffers.back() != 0) {
         auto request = utils::IntraComm::getCommunication()->aSend(span<const int>{receivingRank.second}, receivingRank.first);
         vertexListRequests.push_back(request);
       }

--- a/src/precice/config/ParticipantConfiguration.cpp
+++ b/src/precice/config/ParticipantConfiguration.cpp
@@ -441,10 +441,6 @@ void ParticipantConfiguration::finishParticipantConfiguration(
     // sanity checks
     if (confMapping.direction == mapping::MappingConfiguration::Direction::READ) {
       // A read mapping maps from received to provided
-      PRECICE_CHECK(participant->isMeshReceived(fromMesh) || confMapping.toMesh->isJustInTime() || participant->isMeshProvided(toMesh),
-                    "A read mapping of participant \"{}\" needs to map from a received to a provided mesh, but in this case they are swapped. "
-                    "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a write mapping instead?",
-                    participant->getName(), confMapping.toMesh->getName(), confMapping.fromMesh->getName());
       PRECICE_CHECK(participant->isMeshReceived(fromMesh),
                     "Participant \"{}\" has a read mapping from mesh \"{}\", without receiving it. "
                     "Please add a receive-mesh tag with name=\"{}\"",
@@ -456,10 +452,6 @@ void ParticipantConfiguration::finishParticipantConfiguration(
                     participant->getName(), toMesh, toMesh);
     } else {
       // A write mapping maps from provided to received
-      PRECICE_CHECK(confMapping.fromMesh->isJustInTime() || participant->isMeshProvided(fromMesh) || participant->isMeshReceived(toMesh),
-                    "A write mapping of participant \"{}\" needs to map from a provided to a received mesh, but in this case they are swapped. "
-                    "Did you intent to map from mesh \"{}\" to mesh \"{}\", or use a read mapping instead?",
-                    participant->getName(), confMapping.toMesh->getName(), confMapping.fromMesh->getName());
       // The just-in-time mesh cannot be on the "to" mesh, as only the combinations read-consistent and write-conservative are allowed
       PRECICE_CHECK(confMapping.fromMesh->isJustInTime() || participant->isMeshProvided(fromMesh),
                     "Participant \"{}\" has a write mapping from mesh \"{}\", without providing it. "


### PR DESCRIPTION
## Main changes of this PR
This PR renames the Fortran functions for consistency with C/C++ naming scheme. The following functions have been changed to follow the C/C++ naming scheme to include 'mesh' in the name. 

precicef_set_vertex_, precicef_set_edge_, precicef_set_triangle_, precicef_set_quad_, and precicef_set_tetrahedron 

Old names are kept as deprecated wrappers for backward compatibility.
## Motivation and additional information

Closes #2248

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [x] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
