### PR TITLE
Enforce preCICE compatibility with `CMAKE_CXX_STANDARD`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,13 @@ option(PRECICE_RELEASE_WITH_DEBUG_LOG "Enable debug logging in release builds" O
 option(PRECICE_RELEASE_WITH_TRACE_LOG "Enable trace logging in release builds" OFF)
 option(PRECICE_RELEASE_WITH_ASSERTIONS "Enable assertions in release builds" OFF)
 
-set(PRECICE_CXX_STANDARD "17" CACHE STRING "CXX Standard for all preCICE targets" )
+if(NOT CMAKE_CXX_STANDARD)
+  set(PRECICE_CXX_STANDARD "17" CACHE STRING "CXX Standard for all preCICE targets" )
+else()
+  set(PRECICE_CXX_STANDARD ${CMAKE_CXX_STANDARD})
+endif()
+message(STATUS "Setting preCICE CXX standard to ${PRECICE_CXX_STANDARD}")
+
 option(PRECICE_HIDE_SYMBOLS "Hide non-API symbols in preCICE library" ON)
 mark_as_advanced(PRECICE_HIDE_SYMBOLS PRECICE_CXX_STANDARD)
 


### PR DESCRIPTION
## Main changes of this PR

Enforce preCICE compatibility for [`CMAKE_CXX_STANDARD`](https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html).

## Motivation and additional information

The standard way to define a CXX standard in CMake is `CMAKE_CXX_STANDARD`.  At the moment, this option is silently ignored, and the preCICE variable is well hidden in the CMakeCache. This makes it hard for users who compile preCICE with other tools like CUDA, HIP, etc, which have requirements in this regard. 

The PR also prints the defined standard to the user as a status message, as this is incredibly helpful for debugging and in terms of transparency.

## Author's checklist

* [ ] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
