### PR TITLE
Add integration tests for geometric-filter on-primary-rank

### DIFF
--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPIFilterOnPrimaryRank.cpp
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPIFilterOnPrimaryRank.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(DistributedCommunication)
+PRECICE_TEST_SETUP("Fluid"_on(2_ranks), "Structure"_on(2_ranks))
+BOOST_AUTO_TEST_CASE(TestDistributedCommunicationP2PMPIFilterOnPrimaryRank)
+{
+  PRECICE_TEST();
+  runTestDistributedCommunication(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DistributedCommunication
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPIFilterOnPrimaryRank.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPIFilterOnPrimaryRank.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Forces" />
+  <data:vector name="Velocities" />
+
+  <mesh name="FluidMesh" dimensions="3">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <mesh name="StructureMesh" dimensions="3">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <participant name="Fluid">
+    <provide-mesh name="FluidMesh" />
+    <receive-mesh name="StructureMesh" from="Structure" geometric-filter="on-primary-rank" />
+    <write-data name="Forces" mesh="FluidMesh" />
+    <read-data name="Velocities" mesh="FluidMesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="FluidMesh"
+      to="StructureMesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="StructureMesh"
+      to="FluidMesh"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="Structure">
+    <provide-mesh name="StructureMesh" />
+    <write-data name="Velocities" mesh="StructureMesh" />
+    <read-data name="Forces" mesh="StructureMesh" />
+  </participant>
+
+  <m2n:mpi acceptor="Fluid" connector="Structure" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Fluid" second="Structure" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure" />
+    <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSocketsFilterOnPrimaryRank.cpp
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSocketsFilterOnPrimaryRank.cpp
@@ -1,0 +1,22 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include "helpers.hpp"
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Parallel)
+BOOST_AUTO_TEST_SUITE(DistributedCommunication)
+PRECICE_TEST_SETUP("Fluid"_on(2_ranks), "Structure"_on(2_ranks))
+BOOST_AUTO_TEST_CASE(TestDistributedCommunicationP2PSocketsFilterOnPrimaryRank)
+{
+  PRECICE_TEST();
+  runTestDistributedCommunication(context.config(), context);
+}
+
+BOOST_AUTO_TEST_SUITE_END() // Integration
+BOOST_AUTO_TEST_SUITE_END() // Parallel
+BOOST_AUTO_TEST_SUITE_END() // DistributedCommunication
+
+#endif // PRECICE_NO_MPI

--- a/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSocketsFilterOnPrimaryRank.xml
+++ b/tests/parallel/distributed-communication/TestDistributedCommunicationP2PSocketsFilterOnPrimaryRank.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:vector name="Forces" />
+  <data:vector name="Velocities" />
+
+  <mesh name="FluidMesh" dimensions="3">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <mesh name="StructureMesh" dimensions="3">
+    <use-data name="Forces" />
+    <use-data name="Velocities" />
+  </mesh>
+
+  <participant name="Fluid">
+    <provide-mesh name="FluidMesh" />
+    <receive-mesh name="StructureMesh" from="Structure" geometric-filter="on-primary-rank" />
+    <write-data name="Forces" mesh="FluidMesh" />
+    <read-data name="Velocities" mesh="FluidMesh" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="FluidMesh"
+      to="StructureMesh"
+      constraint="conservative" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="StructureMesh"
+      to="FluidMesh"
+      constraint="consistent" />
+  </participant>
+
+  <participant name="Structure">
+    <provide-mesh name="StructureMesh" />
+    <write-data name="Velocities" mesh="StructureMesh" />
+    <read-data name="Forces" mesh="StructureMesh" />
+  </participant>
+
+  <m2n:sockets acceptor="Fluid" connector="Structure" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="Fluid" second="Structure" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="Forces" mesh="StructureMesh" from="Fluid" to="Structure" />
+    <exchange data="Velocities" mesh="StructureMesh" from="Structure" to="Fluid" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -70,7 +70,9 @@ target_sources(testprecice
     tests/parallel/direct-mesh-access/helpers.hpp
     tests/parallel/distributed-communication/TestDistributedCommunicationGatherScatterMPI.cpp
     tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPI.cpp
+    tests/parallel/distributed-communication/TestDistributedCommunicationP2PMPIFilterOnPrimaryRank.cpp
     tests/parallel/distributed-communication/TestDistributedCommunicationP2PSockets.cpp
+    tests/parallel/distributed-communication/TestDistributedCommunicationP2PSocketsFilterOnPrimaryRank.cpp
     tests/parallel/distributed-communication/helpers.cpp
     tests/parallel/distributed-communication/helpers.hpp
     tests/parallel/gather-scatter/EnforceGatherScatterEmptyPrimaryRank.cpp


### PR DESCRIPTION
Closes #1280 Add tests to check the filter attribute `on-primary-rank`

## Main changes of this PR
This PR aims to cover the integration tests to check the filter attribute `on-primary-rank` that is fully implemented but is not tested explicitly yet.

This PR adds two tests for testing the `on-primary-rank` as follows:

- `TestDistributedCommunicationP2PMPIFilterOnPrimaryRank` (with MPI P2P communication)
- `TestDistributedCommunicationP2PSocketsFilterOnPrimaryRank` (with TCP/IP sockets communication)

These tests are similar to the ones being used to test the `on-secondary-rank` but with the modified attribute `on-primary-rank`.

## Testing

Both the tests successfully passed locally.

<img width="1458" height="277" alt="Screenshot 2026-03-04 180208" src="https://github.com/user-attachments/assets/0398f57f-41c2-47d6-987f-49a34b0bd68a" />




## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->

