### PR TITLE
Enhance preconditioner warnings with sub-vector names

### DIFF
--- a/src/acceleration/AitkenAcceleration.cpp
+++ b/src/acceleration/AitkenAcceleration.cpp
@@ -42,8 +42,12 @@ void AitkenAcceleration::initialize(const DataMap &cplData)
   // Accumulate number of entries
   // Size for each subvector needed for preconditioner
   std::vector<std::size_t> subVectorSizes;
-  // Gather sizes
-  std::transform(_primaryDataIDs.cbegin(), _primaryDataIDs.cend(), std::back_inserter(subVectorSizes), [&cplData](const auto &d) { return cplData.at(d)->getSize(); });
+  // Gather sizes and names
+  std::vector<std::string> subVectorNames;
+  for (const auto &d : _primaryDataIDs) {
+    subVectorSizes.push_back(cplData.at(d)->getSize());
+    subVectorNames.push_back(cplData.at(d)->getDataName());
+  }
   // The accumulated sum
   Eigen::Index entries = std::accumulate(subVectorSizes.cbegin(), subVectorSizes.cend(), static_cast<Eigen::Index>(0));
 
@@ -52,7 +56,7 @@ void AitkenAcceleration::initialize(const DataMap &cplData)
   _values       = Eigen::VectorXd::Zero(entries);
   _oldValues    = Eigen::VectorXd::Zero(entries);
   if (_primaryDataIDs.size() > 1) {
-    _preconditioner->initialize(subVectorSizes);
+    _preconditioner->initialize(subVectorSizes, subVectorNames);
   }
 }
 

--- a/src/acceleration/BaseQNAcceleration.cpp
+++ b/src/acceleration/BaseQNAcceleration.cpp
@@ -743,9 +743,13 @@ void BaseQNAcceleration::initializeVectorsAndPreconditioner(const DataMap &cplDa
   _qrV.reset();
   _qrV.setGlobalRows(getPrimaryLSSystemRows());
 
-  std::vector<size_t> subVectorSizes; // needed for preconditioner
-  std::transform(_primaryDataIDs.cbegin(), _primaryDataIDs.cend(), std::back_inserter(subVectorSizes), [&cplData, windowStart, this](const auto &d) { return _primaryTimeGrids.value().getTimeGridAfter(d, windowStart).size() * cplData.at(d)->getSize(); });
-  _preconditioner->initialize(subVectorSizes);
+  std::vector<size_t>      subVectorSizes; // needed for preconditioner
+  std::vector<std::string> subVectorNames; // needed for preconditioner warnings
+  for (const auto &d : _primaryDataIDs) {
+    subVectorSizes.push_back(_primaryTimeGrids.value().getTimeGridAfter(d, windowStart).size() * cplData.at(d)->getSize());
+    subVectorNames.push_back(cplData.at(d)->getDataName());
+  }
+  _preconditioner->initialize(subVectorSizes, subVectorNames);
 
   specializedInitializeVectorsAndPreconditioner(cplData);
 }

--- a/src/acceleration/impl/ConstantPreconditioner.cpp
+++ b/src/acceleration/impl/ConstantPreconditioner.cpp
@@ -13,10 +13,10 @@ ConstantPreconditioner::ConstantPreconditioner(std::vector<double> factors)
 {
 }
 
