### PR TITLE
Raise error if receive data is declared but not exchanged (#1836)

### DIFF
--- a/docs/changelog/1836.md
+++ b/docs/changelog/1836.md
@@ -1,0 +1,1 @@
+- Raised an error when receive data is declared but not exchanged in the coupling configuration.

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -166,7 +166,12 @@ ParticipantImpl::~ParticipantImpl()
 {
   if (_state != State::Finalized) {
     PRECICE_INFO("Implicitly finalizing in destructor");
-    finalize();
+    try {
+      finalize();
+    } catch (...) {
+      // Suppress exceptions during cleanup so an in-flight exception (e.g. from
+      // initialize()) can propagate to the caller
+    }
   }
 }
 
@@ -1295,6 +1300,12 @@ void ParticipantImpl::mapAndReadData(
                 "Please define a mapping in read direction from the mesh \"{0}\" and omit the \"to\" attribute from the definition. "
                 "Example \"<mapping:nearest-neighbor direction=\"read\" from=\"{0}\" constraint=\"consistent\" />",
                 meshName);
+
+  PRECICE_CHECK(dataContext.hasSamples(),
+                "Data \"{}\" cannot be read from mesh \"{}\" as it contains no samples. "
+                "This is typically a configuration issue of the data flow. "
+                "Check if the data is correctly exchanged to this participant \"{}\" and mapped to mesh \"{}\".",
+                dataName, meshName, _accessorName, meshName);
 
   // Inconsistent sizes will be handled below
   if (coordinates.empty() && values.empty()) {

--- a/tests/serial/configuration/ReceiveDataNotExchanged.cpp
+++ b/tests/serial/configuration/ReceiveDataNotExchanged.cpp
@@ -1,0 +1,62 @@
+#ifndef PRECICE_NO_MPI
+
+#include "testing/Testing.hpp"
+
+#include <precice/precice.hpp>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(Integration)
+BOOST_AUTO_TEST_SUITE(Serial)
+BOOST_AUTO_TEST_SUITE(Configuration)
+
+/// Regression test for #1836: receive data declared but not exchanged should raise
+/// a clear error instead of an assertion when mapping or reading.
+PRECICE_TEST_SETUP("SolverOne"_on(1_rank), "SolverTwo"_on(1_rank))
+BOOST_AUTO_TEST_CASE(ReceiveDataNotExchanged)
+{
+  PRECICE_TEST();
+  precice::Participant interface(context.name, context.config(), context.rank, context.size);
+
+  if (context.isNamed("SolverOne")) {
+    auto   meshName = "MeshOne";
+    double coords[] = {0.1, 1.2};
+    auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+    double dataOne[] = {3.4};
+    interface.writeData(meshName, "DataOne", {&vertexid, 1}, dataOne);
+  } else {
+    auto   meshName = "MeshTwo";
+    double coords[] = {0.12, 1.21};
+    auto   vertexid = interface.setMeshVertex(meshName, coords);
+
+    double dataTwo[] = {7.8};
+    interface.writeData(meshName, "DataTwo", {&vertexid, 1}, dataTwo);
+  }
+
+  if (context.isNamed("SolverOne")) {
+    try {
+      interface.initialize();
+      double            dt       = interface.getMaxTimeStepSize();
+      auto              meshName = "MeshOne";
+      double            dataTwo[1];
+      precice::VertexID vid = 0;
+      interface.readData(meshName, "DataTwo", {&vid, 1}, 0.0, dataTwo);
+      double dataOne[] = {3.4};
+      interface.writeData(meshName, "DataOne", {&vid, 1}, dataOne);
+      interface.advance(dt);
+    } catch (const ::precice::Error &) {
+      // SolverTwo failed during init (receive data not exchanged); partner disconnected
+    }
+  } else {
+    BOOST_CHECK_EXCEPTION(
+        interface.initialize(),
+        ::precice::Error,
+        precice::testing::errorContains("contain any data samples"));
+  }
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/tests/serial/configuration/ReceiveDataNotExchanged.xml
+++ b/tests/serial/configuration/ReceiveDataNotExchanged.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<precice-configuration>
+  <data:scalar name="DataOne" />
+  <data:scalar name="DataTwo" />
+  <data:scalar name="NeverExchanged" />
+
+  <mesh name="MeshOne" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+    <use-data name="NeverExchanged" />
+  </mesh>
+
+  <mesh name="MeshTwo" dimensions="2">
+    <use-data name="DataOne" />
+    <use-data name="DataTwo" />
+    <use-data name="NeverExchanged" />
+  </mesh>
+
+  <participant name="SolverOne">
+    <provide-mesh name="MeshOne" />
+    <write-data name="DataOne" mesh="MeshOne" />
+    <read-data name="DataTwo" mesh="MeshOne" />
+  </participant>
+
+  <participant name="SolverTwo">
+    <receive-mesh name="MeshOne" from="SolverOne" />
+    <provide-mesh name="MeshTwo" />
+    <mapping:nearest-neighbor
+      direction="read"
+      from="MeshOne"
+      to="MeshTwo"
+      constraint="consistent" />
+    <mapping:nearest-neighbor
+      direction="write"
+      from="MeshTwo"
+      to="MeshOne"
+      constraint="conservative" />
+    <write-data name="DataTwo" mesh="MeshTwo" />
+    <read-data name="DataOne" mesh="MeshTwo" />
+    <read-data name="NeverExchanged" mesh="MeshTwo" />
+  </participant>
+
+  <m2n:sockets acceptor="SolverOne" connector="SolverTwo" />
+
+  <coupling-scheme:serial-explicit>
+    <participants first="SolverOne" second="SolverTwo" />
+    <max-time-windows value="1" />
+    <time-window-size value="1.0" />
+    <exchange data="DataOne" mesh="MeshOne" from="SolverOne" to="SolverTwo" />
+    <exchange data="DataTwo" mesh="MeshOne" from="SolverTwo" to="SolverOne" />
+  </coupling-scheme:serial-explicit>
+</precice-configuration>

--- a/tests/tests.cmake
+++ b/tests/tests.cmake
@@ -244,6 +244,7 @@ target_sources(testprecice
     tests/serial/compositional/data/implicit-second/Parallel.cpp
     tests/serial/compositional/data/implicit-second/SerialFirst.cpp
     tests/serial/compositional/data/implicit-second/SerialSecond.cpp
+    tests/serial/configuration/ReceiveDataNotExchanged.cpp
     tests/serial/convergence-measures/helpers.cpp
     tests/serial/convergence-measures/helpers.hpp
     tests/serial/convergence-measures/testConvergenceMeasures1.cpp


### PR DESCRIPTION
- Add hasSamples check in readData and mapAndReadData before reading
- Add PRECICE_CHECK in DataContext::mapData when mapping receive data with no samples
- Suppress destructor exceptions during cleanup so init errors propagate
- Add regression test ReceiveDataNotExchanged

Closes #1836

## Main changes of this PR

- Add checks using `ReadDataContext::hasSamples()` in `ParticipantImpl::readData` and `ParticipantImpl::mapAndReadData`. If receive data has no samples, a clear `precice::Error` is raised instead of continuing and failing later.

- Use the existing `PRECICE_CHECK` in `DataContext::mapData` so that mapping receive data which was declared but never exchanged fails with a clear error message rather than an internal assertion.

- Wrap the implicit `finalize()` call in `ParticipantImpl::~ParticipantImpl()` in a try/catch block. This avoids destructor-time exceptions masking the actual error thrown during `initialize()`.

- Add a regression test (`ReceiveDataNotExchanged.cpp` and `ReceiveDataNotExchanged.xml`) reproducing the configuration from #1836 and verifying that the correct error is raised.

- Add a changelog entry in `docs/changelog/1836.md`.

## Motivation and additional information

The configuration in #1836 declares `<read-data>` for a participant, but the corresponding data is never exchanged.

Before this change, this situation could lead to an assertion failure somewhere in the mapping or initialization logic, which made the problem hard to understand from a user perspective.

With this PR, preCICE now detects that the receive data contains no samples and throws a clear `precice::Error` explaining that the data was declared but never exchanged. The error message points users to check the `<exchange>` configuration.

The regression test ensures this behavior remains covered, and suppressing destructor exceptions ensures that initialization errors are not hidden during cleanup.
   **Local testing**

   `ctest -R "Integration/Serial/Configuration/ReceiveDataNotExchanged" --output-on-failure`

<img width="741" height="502" alt="image" src="https://github.com/user-attachments/assets/ef55d78c-b9ff-417e-87ae-b38607d082d9" />


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate porting guide.
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [x] Do you understand the code changes?