### PR TITLE
Fix Ginkgo includes and improve HIP/CUDA dependency in RBF TU

### DIFF
--- a/docs/changelog/2549.md
+++ b/docs/changelog/2549.md
@@ -1,0 +1,1 @@
+- Fixed include bug where compiling with Kokkos-Kernels depends on Ginkgo.

--- a/src/mapping/impl/BasisFunctions.hpp
+++ b/src/mapping/impl/BasisFunctions.hpp
@@ -2,28 +2,17 @@
 
 #include <stdexcept>
 
-#ifdef __CUDACC__
-#include <cuda_runtime.h>
-#endif
+#if !defined(PRECICE_NO_GINKGO) || !defined(PRECICE_NO_KOKKOS_KERNELS)
 
-#ifdef __HIPCC__
-#include <hip/hip_runtime.h>
-#endif
+#include <Kokkos_Core.hpp>
 
-#if defined(__CUDACC__) || defined(__HIPCC__)
-
-#include <ginkgo/extensions/kokkos.hpp>
-#include <ginkgo/ginkgo.hpp>
-
-#define PRECICE_HOST_DEVICE __host__ __device__
-#define PRECICE_MEMORY_SPACE __device__
+#define PRECICE_HOST_DEVICE KOKKOS_FUNCTION
 #define PRECICE_FMA Kokkos::fma
 #define PRECICE_LOG Kokkos::log
 
 #else
 
 #define PRECICE_HOST_DEVICE
-#define PRECICE_MEMORY_SPACE
 #define PRECICE_FMA std::fma
 #define PRECICE_LOG std::log
 
@@ -619,7 +608,6 @@ private:
 
 #undef PRECICE_FMA
 #undef PRECICE_LOG
-#undef PRECICE_MEMORY_SPACE
 #undef PRECICE_HOST_DEVICE
 #undef NUMERICAL_ZERO_DIFFERENCE_DEVICE
 


### PR DESCRIPTION
## Main changes of this PR

Fixes the erroneous includes pointing to Ginkgo and provides a portable way for compiling with CUDA/HIP.

## Motivation and additional information

While the previous PRs fixed the CMake handling #2451 correctly, the problem is that I had Ginkgo installed on all my systems. Thus headers were still discoverable in my include paths, so no error was triggered. Reproduced it with spack. 

<!--
Short rational why preCICE needs this change. If this is already described in an issue a link to that issue (closes #123) is sufficient.
-->

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