-void ConstantPreconditioner::initialize(std::vector<size_t> &svs)
+void ConstantPreconditioner::initialize(std::vector<size_t> &svs, const std::vector<std::string> &svNames)
 {
   PRECICE_TRACE();
-  Preconditioner::initialize(svs);
+  Preconditioner::initialize(svs, svNames);
 
   // is always constant by definition
   _frozen = true;

--- a/src/acceleration/impl/ConstantPreconditioner.hpp
+++ b/src/acceleration/impl/ConstantPreconditioner.hpp
@@ -19,7 +19,7 @@ public:
    */
   ~ConstantPreconditioner() override = default;
 
-  void initialize(std::vector<size_t> &svs) override;
+  void initialize(std::vector<size_t> &svs, const std::vector<std::string> &svNames = {}) override;
 
 private:
   /**

--- a/src/acceleration/impl/Preconditioner.hpp
+++ b/src/acceleration/impl/Preconditioner.hpp
@@ -34,11 +34,12 @@ public:
    * @brief initialize the preconditioner
    * @param size of the pp system (e.g. rows of V)
    */
-  virtual void initialize(std::vector<size_t> &svs)
+  virtual void initialize(std::vector<size_t> &svs, const std::vector<std::string> &svNames = {})
   {
     PRECICE_TRACE();
 
     _subVectorSizes = svs;
+    _subVectorNames = svNames;
 
     // Compute offsets of each subvector
     _subVectorOffsets.resize(_subVectorSizes.size(), 0);
@@ -220,6 +221,9 @@ protected:
 
   /// Sizes of each sub-vector, i.e. each coupling data
   std::vector<size_t> _subVectorSizes;
+
+  /// Names of each sub-vector, if provided
+  std::vector<std::string> _subVectorNames;
 
   /// Offsets of each sub-vector in concatenated data, i.e. each coupling data
   std::vector<size_t> _subVectorOffsets;

--- a/src/acceleration/impl/ResidualPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualPreconditioner.cpp
@@ -26,10 +26,18 @@ void ResidualPreconditioner::_update_(bool                   timeWindowComplete,
 
     for (size_t k = 0; k < _subVectorSizes.size(); k++) {
       if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
-        PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
-                     "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
-                     "check if the coupling data values of one solver is zero in the first iteration. "
-                     "The preconditioner scaling factors were not applied for this iteration.");
+        if (!_subVectorNames.empty()) {
+          PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero (data: {}). "
+                       "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+                       "check if the coupling data values of one solver is zero in the first iteration. "
+                       "The preconditioner scaling factors were not applied for this iteration.",
+                       _subVectorNames[k]);
+        } else {
+          PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
+                       "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+                       "check if the coupling data values of one solver is zero in the first iteration. "
+                       "The preconditioner scaling factors were not applied for this iteration.");
+        }
       } else {
         for (size_t i = 0; i < _subVectorSizes[k]; i++) {
           PRECICE_ASSERT(norms[k] > 0.0);

--- a/src/acceleration/impl/ResidualSumPreconditioner.cpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.cpp
@@ -16,10 +16,10 @@ ResidualSumPreconditioner::ResidualSumPreconditioner(
 {
 }
 
-void ResidualSumPreconditioner::initialize(std::vector<size_t> &svs)
+void ResidualSumPreconditioner::initialize(std::vector<size_t> &svs, const std::vector<std::string> &svNames)
 {
   PRECICE_TRACE();
-  Preconditioner::initialize(svs);
+  Preconditioner::initialize(svs, svNames);
 
   _residualSum.resize(_subVectorSizes.size(), 0.0);
   _previousResidualSum.resize(_subVectorSizes.size(), 0.0);
@@ -59,14 +59,25 @@ void ResidualSumPreconditioner::_update_(bool                   timeWindowComple
     if (sum > math::NUMERICAL_ZERO_DIFFERENCE)
       _residualSum[k] += norms[k] / sum;
 
-    PRECICE_WARN_IF(
-        math::equals(_residualSum[k], 0.0),
-        "A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = {}). "
-        "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
-        "check if the coupling data values of one solver is zero in the first iteration. "
-        "The preconditioner scaling factors were not updated for this iteration and the scaling factors "
-        "determined in the previous iteration were used.",
-        _residualSum[k]);
+    if (!_subVectorNames.empty()) {
+      PRECICE_WARN_IF(
+          math::equals(_residualSum[k], 0.0),
+          "A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = {}, data: {}). "
+          "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+          "check if the coupling data values of one solver is zero in the first iteration. "
+          "The preconditioner scaling factors were not updated for this iteration and the scaling factors "
+          "determined in the previous iteration were used.",
+          _residualSum[k], _subVectorNames[k]);
+    } else {
+      PRECICE_WARN_IF(
+          math::equals(_residualSum[k], 0.0),
+          "A sub-vector in the residual-sum preconditioner became numerically zero ( sub-vector = {}). "
+          "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+          "check if the coupling data values of one solver is zero in the first iteration. "
+          "The preconditioner scaling factors were not updated for this iteration and the scaling factors "
+          "determined in the previous iteration were used.",
+          _residualSum[k]);
+    }
   }
 
   // Determine if weights needs to be reset

--- a/src/acceleration/impl/ResidualSumPreconditioner.hpp
+++ b/src/acceleration/impl/ResidualSumPreconditioner.hpp
@@ -21,7 +21,7 @@ public:
    */
   ~ResidualSumPreconditioner() override = default;
 
-  void initialize(std::vector<size_t> &svs) override;
+  void initialize(std::vector<size_t> &svs, const std::vector<std::string> &svNames = {}) override;
 
 private:
   /**

--- a/src/acceleration/impl/ValuePreconditioner.cpp
+++ b/src/acceleration/impl/ValuePreconditioner.cpp
@@ -30,10 +30,18 @@ void ValuePreconditioner::_update_(bool                   timeWindowComplete,
 
   for (size_t k = 0; k < _subVectorSizes.size(); k++) {
     if (norms[k] < math::NUMERICAL_ZERO_DIFFERENCE) {
-      PRECICE_WARN("A sub-vector in the residual preconditioner became numerically zero. "
-                   "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
-                   "check if the coupling data values of one solver is zero in the first iteration. "
-                   "The preconditioner scaling factors were not applied for this iteration.");
+      if (!_subVectorNames.empty()) {
+        PRECICE_WARN("A sub-vector in the value preconditioner became numerically zero (data: {}). "
+                     "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+                     "check if the coupling data values of one solver is zero in the first iteration. "
+                     "The preconditioner scaling factors were not applied for this iteration.",
+                     _subVectorNames[k]);
+      } else {
+        PRECICE_WARN("A sub-vector in the value preconditioner became numerically zero. "
+                     "If this occurred in the second iteration and the initial-relaxation factor is equal to 1.0, "
+                     "check if the coupling data values of one solver is zero in the first iteration. "
+                     "The preconditioner scaling factors were not applied for this iteration.");
+      }
     } else {
       for (size_t i = 0; i < _subVectorSizes[k]; i++) {
         PRECICE_ASSERT(norms[k] > 0.0);


### PR DESCRIPTION
## Main changes of this PR

This PR enhances the warnings produced by `ResidualSumPreconditioner`, `ResidualPreconditioner`, and `ValuePreconditioner` when a sub-vector becomes numerically zero. It modifies the `Preconditioner` interface to recursively pass down and utilize sub-vector names, and updates `AitkenAcceleration` and `BaseQNAcceleration` to pass these data names directly from the `CouplingData`.

## Motivation and additional information

This provides users with better context regarding which data is numerically zero (e.g. `data: "Forces"`), rather than an obscure error. 
Closes #1515.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
