### PR TITLE
Add DuMux adapter ref to system-tests.yaml

### DIFF
--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -12,6 +12,7 @@ jobs:
     outputs:
       ref-python-bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}
       ref-calculix-adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}
+      ref-dumux-adapter: ${{ steps.ref-dumux-adapter.outputs.shorthash }}
       ref-fenics-adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}
       ref-openfoam-adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }}
       ref-su2-adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}
@@ -30,6 +31,13 @@ jobs:
         with:
           owner: precice
           repo: calculix-adapter
+          branch: develop
+      - id: ref-dumux-adapter
+        name: Get DuMux adapter ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: dumux-adapter
           branch: develop
       - id: ref-fenics-adapter
         name: Get FEniCS adapter ref
@@ -64,6 +72,7 @@ jobs:
         run: |
           printf 'Python bindings: ${{ steps.ref-python-bindings.outputs.shorthash }}\n ${{ steps.ref-python-bindings.outputs.description }}\n----------\n'
           printf 'CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n'
+          printf 'DuMux adapter: ${{ steps.ref-dumux-adapter.outputs.shorthash }}\n ${{ steps.ref-dumux-adapter.outputs.description }}\n----------\n'
           printf 'FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n'
           printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
           printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
@@ -86,6 +95,12 @@ jobs:
           echo "Description:"
           echo "\`\`\`"
           echo '${{ steps.ref-calculix-adapter.outputs.description }}'
+          echo "\`\`\`"
+          echo "### DuMux adapter"
+          echo "Reference: [\`${{ steps.ref-dumux-adapter.outputs.shorthash }}\`](https://github.com/precice/dumux-adapter/commit/${{ steps.ref-dumux-adapter.outputs.shorthash }})"
+          echo "Description:"
+          echo "\`\`\`"
+          echo '${{ steps.ref-dumux-adapter.outputs.description }}'
           echo "\`\`\`"
           echo "### FEniCS adapter"
           echo "Reference: [\`${{ steps.ref-fenics-adapter.outputs.shorthash }}\`](https://github.com/precice/fenics-adapter/commit/${{ steps.ref-fenics-adapter.outputs.shorthash }})"
@@ -126,6 +141,7 @@ jobs:
         PYTHON_BINDINGS_REF:${{ needs.gather-refs.outputs.ref-python-bindings }},\
         CALCULIX_VERSION:2.20,\
         CALCULIX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-calculix-adapter }},\
+        DUMUX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-dumux-adapter }},\
         FENICS_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-fenics-adapter }},\
         OPENFOAM_EXECUTABLE:openfoam2312,\
         OPENFOAM_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-openfoam-adapter }},\

--- a/.github/workflows/system-tests.yaml
+++ b/.github/workflows/system-tests.yaml
@@ -14,6 +14,7 @@ jobs:
       ref-calculix-adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}
       ref-dumux-adapter: ${{ steps.ref-dumux-adapter.outputs.shorthash }}
       ref-fenics-adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}
+      ref-micro-manager: ${{ steps.ref-micro-manager.outputs.shorthash }}
       ref-openfoam-adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }}
       ref-su2-adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}
       ref-tutorials: ${{ steps.ref-tutorials.outputs.shorthash }}
@@ -46,6 +47,13 @@ jobs:
           owner: precice
           repo: fenics-adapter
           branch: develop
+      - id: ref-micro-manager
+        name: Get Micro-Manager ref
+        uses: nmbgeek/github-action-get-latest-commit@main
+        with:
+          owner: precice
+          repo: micro-manager
+          branch: develop
       - id: ref-openfoam-adapter
         name: Get OpenFOAM adapter ref
         uses: nmbgeek/github-action-get-latest-commit@main
@@ -74,6 +82,7 @@ jobs:
           printf 'CalculiX adapter: ${{ steps.ref-calculix-adapter.outputs.shorthash }}\n ${{ steps.ref-calculix-adapter.outputs.description }}\n----------\n'
           printf 'DuMux adapter: ${{ steps.ref-dumux-adapter.outputs.shorthash }}\n ${{ steps.ref-dumux-adapter.outputs.description }}\n----------\n'
           printf 'FEniCS adapter: ${{ steps.ref-fenics-adapter.outputs.shorthash }}\n ${{ steps.ref-fenics-adapter.outputs.description }}\n----------\n'
+          printf 'Micro-Manager: ${{ steps.ref-micro-manager.outputs.shorthash }}\n ${{ steps.ref-micro-manager.outputs.description }}\n----------\n'
           printf 'OpenFOAM adapter: ${{ steps.ref-openfoam-adapter.outputs.shorthash }} ${{ steps.ref-openfoam-adapter.outputs.description }}\n----------\n'
           printf 'SU2 adapter: ${{ steps.ref-su2-adapter.outputs.shorthash }}\n ${{ steps.ref-su2-adapter.outputs.description }}\n----------\n'
           printf 'Tutorials: ${{ steps.ref-tutorials.outputs.shorthash }} ${{ steps.ref-tutorials.outputs.description }}\n----------\n'
@@ -108,6 +117,12 @@ jobs:
           echo "\`\`\`"
           echo '${{ steps.ref-fenics-adapter.outputs.description }}'
           echo "\`\`\`"
+          echo "### Micro-Manager" >> $GITHUB_STEP_SUMMARY
+          echo "Reference: [\`${{ steps.ref-micro-manager.outputs.shorthash }}\`](https://github.com/precice/micro-manager/commit/${{ steps.ref-micro-manager.outputs.shorthash }})" >> $GITHUB_STEP_SUMMARY
+          echo "Description:" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.ref-micro-manager.outputs.description }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "### OpenFOAM adapter"
           echo "Reference: [\`${{ steps.ref-openfoam-adapter.outputs.shorthash }}\`](https://github.com/precice/openfoam-adapter/commit/${{ steps.ref-openfoam-adapter.outputs.shorthash }})"
           echo "Description:"
@@ -143,6 +158,7 @@ jobs:
         CALCULIX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-calculix-adapter }},\
         DUMUX_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-dumux-adapter }},\
         FENICS_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-fenics-adapter }},\
+        MICRO_MANAGER_REF:${{ needs.gather-refs.outputs.ref-micro-manager }},\
         OPENFOAM_EXECUTABLE:openfoam2312,\
         OPENFOAM_ADAPTER_REF:${{ needs.gather-refs.outputs.ref-openfoam-adapter }},\
         SU2_VERSION:7.5.1,\


### PR DESCRIPTION
## Main changes of this PR

Modifies the [system-tests.yaml workflow](https://github.com/precice/precice/blob/develop/.github/workflows/system-tests.yaml) to get the latest state of the DuMux adapter `develop` branch before triggering the system tests.

@Fujikawas @IshaanDesai As far as I understand, you wanted the Micro-Manager version to be fixed. There is no `MICRO_MANAGER_REF` variable to set.

~~Depends on https://github.com/precice/tutorials/pull/758, see that for previous work.~~ Actually, it does not, it only passes additional arguments.

## Motivation and additional information

Required to actually get the latest version of the DuMux adapter in the system tests. I know that we need to offload this step to the `tutorials` repository, but this is the state we have right now.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* I added a changelog file with `make changelog` if there are user-observable changes since the last release. -> I don't think one is needed.
* [x] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change) -> see [this run](https://github.com/precice/precice/actions/runs/23812435427?pr=2541)

