### PR TITLE
Refactor typename getter logic

### DIFF
--- a/src/utils/TypeNames.hpp
+++ b/src/utils/TypeNames.hpp
@@ -1,7 +1,6 @@
 /*
  * Returns pretty type names for various types.
  * Used for generating the XML documentation.
- * They are inlined, so that they don't need to be defined in a separate cpp file.
  */
 
 #pragma once
@@ -11,29 +10,24 @@
 
 namespace precice::utils {
 
-inline std::string getTypeName(const double &var)
+template <typename T>
+constexpr std::string_view getTypeName(const T &)
 {
-  return "float";
-}
+  // if we move to cpp20 can switch this with std::remove_cvref_t
+  using U = std::remove_cv_t<std::remove_reference_t<T>>;
 
-inline std::string getTypeName(const std::string &var)
-{
-  return "string";
-}
-
-inline std::string getTypeName(const bool &var)
-{
-  return "boolean";
-}
-
-inline std::string getTypeName(const int &var)
-{
-  return "integer";
-}
-
-inline std::string getTypeName(Eigen::VectorXd const &var)
-{
-  return "vector";
+  if constexpr (std::is_same_v<U, double>)
+    return "float";
+  else if constexpr (std::is_same_v<U, std::string>)
+    return "string";
+  else if constexpr (std::is_same_v<U, bool>)
+    return "boolean";
+  else if constexpr (std::is_same_v<U, int>)
+    return "integer";
+  else if constexpr (std::is_same_v<U, Eigen::VectorXd>)
+    return "vector";
+  else
+    static_assert(false, "Unsupported type passed to getTypeName()");
 }
 
 } // namespace precice::utils


### PR DESCRIPTION
## Main changes of this PR

Instead of different inlined functions allocating strings, this singular constexpr string_view alternative that first cleans the type by omitting cv and refs before checking via `is_same_v` is more idiomatic and logical.

if the cpp20 draft were to be implemented in the future, note that `std::remove_cv_t<std::remove_ref_t<T>` can be replaced with `std::remove_cvref_t<T>`

I messed up the branch in #2495 so this should match what was expected by @fsimonis i got confused with `is_scalar` and didnt see ur point yes this is much better

## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
