### PR TITLE
Restrict coverity-scan and further workflows to precice/precice

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -11,6 +11,7 @@ jobs:
   latest:
     runs-on: ubuntu-latest
     container: 'precice/ci-ubuntu-2204:latest'
+    if: github.repository == 'precice/precice'
     steps:
       - name: Download Coverity Build Tool
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
     secrets: inherit
 
   docker-release:
+    if: github.repository == 'precice/precice'
     name: "Release Dockerfile"
     needs: package-deb
     uses: ./.github/workflows/publish-docker-release.yml
@@ -52,6 +53,7 @@ jobs:
     secrets: inherit
 
   docker-nightly:
+    if: github.repository == 'precice/precice'
     name: "Release Nightly"
     needs: release-draft
     uses: ./.github/workflows/publish-docker-nightly.yml

--- a/.github/workflows/request-deb-package.yml
+++ b/.github/workflows/request-deb-package.yml
@@ -86,6 +86,7 @@ jobs:
     name: 'Upload DEB package for ${{ inputs.distro }}:${{ inputs.version }} to release ${{ inputs.release }}'
     needs: package
     runs-on: ubuntu-latest
+    if: github.repository == 'precice/precice'
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
## Main changes of this PR

Restricts the `coverity-scan.yml` workflow to this repository, to avoid running by default in forks (which would generally not set an access token). This workflow is triggered periodically.

## Motivation and additional information

Similar to https://github.com/precice/precice/pull/2542.

Other workflows with secrets, which are not triggered periodically:

- `secrets.CODECOV_TOKEN`:
   - [build-and-test.yml](https://github.com/precice/precice/blob/develop/.github/workflows/build-and-test.yml)
- `secrets.GITHUB_TOKEN`: should not really matter for forks, as that token is easy to create if needed.
   - [auto-author-assign.yml](https://github.com/precice/precice/blob/develop/.github/workflows/auto-author-assign.yml)
   - [release.yml](https://github.com/precice/precice/blob/develop/.github/workflows/release.yml)
   - [request-deb-package.yml](https://github.com/precice/precice/blob/develop/.github/workflows/request-deb-package.yml)

@fsimonis Should we block these as well?

## Author's checklist

* ~~I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.~~
* ~~I added a changelog file with `make changelog` if there are user-observable changes since the last release.~~
