### PR TITLE
Use release artifacts in docker release

### DIFF
--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -46,6 +46,10 @@ jobs:
     env:
         docker_username: precice
     steps:
+      - name: Print input
+        env:
+          params: "${{ tojson(inputs) }}"
+        run: 'echo "${params}" | jq .'
       - name: Check and clean version
         id: version
         run: |

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -58,6 +58,8 @@ jobs:
         run: |
           gh release download "v${{ steps.version.outputs.version }}"
           ls -l
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -52,7 +52,12 @@ jobs:
           echo "${{ inputs.version }}" | grep -Pq '^v?\d+\.\d+\.\d+$'
           version="${{ inputs.version }}"
           echo "version=${version#v}" >> "$GITHUB_OUTPUT"
-
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Get release artifacts
+        run: |
+          gh release download "v${{ steps.version.outputs.version }}"
+          ls -l
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Login to DockerHub
@@ -64,16 +69,14 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
+          context: .
           file: "./tools/releasing/packaging/docker/release.dockerfile"
           tags: ${{ env.docker_username }}/precice:${{ steps.version.outputs.version }}
-          build-args: |
-            version=${{ steps.version.outputs.version }}
       - name: Build and push latest tag
         if: ${{ inputs.latest == 'true' }}
         uses: docker/build-push-action@v6
         with:
           push: true
+          context: .
           file: "./tools/releasing/packaging/docker/release.dockerfile"
           tags: ${{ env.docker_username }}/precice:latest
-          build-args: |
-            version=${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Print input
         env:
           params: "${{ tojson(inputs) }}"
-        run: 'echo "${params}" | jq .'
+        run: |
+          echo "${params}" | jq .
+          echo ${{ inputs.latest == 'true' }}
       - name: Check and clean version
         id: version
         run: |

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -72,7 +72,7 @@ jobs:
           username: ${{ env.docker_username }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push version tag
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .
@@ -80,7 +80,7 @@ jobs:
           tags: ${{ env.docker_username }}/precice:${{ steps.version.outputs.version }}
       - name: Build and push latest tag
         if: ${{ inputs.latest == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           push: true
           context: .

--- a/.github/workflows/publish-docker-release.yml
+++ b/.github/workflows/publish-docker-release.yml
@@ -51,7 +51,6 @@ jobs:
           params: "${{ tojson(inputs) }}"
         run: |
           echo "${params}" | jq .
-          echo ${{ inputs.latest == 'true' }}
       - name: Check and clean version
         id: version
         run: |
@@ -81,7 +80,7 @@ jobs:
           file: "./tools/releasing/packaging/docker/release.dockerfile"
           tags: ${{ env.docker_username }}/precice:${{ steps.version.outputs.version }}
       - name: Build and push latest tag
-        if: ${{ inputs.latest == 'true' }}
+        if: ${{ inputs.latest == 'true' || inputs.latest == true }}
         uses: docker/build-push-action@v7
         with:
           push: true

--- a/tools/releasing/packaging/docker/README.md
+++ b/tools/releasing/packaging/docker/README.md
@@ -6,13 +6,15 @@ All images contain the user `precice`, allowing them to run executables using MP
 
 ## Release images `release.dockerfile`
 
-This Dockerfile uses named releases of preCICE such as `3.1.2` and installs the attached debian package in the container.
+This Dockerfile uses the matching debian package of preCICE from the build context and installs the debian package in the container.
 
 Use the following to build the `3.1.2` image locally:
 ```
-cd tools/releasing/packaging/docker/
-docker build -f release.dockerfile  -t precice/precice:3.1.2 --build-arg=version=3.1.2 .
+gh release download v3.1.2
+docker build -f release.dockerfile  -t precice/precice:3.1.2 .
 ```
+
+To upgrade the Ubuntu version, change the version of the baseimage `FROM ubuntu` and the `CODENAME` (output of `lsb_release -sc)`.
 
 ## Nightly release images `nightly.dockerfile`
 

--- a/tools/releasing/packaging/docker/release.dockerfile
+++ b/tools/releasing/packaging/docker/release.dockerfile
@@ -1,17 +1,27 @@
 # Dockerfile to build a ubuntu image containing the installed Debian package of a release
+#
+# The build context must include the debian packages of the release
+# Use gh release download vX.Y.Z
 
+# Update the following two lines when bumping the base version.
 FROM ubuntu:24.04
+ENV CODENAME=noble
+
 # Add the precice user
 RUN useradd -m -s /bin/bash precice
+
+# Copy all debian packages from the build context.
+COPY ./libprecice*.deb /debs/
+
 # Fix the installation of tzdata for Ubuntu
 ARG TIMEZONE=Europe/Berlin
-RUN export TZ=$TIMEZONE && echo $TZ > /etc/timezone && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    apt-get -yy update && apt-get -yy install wget tzdata lsb-release && rm -rf /var/lib/apt/lists/*
-# The version to fetch the package for: X.Y.Z
-ARG version
-RUN echo "$version" | grep "[0-9]\+\.[0-9]\+\.[0-9]\+" > /dev/null # The version must follow the format X.Y.Z
-RUN wget -q -O libprecice.deb https://github.com/precice/precice/releases/download/v${version}/libprecice`echo ${version} | sed 's/\([0-9]\+\)\.\([0-9]\+\.[0-9]\+\)/\1_\1.\2/'`_$(lsb_release -sc).deb && \
-    apt-get update && apt-get -yy install ./libprecice.deb && \
-    rm libprecice.deb && rm -rf /var/lib/apt/lists/*
+ENV TZ=${TIMEZONE}
+
+# Install tzdata and the matching debian package and cleanup
+RUN echo ${TZ} > /etc/timezone && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    apt-get -yy update && apt-get -yy install tzdata wget && \
+    apt-get -yy install /debs/libprecice*_${CODENAME}.deb && \
+    rm -rf /var/lib/apt/lists/* /debs
+
 # Make sure the installation is functional
-RUN precice-tools version
+RUN precice-version


### PR DESCRIPTION
## Main changes of this PR

This PR changes the
* `dockerfile.release` to copy all Debian packages from the build context into the image and install the matching one.
* Docker release workflow to download all artifacts using `gh release download`, which also works for draft releases
* Docker release workflow to use a local build context instead of the repo URL

## Motivation and additional information

I tested `gh release download` with a draft release in one of my forked repos, and it worked.

Closes #2547

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
