### PR TITLE
Replace `std::optional` by default initialization in Kokkos kernel

### DIFF
--- a/docs/changelog/2551.md
+++ b/docs/changelog/2551.md
@@ -1,0 +1,1 @@
+- fixed `std::optional` usage in Kokkos kernel implementations.

--- a/src/mapping/device/KokkosPUMKernels_Impl.hpp
+++ b/src/mapping/device/KokkosPUMKernels_Impl.hpp
@@ -11,7 +11,6 @@
 #include "math/math.hpp"
 
 #include <functional>
-#include <optional>
 
 using precice::mapping::RadialBasisParameters;
 using precice::math::pow_int;

--- a/src/mapping/device/KokkosPUMKernels_Impl.hpp
+++ b/src/mapping/device/KokkosPUMKernels_Impl.hpp
@@ -634,13 +634,13 @@ void do_batched_solve(
     // but its layout is different (LayoutRight to have the coordinates aligned in memory).
     // We have to declare it here outsie the "if" to be able to use it further down then.
     // The memory here might point to null (or rather the end of "work"), in case polynomial = false
-    // and the evaluation_op is available but then it also remains unused. We make it here an optional
-    // to prevent Kokkos throwing errors about out-of-bounds accesses, the view is instantiated in the "if"
+    // and the evaluation_op is available but then it also remains unused. Using a std::optional
+    // is not portable, so the view here is unintitalized and only assigned in the "if"
     // branch below
-    std::optional<ScratchMesh> localInMesh;
+    ScratchMesh localInMesh;
 
     if constexpr (!evaluation_op_available || polynomial) {
-      localInMesh.emplace(&work(0, 1), inSize, dim);
+      localInMesh = ScratchMesh(&work(0, 1), inSize, dim);
 
       Kokkos::parallel_for(
           Kokkos::TeamThreadRange(team, inSize),
@@ -653,7 +653,7 @@ void do_batched_solve(
             for (int d = 0; d < dim; ++d) {
               sum += inMesh(globalID, d) * qrCoeffs[d];
               // Put it in shared memory as we later need it in the output evaluation
-              localInMesh->operator()(i, d) = inMesh(globalID, d);
+              localInMesh(i, d) = inMesh(globalID, d);
             }
             in(i) -= sum;
           });
@@ -751,7 +751,7 @@ void do_batched_solve(
                   // compute the local output coefficients
                   double dist = 0;
                   for (int d = 0; d < dim; ++d) {
-                    double diff = outVertex[d] - localInMesh->operator()(c, d);
+                    double diff = outVertex[d] - localInMesh(c, d);
                     dist += diff * diff;
                   }
                   dist = Kokkos::sqrt(dist);


### PR DESCRIPTION
## Main changes of this PR

Replace optional by default initialization in Kokkos kernel.

## Motivation and additional information

Something introduced during the later clean-up of #2346 to fix out-of-bounds checking for OpenMP. `std::optional` is not portable across platforms. The default initialization is.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
