### PR TITLE
Modify XML missing attribute context logic

### DIFF
--- a/src/xml/ConfigParser.cpp
+++ b/src/xml/ConfigParser.cpp
@@ -132,7 +132,8 @@ ConfigParser::ConfigParser(std::string_view filePath, const ConfigurationContext
     SubTags.push_back(m_AllTags[0]);
 
   try {
-    connectTags(context, DefTags, SubTags);
+    // parent xml context here is nil, constructed later on.
+    connectTags(context, DefTags, SubTags, "");
   } catch (::precice::Error &) {
     throw;
   } catch (const std::exception &e) {
@@ -222,7 +223,7 @@ auto gatherCandidates(const std::vector<std::shared_ptr<XMLTag>> &DefTags, std::
 }
 } // namespace
 
-void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<std::shared_ptr<XMLTag>> &DefTags, CTagPtrVec &SubTags)
+void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<std::shared_ptr<XMLTag>> &DefTags, CTagPtrVec &SubTags, const std::string &parentXMLCtx)
 {
   std::unordered_set<std::string> usedTags;
 
@@ -262,12 +263,31 @@ void ConfigParser::connectTags(const ConfigurationContext &context, std::vector<
       usedTags.emplace(pDefSubTag->_fullName);
     }
 
+    // generate the current tag context with existing attributes
+    // (we pass it to fullXMLCtx)
+    std::string tagCtx = fmt::format("<{}", expectedName);
+
+    for (const auto &[k, v] : subtag->m_aAttributes) {
+      tagCtx += fmt::format(" {}=\"{}\"", k, v);
+    }
+
+    tagCtx += ">";
+
+    // note that we construct and modify fullXMLCtx
+    // recursively.
+    std::string fullXMLCtx;
+
+    if (!parentXMLCtx.empty())
+      fullXMLCtx = fmt::format("{} inside {}", tagCtx, parentXMLCtx);
+    else
+      fullXMLCtx = tagCtx;
+
     pDefSubTag->_configuredNamespaces[pDefSubTag->_namespace] = true;
-    pDefSubTag->readAttributes(subtag->m_aAttributes);
+    pDefSubTag->readAttributes(subtag->m_aAttributes, fullXMLCtx);
     pDefSubTag->_listener.xmlTagCallback(context, *pDefSubTag);
     pDefSubTag->_configured = true;
 
-    connectTags(context, pDefSubTag->_subtags, subtag->m_aSubTags);
+    connectTags(context, pDefSubTag->_subtags, subtag->m_aSubTags, fullXMLCtx);
 
     pDefSubTag->areAllSubtagsConfigured();
     pDefSubTag->_listener.xmlEndTagCallback(context, *pDefSubTag);

--- a/src/xml/ConfigParser.hpp
+++ b/src/xml/ConfigParser.hpp
@@ -62,8 +62,9 @@ public:
    * @brief Connects the actual tags of an xml layer with the predefined tags
    * @param DefTags predefined tags
    * @param SubTags actual tags from xml file
+   * @param parentXMLCtx parent context of XML config
    */
-  void connectTags(const ConfigurationContext &context, std::vector<std::shared_ptr<precice::xml::XMLTag>> &DefTags, CTagPtrVec &SubTags);
+  void connectTags(const ConfigurationContext &context, std::vector<std::shared_ptr<precice::xml::XMLTag>> &DefTags, CTagPtrVec &SubTags, const std::string &parentXMLCtx);
 
   /// Callback for Start-Tag
   void OnStartElement(

--- a/src/xml/XMLAttribute.hpp
+++ b/src/xml/XMLAttribute.hpp
@@ -78,7 +78,7 @@ public:
     return _hasValidation;
   };
 
-  void readValue(std::string_view tagName, const std::map<std::string, std::string> &aAttributes);
+  void readValue(const std::map<std::string, std::string> &aAttributes, const std::string_view fullXMLCtx);
 
   const std::string &getName() const
   {
@@ -158,14 +158,14 @@ XMLAttribute<ATTRIBUTE_T> &XMLAttribute<ATTRIBUTE_T>::setDefaultValue(const ATTR
 }
 
 template <typename ATTRIBUTE_T>
-void XMLAttribute<ATTRIBUTE_T>::readValue(std::string_view tagName, const std::map<std::string, std::string> &aAttributes)
+void XMLAttribute<ATTRIBUTE_T>::readValue(const std::map<std::string, std::string> &aAttributes, const std::string_view fullXMLCtx)
 {
   PRECICE_TRACE(_name);
   PRECICE_ASSERT(!_read, "Attribute \"" + _name + "\" has already been read.");
 
   const auto position = aAttributes.find(getName());
   if (position == aAttributes.end()) {
-    PRECICE_CHECK(_hasDefaultValue, "The tag <{}> in the configuration is missing required attribute \"{}\".", tagName, _name);
+    PRECICE_CHECK(_hasDefaultValue, "Missing required attribute \"{}\" in {}.", _name, fullXMLCtx);
     set(_value, _defaultValue);
   } else {
     try {

--- a/src/xml/XMLTag.cpp
+++ b/src/xml/XMLTag.cpp
@@ -181,7 +181,7 @@ Eigen::VectorXd XMLTag::getEigenVectorXdAttributeValue(const std::string &name) 
   PRECICE_UNREACHABLE("The XMLAttribute doesn't exist, check its default.");
 }
 
-void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttributes)
+void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttributes, const std::string_view fullXMLCtx)
 {
   PRECICE_TRACE();
 
@@ -212,7 +212,7 @@ void XMLTag::readAttributes(const std::map<std::string, std::string> &aAttribute
   // Read all attributes
   for (auto &attribute : _attributes) {
     std::visit(
-        [this, &aAttributes](auto &attribute) { attribute.readValue(_fullName, aAttributes); },
+        [&aAttributes, fullXMLCtx](auto &attribute) { attribute.readValue(aAttributes, fullXMLCtx); },
         attribute);
   }
 }

--- a/src/xml/XMLTag.hpp
+++ b/src/xml/XMLTag.hpp
@@ -200,7 +200,7 @@ public:
   }
 
   /// reads all attributes of this tag
-  void readAttributes(const std::map<std::string, std::string> &aAttributes);
+  void readAttributes(const std::map<std::string, std::string> &aAttributes, const std::string_view fullXMLCtx);
 
 private:
   mutable logging::Logger _log{"xml::XMLTag"};

--- a/src/xml/tests/ParserTest.cpp
+++ b/src/xml/tests/ParserTest.cpp
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(MissingRequiredAttributeIncludesTagName)
   BOOST_CHECK_EXCEPTION(
       configure(rootTag, ConfigurationContext{}, filename),
       ::precice::Error,
-      ::precice::testing::errorContains("The tag <test-missing-attr> in the configuration is missing required attribute \"required-attr\"."));
+      ::precice::testing::errorContains("Missing required attribute \"required-attr\" in <test-missing-attr> inside <configuration>"));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Main changes of this PR

This change mainly reflects on #2478 , while it did add more context, this commit adds more info about the parent xml context (like the participant name)

If multiple missing attributes exist with same snippet spread across multiple participants, the current logic would still provide a vague output, meanwhile this change can pinpoint the issue directly

This builds upon the work I made in #2497  and is linked to issue #2441 

Here is how the final output looks like:

<img width="930" height="124" alt="image" src="https://github.com/user-attachments/assets/51a05bd0-471b-4040-860f-fd3ad9858be2" />

<img width="937" height="84" alt="image" src="https://github.com/user-attachments/assets/ff55dc4e-09cf-4f24-9045-9a59d1358abb" />


## Motivation and additional information

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
