### PR TITLE
Improve error message when mesh references undefined data

### DIFF
--- a/src/mesh/config/MeshConfiguration.cpp
+++ b/src/mesh/config/MeshConfiguration.cpp
@@ -79,10 +79,19 @@ void MeshConfiguration::xmlTagCallback(
         break;
       }
     }
+    std::vector<std::string> availableData;
+    for (const DataConfiguration::ConfiguredData &data : _dataConfig->data()) {
+      availableData.push_back(data.name);
+    }
     PRECICE_CHECK(found,
-                  "Data with name \"{}\" used by mesh \"{}\" is not defined. "
-                  "Please define a data tag with name=\"{}\".",
-                  name, _meshes.back()->getName(), name);
+                  "Data \"{}\" used by mesh \"{}\" is not defined. "
+                  "Currently defined data tags are: {}. "
+                  "Please add <data:scalar name=\"{}\"/> or <data:vector name=\"{}\"/> to your configuration.",
+                  name,
+                  _meshes.back()->getName(),
+                  fmt::join(availableData, ", "),
+                  name,
+                  name);
   }
 }
 
@@ -113,7 +122,21 @@ void MeshConfiguration::addMesh(
         break;
       }
     }
-    PRECICE_CHECK(found, "Data {0} is not defined. Please define a data tag with name=\"{0}\".", dataNewMesh->getName());
+    // Collect available data names for helpful error output
+    std::vector<std::string> availableData;
+    for (const DataConfiguration::ConfiguredData &data : _dataConfig->data()) {
+      availableData.push_back(data.name);
+    }
+
+    PRECICE_CHECK(found,
+                  "Data \"{}\" used by mesh \"{}\" is not defined. "
+                  "Currently defined data tags are: {}. "
+                  "Please add <data:scalar name=\"{}\"/> or <data:vector name=\"{}\"/> to your configuration.",
+                  dataNewMesh->getName(),
+                  mesh->getName(),
+                  fmt::join(availableData, ", "),
+                  dataNewMesh->getName(),
+                  dataNewMesh->getName());
   }
   _meshes.push_back(mesh);
 }


### PR DESCRIPTION
## Main changes of this PR

- Enhanced the error message in `MeshConfiguration::xmlTagCallback` when  a `<use-data>` tag references an undefined data name.
- The new message includes the mesh name, lists all currently defined data tags, and provides the exact XML to fix the issue.

## Motivation and additional information

Previously, the error only repeated the missing name back to the user:
```
Data with name "Pressure" used by mesh "Fluid-Nodes-Mesh" is not defined. 
Please define a data tag with name="Pressure".
```

The improved message gives actionable context:
```
Data "Pressure" used by mesh "Fluid-Nodes-Mesh" is not defined. 
Currently defined data tags are: CrossSectionLength. 
Please add <data:scalar name="Pressure"/> or <data:vector name="Pressure"/> 
to your configuration.
```

This helps users immediately understand what data exists and exactly 
what XML to add, rather than just restating the problem.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
