### PR TITLE
Implement RAII for xmlParserCtxt in ConfigParser

### DIFF
--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -188,12 +188,14 @@ int ConfigParser::readXmlFile(std::string const &filePath)
 
   _hash = utils::preciceHash(content);
 
-  xmlParserCtxtPtr ctxt = xmlCreatePushParserCtxt(&SAXHandler, static_cast<void *>(this),
-                                                  content.c_str(), content.size(), nullptr);
+  auto ctxt = std::unique_ptr<xmlParserCtxt, void (*)(xmlParserCtxtPtr)>(
+      xmlCreatePushParserCtxt(&SAXHandler, static_cast<void *>(this),
+                              content.c_str(), content.size(), nullptr),
+      xmlFreeParserCtxt);
 
-  xmlParseChunk(ctxt, nullptr, 0, 1);
-  xmlFreeParserCtxt(ctxt);
-  xmlCleanupParser();
+  PRECICE_CHECK(ctxt != nullptr, "XML parser was unable to create a push parser context for file \"{}\"", filePath);
+
+  xmlParseChunk(ctxt.get(), nullptr, 0, 1);
 
   return 0;
 }


### PR DESCRIPTION
## Main changes of this PR

- Wrapped the raw `xmlParserCtxtPtr` in `std::unique_ptr` with `xmlFreeParserCtxt` as a custom deleter, ensuring the context is freed during stack unwinding if an exception occurs.
- Added a `PRECICE_CHECK` to guard against a null return from `xmlCreatePushParserCtxt` before parsing begins.

## Motivation and additional information

`ConfigParser::readXmlFile` relied on manual cleanup of the libxml2 parser context. If `xmlParseChunk` or a SAX callback threw an exception, `xmlFreeParserCtxt` would be skipped, leaking the context. Additionally, the return value of `xmlCreatePushParserCtxt` was not checked, risking a null pointer dereference on failed initialization.

## Author's checklist
* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist
* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?