### PR TITLE
Minor portability updates on Kokkos implementation

### DIFF
--- a/src/mapping/device/KokkosPUMKernels_Impl.hpp
+++ b/src/mapping/device/KokkosPUMKernels_Impl.hpp
@@ -137,7 +137,7 @@ bool compute_weights(const int                     nCenters,
           dist       = Kokkos::sqrt(dist);
           double val = w(dist, rbf_params);
           // is NUMERICAL_ZERO_DIFFERENCE_DEVICE
-          double res           = std::max(val, 1.0e-14);
+          double res           = Kokkos::fmax(val, 1.0e-14);
           normalizedWeights(i) = res;
 
           Kokkos::atomic_add(&weightSum(globalID), res);
@@ -551,7 +551,7 @@ void do_batched_solve(
     // Step 2: Allocate shared memory for the team and fill it with the inData of this cluster
     // The scratch memory (shared memory for the device)
     ScratchMatrix work(team.team_scratch(0), Kokkos::max(4, inSize));
-    auto          in = Kokkos::subview(work, std::pair<int, int>(0, inSize), 0);
+    auto          in = Kokkos::subview(work, Kokkos::pair<int, int>(0, inSize), 0);
 
     Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, inSize), [&](int i) {
@@ -568,7 +568,7 @@ void do_batched_solve(
       // Step 3a: Backup the current in data, since we solve the QR in place
       // In principle, we need a vector here (just as in), but the ApplyQ routine expects a Rank2 matrix,
       // so we have to stick to this particular syntax (keeping it rank 2 with one column)
-      auto in_cp = Kokkos::subview(work, std::pair<int, int>(0, inSize), std::pair<int, int>(1, 2));
+      auto in_cp = Kokkos::subview(work, Kokkos::pair<int, int>(0, inSize), Kokkos::pair<int, int>(1, 2));
       Kokkos::parallel_for(
           Kokkos::TeamThreadRange(team, inSize), [&](int i) { in_cp(i, 0) = in(i); });
       team.team_barrier();
@@ -597,8 +597,8 @@ void do_batched_solve(
                               KokkosBatched::Algo::ApplyQ::Unblocked>::invoke(team, qr, tau, in_cp, tmp);
 
         // Step 3d: Solve triangular solve R z = y
-        auto in_r = Kokkos::subview(in_cp, std::pair<int, int>(0, rank), 0);
-        auto R    = Kokkos::subview(qr, std::pair<int, int>(0, rank), std::pair<int, int>(0, rank));
+        auto in_r = Kokkos::subview(in_cp, Kokkos::pair<int, int>(0, rank), 0);
+        auto R    = Kokkos::subview(qr, Kokkos::pair<int, int>(0, rank), Kokkos::pair<int, int>(0, rank));
 
         KokkosBatched::Trsv<
             MemberType,
@@ -887,8 +887,8 @@ void do_qr_solve(int                           nCluster,
                                                          KokkosBatched::Algo::ApplyQ::Unblocked>::invoke(team, qr, tau, in, work);
                          team.team_barrier();
 
-                         auto in_r = Kokkos::subview(in, std::pair<int, int>(0, rank));
-                         auto R    = Kokkos::subview(qr, std::pair<int, int>(0, rank), std::pair<int, int>(0, rank));
+                         auto in_r = Kokkos::subview(in, Kokkos::pair<int, int>(0, rank));
+                         auto R    = Kokkos::subview(qr, Kokkos::pair<int, int>(0, rank), Kokkos::pair<int, int>(0, rank));
 
                          // Step 4b: Solve triangular solve R z = y
                          KokkosBatched::Trsv<
@@ -900,7 +900,7 @@ void do_qr_solve(int                           nCluster,
                              KokkosBatched::Algo::Trsv::Blocked>::invoke(team, 1.0, R, in_r);
                          team.team_barrier();
 
-                         auto res = Kokkos::subview(in, std::pair<int, int>(0, matrixCols));
+                         auto res = Kokkos::subview(in, Kokkos::pair<int, int>(0, matrixCols));
 
                          // Steo 4c: zero out the entries which are not within the rank region
                          Kokkos::parallel_for(


### PR DESCRIPTION
## Main changes of this PR

Minor portability updates on Kokkos implementation.

## Motivation and additional information

No bug, but sticking closer to the Kokkos syntax, see also https://kokkos.org/kokkos-core-wiki/API/core/stl-compat/pair.html

Using `std::pair` is explicitly declared in the docs as valid argument and use case. Still, I guess this may prevent future issues.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
