### PR TITLE
Communicate connection info via primaries with MPI_Gatherv

### DIFF
--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -389,6 +389,28 @@ std::vector<std::vector<int>> Communication::gatherRanges(span<const int> itemTo
   return result;
 }
 
+std::vector<std::string> Communication::gatherRanges(std::string itemToSend)
+{
+  PRECICE_TRACE(itemToSend.size());
+  std::vector<int> sizes;
+  std::vector<std::string> result;
+
+  gather(itemToSend.size(), sizes);
+
+  if (utils::IntraComm::isPrimary()) {
+    result.resize(sizes.size());
+
+    for (int i = 0; i < sizes.size(); i++) {
+      PRECICE_ASSERT(sizes[i] >= 0);
+      result[i].resize(sizes[i]);
+    }
+  }
+
+  gather(itemToSend, result, sizes);
+
+  return result;
+}
+
 int Communication::adjustRank(Rank rank) const
 {
   return rank - _rankOffset;

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -366,6 +366,26 @@ std::vector<double> Communication::receiveRange(Rank rankSender, AsVectorTag<dou
   return result;
 }
 
+std::vector<std::vector<int>> Communication::gatherRanges(span<const int> itemToSend, AsVectorTag<int>)
+{
+  std::vector<int> sizes;
+  gather(itemToSend.size(), sizes);
+
+  std::vector<std::vector<int>> result;
+  result.resize(sizes.size());
+
+  for (int i = 0; i < sizes.size(); i++) {
+    PRECICE_ASSERT(sizes[i] >= 0);
+    result[i].resize(sizes[i]);
+  }
+
+  if (sizes.size() > 0) {
+    gather(itemToSend, result, sizes);
+  }
+
+  return result;
+}
+
 int Communication::adjustRank(Rank rank) const
 {
   return rank - _rankOffset;

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -7,7 +7,10 @@
 #include "Request.hpp"
 #include "logging/LogMacros.hpp"
 #include "precice/impl/Types.hpp"
+#include "profiling/Event.hpp"
 #include "utils/assertion.hpp"
+
+using precice::profiling::Event;
 
 namespace precice::com {
 
@@ -26,9 +29,21 @@ void Communication::connectIntraComm(std::string const &participantName,
   int            secondaryRanksSize = size - rankOffset;
   if (rank == 0) {
     PRECICE_INFO("Connecting Primary rank to {} Secondary ranks", secondaryRanksSize);
+    Event e0("prepareEstablishment");
+
     prepareEstablishment(primaryName, secondaryName);
+
+    e0.stop();
+    Event e1("acceptConnection");
+
     acceptConnection(primaryName, secondaryName, tag, rank, rankOffset);
+
+    e1.stop();
+    Event e2("cleanupEstablishment");
+
     cleanupEstablishment(primaryName, secondaryName);
+
+    e2.stop();
   } else {
     int secondaryRank = rank - rankOffset;
     PRECICE_INFO("Connecting Secondary rank #{} to Primary rank", secondaryRank);

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -8,6 +8,7 @@
 #include "logging/LogMacros.hpp"
 #include "precice/impl/Types.hpp"
 #include "profiling/Event.hpp"
+#include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
 
 using precice::profiling::Event;
@@ -369,19 +370,20 @@ std::vector<double> Communication::receiveRange(Rank rankSender, AsVectorTag<dou
 std::vector<std::vector<int>> Communication::gatherRanges(span<const int> itemToSend, AsVectorTag<int>)
 {
   std::vector<int> sizes;
+  std::vector<std::vector<int>> result;
+
   gather(itemToSend.size(), sizes);
 
-  std::vector<std::vector<int>> result;
-  result.resize(sizes.size());
+  if (utils::IntraComm::isPrimary()) {
+    result.resize(sizes.size());
 
-  for (int i = 0; i < sizes.size(); i++) {
-    PRECICE_ASSERT(sizes[i] >= 0);
-    result[i].resize(sizes[i]);
+    for (int i = 0; i < sizes.size(); i++) {
+      PRECICE_ASSERT(sizes[i] >= 0);
+      result[i].resize(sizes[i]);
+    }
   }
 
-  if (sizes.size() > 0) {
-    gather(itemToSend, result, sizes);
-  }
+  gather(itemToSend, result, sizes);
 
   return result;
 }

--- a/src/com/Communication.cpp
+++ b/src/com/Communication.cpp
@@ -369,6 +369,7 @@ std::vector<double> Communication::receiveRange(Rank rankSender, AsVectorTag<dou
 
 std::vector<std::vector<int>> Communication::gatherRanges(span<const int> itemToSend, AsVectorTag<int>)
 {
+  PRECICE_TRACE(itemToSend.size());
   std::vector<int> sizes;
   std::vector<std::vector<int>> result;
 

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -371,7 +371,7 @@ public:
   virtual void gather(int itemToSend, std::vector<int> &itemsToReceive) = 0;
 
   /// Gathers an array of ints per process.
-  virtual void gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts) = 0;
+  virtual void gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts) = 0;
 
   /// @}
 

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -373,6 +373,9 @@ public:
   /// Gathers an array of ints per process.
   virtual void gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts) = 0;
 
+  /// Gathers a string of specified length per process.
+  virtual void gather(std::string itemToSend, std::vector<std::string>& itemsToReceive, const std::vector<int>& recvcounts) = 0;
+
   /// @}
 
   /// @name Range communication
@@ -400,6 +403,9 @@ public:
 
   /// Sends and receives a range of ints for each connected rank
   std::vector<std::vector<int>> gatherRanges(span<const int> itemToSend, AsVectorTag<int>);
+
+  /// Sends and receives a string for each connected rank
+  std::vector<std::string> gatherRanges(std::string itemToSend);
 
   /// @}
 

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -367,6 +367,12 @@ public:
   /// Asynchronously receives a bool from process with given rank.
   virtual PtrRequest aReceive(bool &itemToReceive, Rank rankSender) = 0;
 
+  /// Gathers an int per process.
+  virtual void gather(int itemToSend, std::vector<int> &itemsToReceive) = 0;
+
+  /// Gathers an array of ints per process.
+  virtual void gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts) = 0;
+
   /// @}
 
   /// @name Range communication
@@ -391,6 +397,9 @@ public:
 
   /// Receives a range of doubles as a vector<double>
   std::vector<double> receiveRange(Rank rankSender, AsVectorTag<double>);
+
+  /// Sends and receives a range of ints for each connected rank
+  std::vector<std::vector<int>> gatherRanges(span<const int> itemToSend, AsVectorTag<int>);
 
   /// @}
 

--- a/src/com/Communication.hpp
+++ b/src/com/Communication.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "ConnectionInfoPublisher.hpp"
+#include "SerializedConnectionInfo.hpp"
+
 #include <set>
 #include <stddef.h>
 #include <string>
@@ -125,6 +128,18 @@ public:
                                         int                acceptorRank,
                                         int                requesterCommunicatorSize) = 0;
 
+  virtual std::string prepareAcceptConnectionAsServer(std::string const &acceptorName,
+                                                      std::string const &requesterName,
+                                                      std::string const &tag,
+                                                      int                acceptorRank,
+                                                      int                requesterCommunicatorSize) = 0;
+
+  virtual void finishAcceptConnectionAsServer(std::string const &acceptorName,
+                                              std::string const &requesterName,
+                                              std::string const &tag,
+                                              int                acceptorRank,
+                                              int                requesterCommunicatorSize) = 0;
+
   /**
    * @brief Connects to another communicator, which has to call acceptConnection().
    *
@@ -165,6 +180,28 @@ public:
                                          std::string const   &tag,
                                          std::set<int> const &acceptorRanks,
                                          int                  requesterRank) = 0;
+
+  /**
+   * @brief Connects to another communicator, which has to call acceptConnectionAsServer().
+   *
+   * Establishes a 1-to-N communication, whereas the requestor's side is the "N". Contrary to
+   * requestConnection(), this side can have arbitrary ranks (e.g. 2,3,7). All ranks need to
+   * call this function. This communication is only used in PointToPointCommunication, i.e.
+   * for the M-to-N communication between two participants.
+   *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to
+   * @param[in] tag Tag for establishing this connection
+   * @param[in] acceptorRanks Set of ranks that accept a connection
+   * @param[in] requesterRank Rank that requests the connection, usually the caller's rank
+   * @param[in] connectionInfoMap Information on how to connect to the acceptor ranks
+   */
+  virtual void requestConnectionAsClient(std::string const                                               &acceptorName,
+                                         std::string const                                               &requesterName,
+                                         std::string const                                               &tag,
+                                         std::set<int> const                                             &acceptorRanks,
+                                         int                                                              requesterRank,
+                                         serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap) = 0;
 
   /** Establishes the intra-participant communication connection.
    *

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -12,6 +12,10 @@
 #include "utils/Hash.hpp"
 #include "utils/assertion.hpp"
 
+#include <profiling/Event.hpp>
+
+using precice::profiling::Event;
+
 namespace fs = std::filesystem;
 namespace precice::com {
 
@@ -53,6 +57,7 @@ std::string ConnectionInfoReader::read() const
 {
   auto path = getFilename();
 
+  Event e0 = Event("ConnectionInfoReader.read.waitingForConnectionFile");
   PRECICE_DEBUG("Waiting for connection file \"{}\"", path);
   const auto waitdelay = std::chrono::milliseconds(1);
   while (!fs::exists(path)) {
@@ -60,6 +65,9 @@ std::string ConnectionInfoReader::read() const
   }
   PRECICE_ASSERT(fs::exists(path));
   PRECICE_DEBUG("Found connection file \"{}\"", path);
+
+  e0.stop();
+  Event e1 = Event("ConnectionInfoReader.read.readingConnectionFile");
 
   std::ifstream ifs(path);
 
@@ -80,18 +88,31 @@ std::string ConnectionInfoReader::read() const
                 "Please report this bug to the preCICE developers.",
                 path);
   boost::algorithm::trim_right(addressData);
+
+  e1.stop();
+
   return addressData;
 }
 
 ConnectionInfoWriter::~ConnectionInfoWriter()
 {
+  Event e0 = Event("ConnectionInfoWriter.init.constructingFilename");
+
   fs::path path(getFilename());
+
+  e0.stop();
+  Event e1 = Event("ConnectionInfoWriter.init.checkingConnectingFile");
+
   if (!fs::exists(path)) {
     PRECICE_WARN("Cannot clean-up the connection file \"{}\" as it doesn't exist. "
                  "In case of connection problems, please report this to the preCICE developers.",
                  path.generic_string());
     return;
   }
+
+  e1.stop();
+  Event e2 = Event("ConnectionInfoWriter.init.deletingConnectionFile");
+
   PRECICE_DEBUG("Deleting connection file \"{}\"", path.generic_string());
   try {
     fs::remove(path);
@@ -105,12 +126,18 @@ ConnectionInfoWriter::~ConnectionInfoWriter()
                  "Make sure to delete the \"precice-run\" directory before restarting the simulation.",
                  e.what());
   }
+
+  e2.stop();
 }
 
 void ConnectionInfoWriter::write(std::string_view info) const
 {
+  Event e0 = Event("ConnectionInfoWriter.write.constructingFilename");
   auto path = getFilename();
   auto tmp  = fs::path(path + "~");
+
+  e0.stop();
+  Event e1 = Event("ConnectionInfoWriter.write.checkExistingFile");
 
   {
     auto message = "Unable to establish connection as a {}connection file already exists at \"{}\". "
@@ -119,6 +146,9 @@ void ConnectionInfoWriter::write(std::string_view info) const
     PRECICE_CHECK(!fs::exists(path), message, "", path);
     PRECICE_CHECK(!fs::exists(tmp), message, "temporary ");
   }
+
+  e1.stop();
+  Event e2 = Event("ConnectionInfoWriter.write.writingTemporaryFile");
 
   PRECICE_DEBUG("Writing temporary connection file \"{}\"", tmp.generic_string());
   fs::create_directories(tmp.parent_path());
@@ -137,13 +167,22 @@ void ConnectionInfoWriter::write(std::string_view info) const
                "{}\nAcceptor: {}, Requester: {}, Tag: {}, Rank: {}",
                info, acceptorName, requesterName, tag, rank);
   }
+  e2.stop();
+  Event e3 = Event("ConnectionInfoWriter.write.checkingTemporaryFile");
   PRECICE_CHECK(fs::exists(tmp),
                 "Unable to establish connection as the temporary connection file \"{}\" was written, but doesn't exist on disk. "
                 "Please report this bug to the preCICE developers.",
                 tmp.generic_string());
+  e3.stop();
+
+  Event e4 = Event("ConnectionInfoWriter.write.publishingFile");
 
   PRECICE_DEBUG("Publishing connection file \"{}\"", path);
   fs::rename(tmp, path);
+
+  e4.stop();
+  Event e5 = Event("ConnectionInfoWriter.write.checkingFile");
+
   PRECICE_WARN_IF(
       fs::exists(tmp),
       "The temporary connection file \"{}\" wasn't properly removed. "
@@ -153,6 +192,8 @@ void ConnectionInfoWriter::write(std::string_view info) const
                 "Unable to establish connection as the connection file \"{}\" doesn't exist on disk. "
                 "Please report this bug to the preCICE developers.",
                 path);
+
+  e5.stop();
 }
 
 } // namespace precice::com

--- a/src/com/ConnectionInfoPublisher.cpp
+++ b/src/com/ConnectionInfoPublisher.cpp
@@ -55,9 +55,13 @@ std::string ConnectionInfoPublisher::getFilename() const
 
 std::string ConnectionInfoReader::read() const
 {
+  Event e0 = Event("ConnectionInfoReader.read.constructingFilename");
+
   auto path = getFilename();
 
-  Event e0 = Event("ConnectionInfoReader.read.waitingForConnectionFile");
+  e0.stop();
+  Event e1 = Event("ConnectionInfoReader.read.waitingForConnectionFile");
+
   PRECICE_DEBUG("Waiting for connection file \"{}\"", path);
   const auto waitdelay = std::chrono::milliseconds(1);
   while (!fs::exists(path)) {
@@ -66,8 +70,8 @@ std::string ConnectionInfoReader::read() const
   PRECICE_ASSERT(fs::exists(path));
   PRECICE_DEBUG("Found connection file \"{}\"", path);
 
-  e0.stop();
-  Event e1 = Event("ConnectionInfoReader.read.readingConnectionFile");
+  e1.stop();
+  Event e2 = Event("ConnectionInfoReader.read.readingConnectionFile");
 
   std::ifstream ifs(path);
 
@@ -89,7 +93,7 @@ std::string ConnectionInfoReader::read() const
                 path);
   boost::algorithm::trim_right(addressData);
 
-  e1.stop();
+  e2.stop();
 
   return addressData;
 }

--- a/src/com/Extra.cpp
+++ b/src/com/Extra.cpp
@@ -2,6 +2,7 @@
 
 #include "com/SerializedMesh.hpp"
 #include "com/SerializedPartitioning.hpp"
+#include "com/SerializedConnectionInfo.hpp"
 
 namespace precice::com {
 
@@ -63,6 +64,36 @@ void sendBoundingBoxMap(Communication &communication, int rankReceiver, const me
 void receiveBoundingBoxMap(Communication &communication, int rankSender, mesh::Mesh::BoundingBoxMap &bbm)
 {
   bbm = serialize::SerializedBoundingBoxMap::receive(communication, rankSender).toBoundingBoxMap();
+}
+
+void sendConnectionInfo(Communication &communication, int rankReceiver, const std::string &connectionInfo)
+{
+  communication.send(connectionInfo, rankReceiver);
+}
+
+void receiveConnectionInfo(Communication &communication, int rankSender, std::string &connectionInfo)
+{
+  communication.receive(connectionInfo, rankSender);
+}
+
+void sendConnectionInfoMap(Communication &communication, int rankReceiver, const serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap)
+{
+  serialize::SerializedConnectionInfoMap::serialize(connectionInfoMap).send(communication, rankReceiver);
+}
+
+void receiveConnectionInfoMap(Communication &communication, int rankSender, serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap)
+{
+  connectionInfoMap = serialize::SerializedConnectionInfoMap::receive(communication, rankSender).toConnectionInfoMap();
+}
+
+void broadcastSendConnectionInfoMap(Communication &communication, const serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap)
+{
+  serialize::SerializedConnectionInfoMap::serialize(connectionInfoMap).broadcastSend(communication);
+}
+
+void broadcastReceiveConnectionInfoMap(Communication &communication, serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap)
+{
+  connectionInfoMap = serialize::SerializedConnectionInfoMap::broadcastReceive(communication).toConnectionInfoMap();
 }
 
 void broadcastSendBoundingBoxMap(Communication &communication, const mesh::Mesh::BoundingBoxMap &bbm)

--- a/src/com/Extra.hpp
+++ b/src/com/Extra.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "SerializedConnectionInfo.hpp"
 #include "com/Communication.hpp"
 #include "mesh/Mesh.hpp"
 
@@ -28,6 +29,18 @@ void receiveBoundingBox(Communication &communication, int rankSender, mesh::Boun
 void sendBoundingBoxMap(Communication &communication, int rankReceiver, const mesh::Mesh::BoundingBoxMap &bbm);
 
 void receiveBoundingBoxMap(Communication &communication, int rankSender, mesh::Mesh::BoundingBoxMap &bbm);
+
+void sendConnectionInfo(Communication &communication, int rankReceiver, const std::string &connectionInfo);
+
+void receiveConnectionInfo(Communication &communication, int rankSender, std::string &connectionInfo);
+
+void sendConnectionInfoMap(Communication &communication, int rankReceiver, const serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap);
+
+void receiveConnectionInfoMap(Communication &communication, int rankSender, serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap);
+
+void broadcastSendConnectionInfoMap(Communication &communication, const serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap);
+
+void broadcastReceiveConnectionInfoMap(Communication &communication, serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap);
 
 void broadcastSendBoundingBoxMap(Communication &communication, const mesh::Mesh::BoundingBoxMap &bbm);
 

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -333,7 +333,7 @@ PtrRequest MPICommunication::aReceive(bool &itemToReceive, Rank rankSender)
 
 void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
 {
-  PRECICE_TRACE(itemToSend);
+  PRECICE_TRACE(itemToSend, itemsToReceive.size());
 
   Rank rootRank = adjustRank(0);
 
@@ -350,7 +350,7 @@ void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
 
 void MPICommunication::gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts)
 {
-  PRECICE_TRACE(itemToSend.size(), recvcounts);
+  PRECICE_TRACE(itemToSend.size(), itemsToReceive.size(), recvcounts);
 
   Rank rootRank = adjustRank(0);
   bool isPrimary = utils::IntraComm::isPrimary();

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -333,12 +333,14 @@ PtrRequest MPICommunication::aReceive(bool &itemToReceive, Rank rankSender)
 
 void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
 {
+  PRECICE_TRACE(itemToSend);
+
   Rank rootRank = adjustRank(0);
 
   MPI_Gather(&itemToSend,
              1,
              MPI_INT,
-             &itemsToReceive,
+             itemsToReceive.data(),
              1,
              MPI_INT,
              rootRank,
@@ -348,6 +350,8 @@ void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
 
 void MPICommunication::gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts)
 {
+  PRECICE_TRACE(itemToSend.size(), recvcounts);
+
   Rank rootRank = adjustRank(0);
   bool isPrimary = utils::IntraComm::isPrimary();
 
@@ -365,6 +369,8 @@ void MPICommunication::gather(span<const int> itemToSend, std::vector<std::vecto
         0);
     flatBuffer.resize(totalSize);
   }
+
+  PRECICE_WARN("This gather only works if all ranks are in the same communicator. It will likely crash when using mpi-multiple-ports (MPIPortsCommunication instead of MPISinglePortsCommunication)");
 
   MPI_Gatherv(itemToSend.data(),
               itemToSend.size(),

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -400,6 +400,50 @@ void MPICommunication::gather(span<const int> itemToSend, std::vector<std::vecto
     }
   }
 }
+void MPICommunication::gather(std::string itemToSend, std::vector<std::string> &itemsToReceive, const std::vector<int> &recvcounts)
+{
+  PRECICE_TRACE(itemToSend.size(), itemsToReceive.size(), recvcounts);
+
+  Rank rootRank = adjustRank(0);
+  bool isPrimary = utils::IntraComm::isPrimary();
+
+  std::vector<char> flatBuffer;
+  std::vector<int> displs;
+
+  if (isPrimary) {
+    displs.resize(recvcounts.size());
+    int totalSize = std::accumulate(recvcounts.begin(), recvcounts.end(), 0);
+
+    std::exclusive_scan(
+        recvcounts.begin(),
+        recvcounts.end(),
+        displs.begin(),
+        0);
+    flatBuffer.resize(totalSize);
+  }
+
+  PRECICE_WARN("This gather only works if all ranks are in the same communicator. It will likely crash when using mpi-multiple-ports (MPIPortsCommunication instead of MPISinglePortsCommunication)");
+
+  MPI_Gatherv(itemToSend.data(),
+              static_cast<int>(itemToSend.size()),
+              MPI_CHAR,
+              isPrimary ? flatBuffer.data() : nullptr,
+              isPrimary ? recvcounts.data() : nullptr,
+              isPrimary ? displs.data() : nullptr,
+              MPI_CHAR,
+              rootRank,
+              communicator(rootRank) // TODO: We cannot just assume that the communicator is the same for all!
+  );
+
+  if (isPrimary) {
+    for (int i = 0; i < recvcounts.size(); i++) {
+      itemsToReceive[i] = std::string(
+        flatBuffer.data() + displs[i],
+        recvcounts[i]
+      );
+    }
+  }
+}
 
 } // namespace precice::com
 

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <ostream>
 
+#include <numeric>
 #include "com/MPICommunication.hpp"
 #include "com/MPIRequest.hpp"
 #include "logging/LogMacros.hpp"
@@ -327,6 +328,45 @@ PtrRequest MPICommunication::aReceive(bool &itemToReceive, Rank rankSender)
             &request);
 
   return PtrRequest(new MPIRequest(request));
+}
+
+void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
+{
+  Rank rootRank = adjustRank(0);
+
+  MPI_Gather(&itemToSend,
+             1,
+             MPI_INT,
+             &itemsToReceive,
+             1,
+             MPI_INT,
+             rootRank,
+             communicator(rootRank) // TODO: We cannot just assume that the communicator is the same for all!
+  );
+}
+
+void MPICommunication::gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts)
+{
+  std::vector<int> displs(recvcounts.size());
+
+  std::exclusive_scan(
+      recvcounts.begin(),
+      recvcounts.end(),
+      displs.begin(),
+      0);
+
+  Rank rootRank = adjustRank(0);
+
+  MPI_Gatherv(itemToSend.data(),
+              itemToSend.size(),
+              MPI_INT,
+              &itemsToReceive,
+              recvcounts.data(),
+              displs.data(),
+              MPI_INT,
+              rootRank,
+              communicator(rootRank) // TODO: We cannot just assume that the communicator is the same for all!
+  );
 }
 
 } // namespace precice::com

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -336,6 +336,14 @@ void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
   PRECICE_TRACE(itemToSend, itemsToReceive.size());
 
   Rank rootRank = adjustRank(0);
+  MPI_Comm comm = communicator(rootRank); // TODO: We cannot just assume that the communicator is the same for all!
+
+  if (utils::IntraComm::isPrimary()) {
+    int commSize;
+    MPI_Comm_size(comm, &commSize);
+
+    itemsToReceive.resize(commSize);
+  }
 
   MPI_Gather(&itemToSend,
              1,
@@ -344,7 +352,7 @@ void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
              1,
              MPI_INT,
              rootRank,
-             communicator(rootRank) // TODO: We cannot just assume that the communicator is the same for all!
+             comm
   );
 }
 

--- a/src/com/MPICommunication.cpp
+++ b/src/com/MPICommunication.cpp
@@ -9,6 +9,7 @@
 #include "logging/LogMacros.hpp"
 #include "precice/impl/Types.hpp"
 #include "utils/span_tools.hpp"
+#include "utils/IntraComm.hpp"
 
 template <size_t>
 struct MPI_Select_unsigned_integer_datatype;
@@ -345,28 +346,45 @@ void MPICommunication::gather(int itemToSend, std::vector<int> &itemsToReceive)
   );
 }
 
-void MPICommunication::gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts)
+void MPICommunication::gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts)
 {
-  std::vector<int> displs(recvcounts.size());
-
-  std::exclusive_scan(
-      recvcounts.begin(),
-      recvcounts.end(),
-      displs.begin(),
-      0);
-
   Rank rootRank = adjustRank(0);
+  bool isPrimary = utils::IntraComm::isPrimary();
+
+  std::vector<int> flatBuffer;
+  std::vector<int> displs;
+
+  if (isPrimary) {
+    displs.resize(recvcounts.size());
+    int totalSize = std::accumulate(recvcounts.begin(), recvcounts.end(), 0);
+
+    std::exclusive_scan(
+        recvcounts.begin(),
+        recvcounts.end(),
+        displs.begin(),
+        0);
+    flatBuffer.resize(totalSize);
+  }
 
   MPI_Gatherv(itemToSend.data(),
               itemToSend.size(),
               MPI_INT,
-              &itemsToReceive,
-              recvcounts.data(),
-              displs.data(),
+              isPrimary ? flatBuffer.data() : nullptr,
+              isPrimary ? recvcounts.data() : nullptr,
+              isPrimary ? displs.data() : nullptr,
               MPI_INT,
               rootRank,
               communicator(rootRank) // TODO: We cannot just assume that the communicator is the same for all!
   );
+
+  if (isPrimary) {
+    for (int i = 0; i < recvcounts.size(); i++) {
+      itemsToReceive[i] = std::vector<int>(
+        flatBuffer.begin() + displs[i],
+        flatBuffer.begin() + displs[i] + recvcounts[i]
+      );
+    }
+  }
 }
 
 } // namespace precice::com

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -125,6 +125,9 @@ public:
   /// Gathers an array of ints per process.
   void gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts) override;
 
+  /// Gathers a string of specified length per process.
+  void gather(std::string itemToSend, std::vector<std::string>& itemsToReceive, const std::vector<int>& recvcounts) override;
+
 protected:
   /// Returns the communicator.
   virtual MPI_Comm &communicator(Rank rank) = 0;

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -123,7 +123,7 @@ public:
   void gather(int itemToSend, std::vector<int> &itemsToReceive) override;
 
   /// Gathers an array of ints per process.
-  void gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts) override;
+  void gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts) override;
 
 protected:
   /// Returns the communicator.

--- a/src/com/MPICommunication.hpp
+++ b/src/com/MPICommunication.hpp
@@ -119,6 +119,12 @@ public:
   /// Asynchronously receives a bool from process with given rank.
   PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
 
+  /// Gathers an int per process.
+  void gather(int itemToSend, std::vector<int> &itemsToReceive) override;
+
+  /// Gathers an array of ints per process.
+  void gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts) override;
+
 protected:
   /// Returns the communicator.
   virtual MPI_Comm &communicator(Rank rank) = 0;

--- a/src/com/MPIDirectCommunication.hpp
+++ b/src/com/MPIDirectCommunication.hpp
@@ -59,6 +59,24 @@ public:
     PRECICE_ASSERT(false, "Not implemented!");
   }
 
+  std::string prepareAcceptConnectionAsServer(std::string const &acceptorName,
+                                                      std::string const &requesterName,
+                                                      std::string const &tag,
+                                                      int                acceptorRank,
+                                                      int                requesterCommunicatorSize) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
+  void finishAcceptConnectionAsServer(std::string const &acceptorName,
+                                              std::string const &requesterName,
+                                              std::string const &tag,
+                                              int                acceptorRank,
+                                              int                requesterCommunicatorSize) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
   /** See precice::com::Communication::requestConnection().
    * @attention Calls precice::utils::Parallel::splitCommunicator()
    * if local and global communicators are equal.
@@ -74,6 +92,16 @@ public:
                                  std::string const   &tag,
                                  std::set<int> const &acceptorRanks,
                                  int                  requesterRank) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
+  void requestConnectionAsClient(std::string const                                               &acceptorName,
+                                 std::string const                                               &requesterName,
+                                 std::string const                                               &tag,
+                                 std::set<int> const                                             &acceptorRanks,
+                                 int                                                              requesterRank,
+                                 serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap) override
   {
     PRECICE_ASSERT(false, "Not implemented!");
   }

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -51,10 +51,14 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
   MPIResult res;
 
+  Event e0("mpi.acceptConnection.openPort");
+
   utils::StringMaker<MPI_MAX_PORT_NAME> sm;
   res = MPI_Open_port(MPI_INFO_NULL, sm.data());
   PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
   _portName = sm.str();
+
+  e0.stop();
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
   conInfo.write(_portName);
@@ -63,11 +67,17 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
   int peerCount   = -1; // The total count of peers (initialized in the first iteration)
   int peerCurrent = 0;  // Current peer to connect to
   do {
+    Event e1("mpi.acceptConnection.peer." + peerCurrent);
+    Event e2("accept");
+
     // Connection
     MPI_Comm communicator;
     res = MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
     PRECICE_CHECK(res, "MPI_Comm_accept failed with message: {}", res.message());
     PRECICE_DEBUG("Accepted connection at {} for peer {}", _portName, peerCurrent);
+
+    e2.stop();
+    Event e3("receiveRequesterRankAndCommunicatorSize");
 
     // Which rank is requesting a connection?
     int requesterRank = -1;
@@ -75,8 +85,14 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
     // How big is the communicator of the requester
     int requesterCommunicatorSize = -1;
     MPI_Recv(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
+
+    e3.stop();
+    Event e4("sendAcceptorRank");
+
     // Send the rank of the acceptor (this rank).
     MPI_Send(&acceptorRank, 1, MPI_INT, 0, 42, communicator);
+
+    e4.stop();
 
     // Initialize the count of peers to connect to
     if (peerCurrent == 0) {
@@ -92,12 +108,17 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
 
     _communicators.emplace(requesterRank, communicator);
 
+    e1.stop();
   } while (++peerCurrent < peerCount);
+
+  Event e4("mpi.acceptConnection.closePort");
 
   res = MPI_Close_port(const_cast<char *>(_portName.c_str()));
   PRECICE_CHECK(res, "MPI_Close_port failed with message: {}", res.message());
   _portName.clear();
   PRECICE_DEBUG("Closed Port");
+
+  e4.stop();
 
   _isConnected = true;
 }
@@ -115,20 +136,30 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
   _isAcceptor = true;
   MPIResult res;
 
+  Event e0("mpi.acceptConnectionAsServer.openPort");
+
   utils::StringMaker<MPI_MAX_PORT_NAME> sm;
   res = MPI_Open_port(MPI_INFO_NULL, sm.data());
   PRECICE_CHECK(res, "MPI_Open_port failed with message: {}", res.message());
   _portName = sm.str();
+
+  e0.stop();
 
   ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
   conInfo.write(_portName);
   PRECICE_DEBUG("Accept connection at {}", _portName);
 
   for (int connection = 0; connection < requesterCommunicatorSize; ++connection) {
+    Event e1("mpi.acceptConnectionAsServer.connection." + connection);
+    Event e2("accept");
+
     MPI_Comm communicator;
     res = MPI_Comm_accept(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
     PRECICE_CHECK(res, "MPI_Comm_accept failed with message: {}", res.message());
     PRECICE_DEBUG("Accepted connection at {}", _portName);
+
+    e2.stop();
+    Event e3("receiveRequesterRank");
 
     // Receive the rank of requester
     int requesterRank = -1;
@@ -138,12 +169,19 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
     PRECICE_ASSERT(_communicators.count(requesterRank) == 0, "This connection has already been established.");
 
     _communicators.emplace(requesterRank, communicator);
+
+    e3.stop();
+    e1.stop();
   }
+
+  Event e4("mpi.acceptConnectionAsServer.closePort");
 
   res = MPI_Close_port(const_cast<char *>(_portName.c_str()));
   PRECICE_CHECK(res, "MPI_Close_port failed with message: {}", res.message());
   _portName.clear();
   PRECICE_DEBUG("Closed Port");
+
+  e4.stop();
 
   _isConnected = true;
 }
@@ -163,6 +201,8 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
 
   PRECICE_DEBUG("Request connection to {}", _portName);
 
+  Event e0("connect");
+
   MPI_Comm  communicator;
   MPIResult res = MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
   PRECICE_CHECK(res, "MPI_Comm_connect failed with message: {}", res.message());
@@ -170,10 +210,17 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
 
   _isConnected = true;
 
+  e0.stop();
+  Event e1("sendRequesterRankAndCommunicatorSize");
+
   // Send the rank of the requester (this rank)
   MPI_Send(&requesterRank, 1, MPI_INT, 0, 42, communicator);
   // Send the size of the requester communicator size
   MPI_Send(&requesterCommunicatorSize, 1, MPI_INT, 0, 42, communicator);
+
+  e1.stop();
+  Event e2("receiveAcceptorRank");
+
   // Receive the rank of the acceptor that we connected to.
   int acceptorRank = -1;
   MPI_Recv(&acceptorRank, 1, MPI_INT, 0, 42, communicator, MPI_STATUS_IGNORE);
@@ -182,6 +229,8 @@ void MPIPortsCommunication::requestConnection(std::string const &acceptorName,
   // intra Communication.
   //
   // PRECICE_ASSERT(acceptorRank == 0, "The acceptor always has to be 0.");
+
+  e2.stop();
 
   _communicators.emplace(acceptorRank, communicator);
 }
@@ -199,20 +248,33 @@ void MPIPortsCommunication::requestConnectionAsClient(std::string const   &accep
   _isAcceptor = false;
 
   for (int acceptorRank : acceptorRanks) {
+    Event e("mpi.requestConnectionAsClient." + acceptorRank);
+
     ConnectionInfoReader conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     _portName = conInfo.read();
     PRECICE_DEBUG("Request connection to {}", _portName);
+
+    Event e0("connect");
 
     MPI_Comm  communicator;
     MPIResult res = MPI_Comm_connect(const_cast<char *>(_portName.c_str()), MPI_INFO_NULL, 0, MPI_COMM_SELF, &communicator);
     PRECICE_CHECK(res, "MPI_Comm_connect failed with message: {}", res.message());
     PRECICE_DEBUG("Requested connection to {}", _portName);
 
+    e0.stop();
+    Event e1("send");
+
     // Rank 0 is always the peer, because we connected on COMM_SELF
     MPI_Send(&requesterRank, 1, MPI_INT, 0, 42, communicator);
 
+    e1.stop();
+    Event e2("storeCommunicator");
+
     PRECICE_ASSERT(_communicators.count(acceptorRank) == 0, "This connection has already been established.");
     _communicators.emplace(acceptorRank, communicator);
+
+    e2.stop();
+    e.stop();
   }
   _isConnected = true;
 }

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -150,7 +150,7 @@ void MPIPortsCommunication::acceptConnectionAsServer(std::string const &acceptor
   PRECICE_DEBUG("Accept connection at {}", _portName);
 
   for (int connection = 0; connection < requesterCommunicatorSize; ++connection) {
-    Event e1("mpi.acceptConnectionAsServer.connection." + connection);
+    Event e1("mpi.acceptConnectionAsServer.connection." + std::to_string(connection));
     Event e2("accept");
 
     MPI_Comm communicator;

--- a/src/com/MPIPortsCommunication.cpp
+++ b/src/com/MPIPortsCommunication.cpp
@@ -67,7 +67,7 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
   int peerCount   = -1; // The total count of peers (initialized in the first iteration)
   int peerCurrent = 0;  // Current peer to connect to
   do {
-    Event e1("mpi.acceptConnection.peer." + peerCurrent);
+    Event e1("mpi.acceptConnection.peer." + std::to_string(peerCurrent));
     Event e2("accept");
 
     // Connection
@@ -111,14 +111,14 @@ void MPIPortsCommunication::acceptConnection(std::string const &acceptorName,
     e1.stop();
   } while (++peerCurrent < peerCount);
 
-  Event e4("mpi.acceptConnection.closePort");
+  Event e5("mpi.acceptConnection.closePort");
 
   res = MPI_Close_port(const_cast<char *>(_portName.c_str()));
   PRECICE_CHECK(res, "MPI_Close_port failed with message: {}", res.message());
   _portName.clear();
   PRECICE_DEBUG("Closed Port");
 
-  e4.stop();
+  e5.stop();
 
   _isConnected = true;
 }
@@ -248,7 +248,7 @@ void MPIPortsCommunication::requestConnectionAsClient(std::string const   &accep
   _isAcceptor = false;
 
   for (int acceptorRank : acceptorRanks) {
-    Event e("mpi.requestConnectionAsClient." + acceptorRank);
+    Event e("mpi.requestConnectionAsClient." + std::to_string(acceptorRank));
 
     ConnectionInfoReader conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     _portName = conInfo.read();

--- a/src/com/MPIPortsCommunication.hpp
+++ b/src/com/MPIPortsCommunication.hpp
@@ -38,6 +38,24 @@ public:
                                 int                acceptorRank,
                                 int                requesterCommunicatorSize) override;
 
+  std::string prepareAcceptConnectionAsServer(std::string const &acceptorName,
+                                                      std::string const &requesterName,
+                                                      std::string const &tag,
+                                                      int                acceptorRank,
+                                                      int                requesterCommunicatorSize) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
+  void finishAcceptConnectionAsServer(std::string const &acceptorName,
+                                              std::string const &requesterName,
+                                              std::string const &tag,
+                                              int                acceptorRank,
+                                              int                requesterCommunicatorSize) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
   void requestConnection(std::string const &acceptorName,
                          std::string const &requesterName,
                          std::string const &tag,
@@ -49,6 +67,16 @@ public:
                                  std::string const   &tag,
                                  std::set<int> const &acceptorRanks,
                                  int                  requesterRank) override;
+
+  void requestConnectionAsClient(std::string const                                &acceptorName,
+                                 std::string const                                &requesterName,
+                                 std::string const                                &tag,
+                                 std::set<int> const                              &acceptorRanks,
+                                 int                                               requesterRank,
+                                 serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
 
   void closeConnection() override;
 

--- a/src/com/MPISinglePortsCommunication.hpp
+++ b/src/com/MPISinglePortsCommunication.hpp
@@ -52,6 +52,24 @@ public:
                                 int                acceptorRank,
                                 int                requesterCommunicatorSize) override;
 
+  std::string prepareAcceptConnectionAsServer(std::string const &acceptorName,
+                                                      std::string const &requesterName,
+                                                      std::string const &tag,
+                                                      int                acceptorRank,
+                                                      int                requesterCommunicatorSize) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
+  void finishAcceptConnectionAsServer(std::string const &acceptorName,
+                                              std::string const &requesterName,
+                                              std::string const &tag,
+                                              int                acceptorRank,
+                                              int                requesterCommunicatorSize) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
   void requestConnection(std::string const &acceptorName,
                          std::string const &requesterName,
                          std::string const &tag,
@@ -63,6 +81,16 @@ public:
                                  std::string const   &tag,
                                  std::set<int> const &acceptorRanks,
                                  int                  requesterRank) override;
+
+  void requestConnectionAsClient(std::string const                                               &acceptorName,
+                                 std::string const                                               &requesterName,
+                                 std::string const                                               &tag,
+                                 std::set<int> const                                             &acceptorRanks,
+                                 int                                                              requesterRank,
+                                 serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
 
   void prepareEstablishment(std::string const &acceptorName,
                             std::string const &requesterName) override;

--- a/src/com/SerializedConnectionInfo.cpp
+++ b/src/com/SerializedConnectionInfo.cpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <numeric>
+
+#include "com/SerializedConnectionInfo.hpp"
+#include "utils/assertion.hpp"
+
+namespace precice::com::serialize {
+
+// SerializedConnectionInfoMap
+
+SerializedConnectionInfoMap SerializedConnectionInfoMap::serialize(const ConnectionInfoMap &cim)
+{
+  SerializedConnectionInfoMap scim;
+  auto                       &content = scim.content;
+
+  auto elements = std::transform_reduce(
+      cim.begin(), cim.end(),
+      1, // num entries
+      std::plus<size_t>{}, [](const auto &kv) {
+        // Rank, size, characters
+        return 2 + kv.second.size();
+      });
+  content.reserve(elements);
+
+  content.push_back(cim.size());
+  for (const auto &[rank, string] : cim) {
+    content.push_back(rank);
+    content.push_back(string.size());
+    content.insert(content.end(), string.begin(), string.end());
+  }
+  PRECICE_ASSERT(content.size() == static_cast<std::size_t>(elements));
+  scim.assertValid();
+  return scim;
+}
+
+SerializedConnectionInfoMap::ConnectionInfoMap SerializedConnectionInfoMap::toConnectionInfoMap() const
+{
+  auto begin      = content.begin();
+  int  numEntries = *begin;
+
+  if (numEntries == 0) {
+    return {};
+  }
+  std::advance(begin, 1);
+
+  ConnectionInfoMap cim;
+  for (int entry = 0; entry < numEntries; ++entry) {
+    // offset 0: rank
+    auto rank = *begin;
+    std::advance(begin, 1);
+    // offset 1: string size n
+    auto size = *begin;
+    std::advance(begin, 1);
+    // offset 2: n characters
+    auto stringStart = begin;
+    std::advance(begin, size);
+
+    cim.emplace(rank, std::string(stringStart, begin));
+  }
+  return cim;
+}
+
+void SerializedConnectionInfoMap::assertValid() const
+{
+  // TODO
+}
+
+void SerializedConnectionInfoMap::send(Communication &communication, int rankReceiver) const
+{
+  communication.sendRange(content, rankReceiver);
+}
+
+SerializedConnectionInfoMap SerializedConnectionInfoMap::receive(Communication &communication, int rankSender)
+{
+  SerializedConnectionInfoMap scim;
+  scim.content = communication.receiveRange(rankSender, asVector<int>);
+  scim.assertValid();
+  return scim;
+}
+
+void SerializedConnectionInfoMap::broadcastSend(Communication &communication) const
+{
+  communication.broadcast(content);
+}
+
+SerializedConnectionInfoMap SerializedConnectionInfoMap::broadcastReceive(Communication &communication)
+{
+  SerializedConnectionInfoMap scim;
+  communication.broadcast(scim.content, 0);
+  scim.assertValid();
+  return scim;
+}
+
+} // namespace precice::com::serialize

--- a/src/com/SerializedConnectionInfo.hpp
+++ b/src/com/SerializedConnectionInfo.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <map>
+#include <vector>
+
+#include  "precice/impl/Types.hpp"
+
+namespace precice::com {
+class Communication;
+
+namespace serialize {
+
+/// serialized representation of ConnectionInfoMap
+class SerializedConnectionInfoMap {
+public:
+  using ConnectionInfoMap = std::map<Rank, std::string>;
+
+  /** serializes a given ConnectionInfoMap
+   *
+   * Calls assertValid
+   */
+  static SerializedConnectionInfoMap serialize(const ConnectionInfoMap &cim);
+
+  /// Builds and returns the connection info map represented by the serialized state
+  ConnectionInfoMap toConnectionInfoMap() const;
+
+  /// asserts the content for correctness
+  void assertValid() const;
+
+  void send(Communication &communication, int rankReceiver) const;
+
+  /// receives a SerializedConnectionInfoMap and calls assertValid before returning
+  static SerializedConnectionInfoMap receive(Communication &communication, int rankSender);
+
+  void broadcastSend(Communication &communication) const;
+
+  /// receives a SerializedConnectionInfoMap and calls assertValid before returning
+  static SerializedConnectionInfoMap broadcastReceive(Communication &communication);
+
+private:
+  SerializedConnectionInfoMap() = default;
+
+  /// Num entries, Rank0, StringLength0, String0, Rank1, ...
+  /// @TODO move to size_t once we changed VertexIDs to size_t
+  std::vector<int> content;
+};
+
+} // namespace serialize
+
+} // namespace precice::com

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -68,8 +68,13 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
   std::string address;
 
   try {
+    Event e0("socket.acceptConnection.getIpAddress");
+
     std::string ipAddress = getIpAddress();
     PRECICE_CHECK(not ipAddress.empty(), "Network \"{}\" not found for socket connection!", _networkName);
+
+    e0.stop();
+    Event e1("socket.acceptConnection.openPort");
 
     using asio::ip::tcp;
 
@@ -81,17 +86,27 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
     acceptor.bind(endpoint);
     acceptor.listen();
 
+    e1.stop();
+    Event e2("socket.acceptConnection.writeConInfo");
+
     _portNumber = acceptor.local_endpoint().port();
     address     = ipAddress + ":" + std::to_string(_portNumber);
     ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, _addressDirectory);
     conInfo.write(address);
     PRECICE_DEBUG("Accept connection at {}", address);
 
+    e2.stop();
+    Event e3("socket.acceptConnection.acceptConnections");
+
     int peerCurrent               = 0;  // Current peer to connect to
     int peerCount                 = -1; // The total count of peers (initialized in the first iteration)
     int requesterCommunicatorSize = -1;
 
     do {
+      Event e3_0("socket.acceptConnection.acceptConnection");
+      e3_0.addData("peerCurrent", peerCurrent);
+      Event e3_0_0("socket.acceptConnection.makeSocket");
+
       auto socket = std::make_shared<Socket>(*_ioContext);
 
       acceptor.accept(*socket);
@@ -101,6 +116,9 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
       PRECICE_DEBUG("Accepted connection at {}", address);
       _isConnected = true;
 
+      e3_0_0.stop();
+      Event e3_0_1("socket.acceptConnection.readRequesterRank");
+
       int requesterRank = -1;
 
       asio::read(*socket, asio::buffer(&requesterRank, sizeof(int)));
@@ -109,12 +127,19 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
                      "Rank {} has already been connected. Duplicate requests are not allowed.", requesterRank);
 
       _sockets[requesterRank] = std::move(socket);
+
+      e3_0_1.stop();
+
       // send and receive expect a rank from the acceptor perspective.
       // Thus we need to apply given rankOffset before passing it to send/receive.
       // This is essentially the inverse of adjustRank().
       auto adjustedRequesterRank = requesterRank + rankOffset;
+      Event e3_0_2("socket.acceptConnection.sendAcceptorRank");
       send(acceptorRank, adjustedRequesterRank);
+      e3_0_2.stop();
+      Event e3_0_3("socket.acceptConnection.receiveRequesterCommunicatorSize");
       receive(requesterCommunicatorSize, adjustedRequesterRank);
+      e3_0_3.stop();
 
       // Initialize the count of peers to connect to
       if (peerCurrent == 0) {
@@ -125,16 +150,24 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
                      "Requester communicator size is {} which is invalid.", requesterCommunicatorSize);
       PRECICE_ASSERT(requesterCommunicatorSize == peerCount,
                      "Current requester size from rank {} is {} but should be {}", requesterRank, requesterCommunicatorSize, peerCount);
+
+      e3_0.stop();
     } while (++peerCurrent < requesterCommunicatorSize);
 
+    e3.stop();
+    Event e4("socket.acceptConnection.closeAcceptor");
     acceptor.close();
+    e4.stop();
   } catch (std::exception &e) {
     PRECICE_ERROR("Accepting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
+  Event e5("socket.acceptConnection.startThread");
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
   _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
+
+  e5.stop();
 }
 
 void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorName,
@@ -156,8 +189,13 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
   std::string address;
 
   try {
+    Event e0("socket.acceptConnectionAsServer.getIpAddress");
+
     std::string ipAddress = getIpAddress();
     PRECICE_ASSERT(not ipAddress.empty(), "Network \"{}\" not found for socket connection!", _networkName);
+
+    e0.stop();
+    Event e1("socket.acceptConnectionAsServer.openPort");
 
     using asio::ip::tcp;
 
@@ -173,13 +211,23 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
       _portNumber = acceptor.local_endpoint().port();
     }
 
+    e1.stop();
+    Event e2("socket.acceptConnectionAsServer.writeConInfo");
+
     address = ipAddress + ":" + std::to_string(_portNumber);
     ConnectionInfoWriter conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     conInfo.write(address);
 
+    e2.stop();
+    Event e3("socket.acceptConnectionAsServer.acceptConnections");
+
     PRECICE_DEBUG("Accepting connection at {}", address);
 
     for (int connection = 0; connection < requesterCommunicatorSize; ++connection) {
+      Event e3_0("socket.acceptConnectionAsServer.acceptConnection");
+      e3_0.addData("connection", connection);
+      Event e3_0_0("socket.acceptConnectionAsServer.makeSocket");
+
       auto socket = std::make_shared<Socket>(*_ioContext);
       acceptor.accept(*socket);
       boost::asio::ip::tcp::no_delay option(true);
@@ -187,19 +235,31 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
       PRECICE_DEBUG("Accepted connection at {}", address);
       _isConnected = true;
 
+      e3_0_0.stop();
+      Event e3_0_1("socket.acceptConnectionAsServer.readRequesterRank");
+
       int requesterRank;
       asio::read(*socket, asio::buffer(&requesterRank, sizeof(int)));
       _sockets[requesterRank] = std::move(socket);
+
+      e3_0_1.stop();
+      e3_0.stop();
     }
 
+    e3.stop();
+    Event e4("socket.acceptConnectionAsServer.closeAcceptor");
     acceptor.close();
+    e4.stop();
   } catch (std::exception &e) {
     PRECICE_ERROR("Accepting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
+  Event e5("socket.acceptConnectionAsServer.startThread");
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
   _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
+
+  e5.stop();
 }
 
 void SocketCommunication::requestConnection(std::string const &acceptorName,
@@ -211,6 +271,8 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected());
 
+  Event e0("socket.requestConnection.readConInfo");
+
   ConnectionInfoReader conInfo(acceptorName, requesterName, tag, _addressDirectory);
   std::string const    address = conInfo.read();
   PRECICE_DEBUG("Request connection to {}", address);
@@ -219,48 +281,75 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
   std::string const portNumber = address.substr(sepidx + 1);
   _portNumber                  = static_cast<unsigned short>(std::stoul(portNumber));
 
+  e0.stop();
+
   try {
+    Event e1("socket.acceptConnection.makeSocket");
     auto socket = std::make_shared<Socket>(*_ioContext);
+
+    e1.stop();
+    Event e2("socket.requestConnection.connect");
 
     using asio::ip::tcp;
 
     while (not isConnected()) {
+      Event e2_0("socket.requestConnection.resolve");
       tcp::resolver resolver(*_ioContext);
       auto          results = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
+
+      e2_0.stop();
+      Event e2_1("socket.requestConnection.connectToEndpoint");
 
       auto                      endpoint = results.begin()->endpoint();
       boost::system::error_code error    = asio::error::host_not_found;
       socket->connect(endpoint, error);
 
+      e2_1.stop();
+
       _isConnected = not error;
 
       if (not isConnected()) {
+        Event e2_2("socket.requestConnection.wait");
         // Wait a little, since after a couple of ten-thousand trials the system
         // seems to get confused and the requester connects wrongly to itself.
         boost::asio::deadline_timer timer(*_ioContext, boost::posix_time::milliseconds(1));
         timer.wait();
+        e2_2.stop();
       }
     }
     boost::asio::ip::tcp::no_delay option(true);
     socket->set_option(option);
 
+    e2.stop();
+    Event e3("socket.requestConnection.writeRequesterRank");
+
     PRECICE_DEBUG("Requested connection to {}", address);
 
     asio::write(*socket, asio::buffer(&requesterRank, sizeof(int)));
+
+    e3.stop();
+    Event e4("socket.requestConnection.readAcceptorRank");
 
     int acceptorRank = -1;
     asio::read(*socket, asio::buffer(&acceptorRank, sizeof(int)));
     _sockets[0] = std::move(socket); // should be acceptorRank instead of 0, likewise all communication below
 
+    e4.stop();
+    Event e5("socket.requestConnection.sendRequesterCommunicatorSize");
+
     send(requesterCommunicatorSize, 0);
 
+    e5.stop();
   } catch (std::exception &e) {
     PRECICE_ERROR("Requesting a socket connection at {} failed with the system error: {}", address, e.what());
   }
 
+  Event e6("socket.requestConnection.startThread");
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
   _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
+
+  e6.stop();
 }
 
 void SocketCommunication::requestConnectionAsClient(std::string const   &acceptorName,
@@ -274,6 +363,10 @@ void SocketCommunication::requestConnectionAsClient(std::string const   &accepto
   PRECICE_ASSERT(not isConnected());
 
   for (auto const &acceptorRank : acceptorRanks) {
+    Event e0("socket.requestConnectionAsClient.");
+    e0.addData("acceptorRank", acceptorRank);
+    Event e0_0("socket.requestConnectionAsClient.readConInfo");
+
     _isConnected = false;
     ConnectionInfoReader conInfo(acceptorName, requesterName, tag, acceptorRank, _addressDirectory);
     std::string const    address    = conInfo.read();
@@ -282,43 +375,69 @@ void SocketCommunication::requestConnectionAsClient(std::string const   &accepto
     std::string const    portNumber = address.substr(sepidx + 1);
     _portNumber                     = static_cast<unsigned short>(std::stoul(portNumber));
 
+    e0_0.stop();
+
     try {
+      Event e0_1("socket.requestConnectionAsClient.makeSocket");
+
       auto socket = std::make_shared<Socket>(*_ioContext);
+
+      e0_1.stop();
+      Event e0_2("socket.requestConnectionAsClient.connect");
 
       using asio::ip::tcp;
 
       PRECICE_DEBUG("Requesting connection to {}, port {}", ipAddress, portNumber);
 
       while (not isConnected()) {
+        Event e0_2_0("socket.requestConnectionAsClient.resolve");
         tcp::resolver resolver(*_ioContext);
         auto          endpoints = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
+
+        e0_2_0.stop();
+        Event e0_2_1("socket.requestConnectionAsClient.connectToEndpoint");
 
         boost::system::error_code error = asio::error::host_not_found;
         boost::asio::connect(*socket, endpoints, error);
 
         _isConnected = not error;
 
+        e0_2_1.stop();
+
         if (not isConnected()) {
+          Event e0_2_2("socket.requestConnectionAsClient.wait");
           // Wait a little, since after a couple of ten-thousand trials the system
           // seems to get confused and the requester connects wrongly to itself.
           boost::asio::deadline_timer timer(*_ioContext, boost::posix_time::milliseconds(1));
           timer.wait();
+
+          e0_2_2.stop();
         }
       }
       boost::asio::ip::tcp::no_delay option(true);
       socket->set_option(option);
 
+      e0_2.stop();
+      Event e0_3("socket.requestConnectionAsClient.sendRequesterRank");
+
       PRECICE_DEBUG("Requested connection to {}, rank = {}", address, acceptorRank);
       _sockets[acceptorRank] = std::move(socket);
       send(requesterRank, acceptorRank); // send my rank
 
+      e0_3.stop();
     } catch (std::exception &e) {
       PRECICE_ERROR("Requesting a socket connection at {} failed with the system error: {}", address, e.what());
     }
+
+    e0.stop();
   }
+
+  Event e6("socket.requestConnectionAsClient.startThread");
   // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
   _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
   _thread    = std::thread([this] { _ioContext->run(); });
+
+  e6.stop();
 }
 
 void SocketCommunication::closeConnection()

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -12,9 +12,12 @@
 #include "SocketRequest.hpp"
 #include "logging/LogMacros.hpp"
 #include "precice/impl/Types.hpp"
+#include "profiling/Event.hpp"
 #include "utils/assertion.hpp"
 #include "utils/networking.hpp"
 #include "utils/span_tools.hpp"
+
+using precice::profiling::Event;
 
 namespace precice::com {
 
@@ -133,7 +136,7 @@ void SocketCommunication::acceptConnection(std::string const &acceptorName,
       // send and receive expect a rank from the acceptor perspective.
       // Thus we need to apply given rankOffset before passing it to send/receive.
       // This is essentially the inverse of adjustRank().
-      auto adjustedRequesterRank = requesterRank + rankOffset;
+      auto  adjustedRequesterRank = requesterRank + rankOffset;
       Event e3_0_2("socket.acceptConnection.sendAcceptorRank");
       send(acceptorRank, adjustedRequesterRank);
       e3_0_2.stop();
@@ -262,6 +265,113 @@ void SocketCommunication::acceptConnectionAsServer(std::string const &acceptorNa
   e5.stop();
 }
 
+std::string SocketCommunication::prepareAcceptConnectionAsServer(std::string const &acceptorName,
+                                                                 std::string const &requesterName,
+                                                                 std::string const &tag,
+                                                                 int                acceptorRank,
+                                                                 int                requesterCommunicatorSize)
+{
+  PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
+  PRECICE_ASSERT(requesterCommunicatorSize >= 0, "Requester communicator size has to be positive.");
+  PRECICE_ASSERT(not isConnected());
+
+  if (requesterCommunicatorSize == 0) {
+    PRECICE_DEBUG("Accepting no connections.");
+    _isConnected = true;
+    return nullptr;
+  }
+
+  std::string address;
+
+  try {
+    Event e0("socket.acceptConnectionAsServer.getIpAddress");
+
+    std::string ipAddress = getIpAddress();
+    PRECICE_ASSERT(not ipAddress.empty(), "Network \"{}\" not found for socket connection!", _networkName);
+
+    e0.stop();
+    Event e1("socket.acceptConnectionAsServer.openPort");
+
+    using asio::ip::tcp;
+
+    _acceptor = std::make_unique<Acceptor>(*_ioContext);
+    {
+      tcp::endpoint endpoint(tcp::v4(), _portNumber);
+
+      _acceptor->open(endpoint.protocol());
+      _acceptor->set_option(tcp::acceptor::reuse_address(_reuseAddress));
+      _acceptor->bind(endpoint);
+      _acceptor->listen();
+
+      _portNumber = _acceptor->local_endpoint().port();
+    }
+
+    e1.stop();
+
+    address = ipAddress + ":" + std::to_string(_portNumber);
+    return address;
+  } catch (std::exception &e) {
+    PRECICE_ERROR("Preparing accepting a socket connection at {} failed with the system error: {}", address, e.what());
+  }
+}
+
+void SocketCommunication::finishAcceptConnectionAsServer(std::string const &acceptorName,
+                                                                std::string const &requesterName,
+                                                                std::string const &tag,
+                                                                int                acceptorRank,
+                                                                int                requesterCommunicatorSize)
+{
+  PRECICE_TRACE(acceptorName, requesterName, acceptorRank, requesterCommunicatorSize);
+  PRECICE_ASSERT(requesterCommunicatorSize >= 0, "Requester communicator size has to be positive.");
+  PRECICE_ASSERT(not isConnected());
+  // TODO: Check if acceptor is fine
+
+  std::string address = getIpAddress() + ":" + std::to_string(_portNumber);
+
+  try {
+    Event e3("socket.acceptConnectionAsServer.acceptConnections");
+
+    PRECICE_DEBUG("Accepting connection at {}", address);
+
+    for (int connection = 0; connection < requesterCommunicatorSize; ++connection) {
+      Event e3_0("socket.acceptConnectionAsServer.acceptConnection");
+      e3_0.addData("connection", connection);
+      Event e3_0_0("socket.acceptConnectionAsServer.makeSocket");
+
+      auto socket = std::make_shared<Socket>(*_ioContext);
+      _acceptor->accept(*socket);
+      asio::ip::tcp::no_delay option(true);
+      socket->set_option(option);
+      PRECICE_DEBUG("Accepted connection at {}", address);
+      _isConnected = true;
+
+      e3_0_0.stop();
+      Event e3_0_1("socket.acceptConnectionAsServer.readRequesterRank");
+
+      int requesterRank;
+      asio::read(*socket, asio::buffer(&requesterRank, sizeof(int)));
+      _sockets[requesterRank] = std::move(socket);
+
+      e3_0_1.stop();
+      e3_0.stop();
+    }
+
+    e3.stop();
+    Event e4("socket.acceptConnectionAsServer.closeAcceptor");
+    _acceptor->close();
+    e4.stop();
+  } catch (std::exception &e) {
+    PRECICE_ERROR("Accepting a socket connection at {} failed with the system error: {}", address, e.what());
+  }
+
+  Event e5("socket.acceptConnectionAsServer.startThread");
+  // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
+  _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _thread    = std::thread([this] { _ioContext->run(); });
+
+  e5.stop();
+}
+
 void SocketCommunication::requestConnection(std::string const &acceptorName,
                                             std::string const &requesterName,
                                             std::string const &tag,
@@ -285,7 +395,7 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
 
   try {
     Event e1("socket.acceptConnection.makeSocket");
-    auto socket = std::make_shared<Socket>(*_ioContext);
+    auto  socket = std::make_shared<Socket>(*_ioContext);
 
     e1.stop();
     Event e2("socket.requestConnection.connect");
@@ -293,7 +403,7 @@ void SocketCommunication::requestConnection(std::string const &acceptorName,
     using asio::ip::tcp;
 
     while (not isConnected()) {
-      Event e2_0("socket.requestConnection.resolve");
+      Event         e2_0("socket.requestConnection.resolve");
       tcp::resolver resolver(*_ioContext);
       auto          results = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
 
@@ -390,7 +500,96 @@ void SocketCommunication::requestConnectionAsClient(std::string const   &accepto
       PRECICE_DEBUG("Requesting connection to {}, port {}", ipAddress, portNumber);
 
       while (not isConnected()) {
-        Event e0_2_0("socket.requestConnectionAsClient.resolve");
+        Event         e0_2_0("socket.requestConnectionAsClient.resolve");
+        tcp::resolver resolver(*_ioContext);
+        auto          endpoints = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
+
+        e0_2_0.stop();
+        Event e0_2_1("socket.requestConnectionAsClient.connectToEndpoint");
+
+        boost::system::error_code error = asio::error::host_not_found;
+        boost::asio::connect(*socket, endpoints, error);
+
+        _isConnected = not error;
+
+        e0_2_1.stop();
+
+        if (not isConnected()) {
+          Event e0_2_2("socket.requestConnectionAsClient.wait");
+          // Wait a little, since after a couple of ten-thousand trials the system
+          // seems to get confused and the requester connects wrongly to itself.
+          boost::asio::deadline_timer timer(*_ioContext, boost::posix_time::milliseconds(1));
+          timer.wait();
+
+          e0_2_2.stop();
+        }
+      }
+      boost::asio::ip::tcp::no_delay option(true);
+      socket->set_option(option);
+
+      e0_2.stop();
+      Event e0_3("socket.requestConnectionAsClient.sendRequesterRank");
+
+      PRECICE_DEBUG("Requested connection to {}, rank = {}", address, acceptorRank);
+      _sockets[acceptorRank] = std::move(socket);
+      send(requesterRank, acceptorRank); // send my rank
+
+      e0_3.stop();
+    } catch (std::exception &e) {
+      PRECICE_ERROR("Requesting a socket connection at {} failed with the system error: {}", address, e.what());
+    }
+
+    e0.stop();
+  }
+
+  Event e6("socket.requestConnectionAsClient.startThread");
+  // NOTE: Keep IO context running so that it fires asynchronous handlers from another thread.
+  _workGuard = std::make_unique<WorkGuard>(boost::asio::make_work_guard(_ioContext->get_executor()));
+  _thread    = std::thread([this] { _ioContext->run(); });
+
+  e6.stop();
+}
+
+void SocketCommunication::requestConnectionAsClient(std::string const                                               &acceptorName,
+                                                    std::string const                                               &requesterName,
+                                                    std::string const                                               &tag,
+                                                    std::set<int> const                                             &acceptorRanks,
+                                                    int                                                              requesterRank,
+                                                    serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap)
+
+{
+  PRECICE_TRACE(acceptorName, requesterName, acceptorRanks, requesterRank);
+  PRECICE_ASSERT(not isConnected());
+
+  for (auto const &acceptorRank : acceptorRanks) {
+    Event e0("socket.requestConnectionAsClient.requestConnection");
+    e0.addData("acceptorRank", acceptorRank);
+    Event e0_0("socket.requestConnectionAsClient.readConInfo");
+
+    _isConnected = false;
+
+    std::string const address    = connectionInfoMap.at(acceptorRank);
+    auto const        sepidx     = address.find(':');
+    std::string const ipAddress  = address.substr(0, sepidx);
+    std::string const portNumber = address.substr(sepidx + 1);
+    _portNumber                  = static_cast<unsigned short>(std::stoul(portNumber));
+
+    e0_0.stop();
+
+    try {
+      Event e0_1("socket.requestConnectionAsClient.makeSocket");
+
+      auto socket = std::make_shared<Socket>(*_ioContext);
+
+      e0_1.stop();
+      Event e0_2("socket.requestConnectionAsClient.connect");
+
+      using asio::ip::tcp;
+
+      PRECICE_DEBUG("Requesting connection to {}, port {}", ipAddress, portNumber);
+
+      while (not isConnected()) {
+        Event         e0_2_0("socket.requestConnectionAsClient.resolve");
         tcp::resolver resolver(*_ioContext);
         auto          endpoints = resolver.resolve(ipAddress, portNumber, boost::asio::ip::resolver_base::numeric_host);
 

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -363,7 +363,7 @@ void SocketCommunication::requestConnectionAsClient(std::string const   &accepto
   PRECICE_ASSERT(not isConnected());
 
   for (auto const &acceptorRank : acceptorRanks) {
-    Event e0("socket.requestConnectionAsClient.");
+    Event e0("socket.requestConnectionAsClient.requestConnection");
     e0.addData("acceptorRank", acceptorRank);
     Event e0_0("socket.requestConnectionAsClient.readConInfo");
 

--- a/src/com/SocketCommunication.cpp
+++ b/src/com/SocketCommunication.cpp
@@ -278,7 +278,7 @@ std::string SocketCommunication::prepareAcceptConnectionAsServer(std::string con
   if (requesterCommunicatorSize == 0) {
     PRECICE_DEBUG("Accepting no connections.");
     _isConnected = true;
-    return nullptr;
+    return std::string();
   }
 
   std::string address;

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -146,7 +146,7 @@ public:
   }
 
   /// Gathers an array of ints per process.
-  void gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts) override
+  void gather(span<const int> itemToSend, std::vector<std::vector<int>>& itemsToReceive, const std::vector<int>& recvcounts) override
   {
     PRECICE_ASSERT(false, "Not implemented!");
   }

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -42,6 +42,18 @@ public:
                                 int                acceptorRank,
                                 int                requesterCommunicatorSize) override;
 
+  std::string prepareAcceptConnectionAsServer(std::string const &acceptorName,
+                                              std::string const &requesterName,
+                                              std::string const &tag,
+                                              int                acceptorRank,
+                                              int                requesterCommunicatorSize) override;
+
+  void finishAcceptConnectionAsServer(std::string const &acceptorName,
+                                      std::string const &requesterName,
+                                      std::string const &tag,
+                                      int                acceptorRank,
+                                      int                requesterCommunicatorSize) override;
+
   void requestConnection(std::string const &acceptorName,
                          std::string const &requesterName,
                          std::string const &tag,
@@ -53,6 +65,13 @@ public:
                                  std::string const   &tag,
                                  std::set<int> const &acceptorRanks,
                                  int                  requesterRank) override;
+
+  void requestConnectionAsClient(std::string const                                               &acceptorName,
+                                 std::string const                                               &requesterName,
+                                 std::string const                                               &tag,
+                                 std::set<int> const                                             &acceptorRanks,
+                                 int                                                              requesterRank,
+                                 serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap) override;
 
   void closeConnection() override;
 
@@ -141,10 +160,12 @@ private:
   std::string _addressDirectory;
 
   using IOContext = boost::asio::io_context;
+  using Acceptor  = boost::asio::ip::tcp::acceptor;
   using Socket    = boost::asio::ip::tcp::socket;
   using WorkGuard = boost::asio::executor_work_guard<IOContext::executor_type>;
 
   std::shared_ptr<IOContext> _ioContext;
+  std::unique_ptr<Acceptor>  _acceptor;
   std::unique_ptr<WorkGuard> _workGuard;
   std::thread                _thread;
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -151,6 +151,12 @@ public:
     PRECICE_ASSERT(false, "Not implemented!");
   }
 
+  /// Gathers a string of specified length per process.
+  void gather(std::string itemToSend, std::vector<std::string>& itemsToReceive, const std::vector<int>& recvcounts) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
   void prepareEstablishment(std::string const &acceptorName,
                             std::string const &requesterName) override;
 

--- a/src/com/SocketCommunication.hpp
+++ b/src/com/SocketCommunication.hpp
@@ -139,6 +139,18 @@ public:
   /// Asynchronously receives a bool from process with given rank.
   PtrRequest aReceive(bool &itemToReceive, Rank rankSender) override;
 
+  /// Gathers an int per process.
+  void gather(int itemToSend, std::vector<int> &itemsToReceive) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
+  /// Gathers an array of ints per process.
+  void gather(span<const int> itemToSend, std::vector<std::vector<int>> itemsToReceive, std::vector<int> recvcounts) override
+  {
+    PRECICE_ASSERT(false, "Not implemented!");
+  }
+
   void prepareEstablishment(std::string const &acceptorName,
                             std::string const &requesterName) override;
 

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -1,6 +1,7 @@
 #include <memory>
 
 #include "com/Communication.hpp"
+#include "com/Extra.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/LogMacros.hpp"
 #include "m2n/BoundM2N.hpp"
@@ -60,14 +61,71 @@ void BoundM2N::preConnectSecondaryRanks()
   PRECICE_WARN("Two-level initialization is still in beta testing. Several edge cases are known to fail. Please report problems nevertheless.");
   Event e("bound-m2n.preConnectSecondaryRanks");
 
-  if (isRequesting) {
-    PRECICE_DEBUG("Awaiting preliminary secondary connections from {}", remoteName);
-    m2n->requestSecondaryRanksPreConnection(remoteName, localName);
-    PRECICE_DEBUG("Established preliminary secondary connections from {}", remoteName);
-  } else {
+  // Accepting side (set up, gather connection info, communicate to requesting side)
+  if (!isRequesting) {
+    // Set up accepting side
+    PRECICE_DEBUG("Setting up preliminary secondary connections from {}", localName);
+    std::string connectionInfo;
+    connectionInfo = m2n->prepareAcceptSecondaryRanksPreConnection(localName, remoteName);
+    PRECICE_DEBUG("Set up preliminary secondary connections from {}. Ready for establishing connections.", localName);
+
+    // Gather connection info and communicate it
+    if (utils::IntraComm::isSecondary()) {
+      Event e1("bound-m2n.gatherSendConnectionInfo");
+      com::sendConnectionInfo(*utils::IntraComm::getCommunication(), 0, connectionInfo);
+      e1.stop();
+    } else { // Primary
+      // Gather connection info
+      Event e1("bound-m2n.gatherConnectionInfoMap");
+
+      std::map<Rank, std::string> connectionInfoMap;
+
+      // Store the primary rank's connection info as well
+      connectionInfoMap.emplace(0, connectionInfo);
+
+      for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
+        connectionInfoMap.emplace(secondaryRank, "");
+
+        Event e2("bound-m2n.gatherReceiveConnectionInfo");
+        com::receiveConnectionInfo(*utils::IntraComm::getCommunication(), secondaryRank, connectionInfoMap.at(secondaryRank));
+        e2.stop();
+      }
+
+      e1.stop();
+
+      // Communicate connection info via primaries
+      Event e2("bound-m2n.sendConnectionInfoMap");
+      com::sendConnectionInfoMap(*m2n->getPrimaryRankCommunication(), 0, connectionInfoMap);
+      e2.stop();
+    }
+
     PRECICE_DEBUG("Establishing preliminary secondary connections to {}", remoteName);
-    m2n->acceptSecondaryRanksPreConnection(localName, remoteName);
+    m2n->finishAcceptSecondaryRanksPreConnection(localName, remoteName);
     PRECICE_DEBUG("Established preliminary secondary connections to {}", remoteName);
+  } else { // isRequesting
+    com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap connectionInfoMap;
+
+    if (utils::IntraComm::isPrimary()) {
+      // Communicate connection info via primaries
+      Event e1("bound-m2n.receiveConnectionInfoMap");
+      com::receiveConnectionInfoMap(*m2n->getPrimaryRankCommunication(), 0, connectionInfoMap);
+      e1.stop();
+
+      // Scatter connection info
+      Event e2("bound-m2n.scatterSendConnectionInfoMap");
+      com::broadcastSendConnectionInfoMap(*utils::IntraComm::getCommunication(), connectionInfoMap);
+      e2.stop();
+    } else {
+      // Receive connection info from scatter
+      Event e1("bound-m2n.scatterReceiveConnectionInfoMap");
+      com::broadcastReceiveConnectionInfoMap(*utils::IntraComm::getCommunication(), connectionInfoMap);
+      e1.stop();
+    }
+
+    // Connect to the accepting side
+    PRECICE_DEBUG("Awaiting preliminary secondary connections from {}", remoteName);
+    m2n->requestSecondaryRanksPreConnection(remoteName, localName, connectionInfoMap);
+    PRECICE_DEBUG("Established preliminary secondary connections from {}", remoteName);
   }
 }
 

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -80,15 +80,14 @@ void BoundM2N::preConnectSecondaryRanks()
 
       std::map<Rank, std::string> connectionInfoMap;
 
+      std::vector<std::string> allConnectionInfos = utils::IntraComm::getCommunication()->gatherRanges(connectionInfo);
+
       // Store the primary rank's connection info as well
-      connectionInfoMap.emplace(0, connectionInfo);
+      connectionInfoMap.emplace(0, allConnectionInfos[0]);
 
       for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
-        connectionInfoMap.emplace(secondaryRank, "");
-
-        Event e2("bound-m2n.gatherReceiveConnectionInfo");
-        com::receiveConnectionInfo(*utils::IntraComm::getCommunication(), secondaryRank, connectionInfoMap.at(secondaryRank));
-        e2.stop();
+        PRECICE_ASSERT(secondaryRank < allConnectionInfos.size(), "Connection information from secondary rank not received");
+        connectionInfoMap.emplace(secondaryRank, allConnectionInfos[secondaryRank]);
       }
 
       e1.stop();

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -72,7 +72,7 @@ void BoundM2N::preConnectSecondaryRanks()
     // Gather connection info and communicate it
     if (utils::IntraComm::isSecondary()) {
       Event e1("bound-m2n.gatherSendConnectionInfo");
-      com::sendConnectionInfo(*utils::IntraComm::getCommunication(), 0, connectionInfo);
+      utils::IntraComm::getCommunication()->gatherRanges(connectionInfo);
       e1.stop();
     } else { // Primary
       // Gather connection info

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -10,6 +10,8 @@
 #include "utils/assertion.hpp"
 #include "profiling/Event.hpp"
 
+using precice::profiling::Event;
+
 namespace precice::m2n {
 
 void BoundM2N::prepareEstablishment()

--- a/src/m2n/BoundM2N.cpp
+++ b/src/m2n/BoundM2N.cpp
@@ -8,6 +8,7 @@
 #include "precice/impl/Types.hpp"
 #include "utils/IntraComm.hpp"
 #include "utils/assertion.hpp"
+#include "profiling/Event.hpp"
 
 namespace precice::m2n {
 
@@ -55,6 +56,7 @@ void BoundM2N::preConnectSecondaryRanks()
     return;
 
   PRECICE_WARN("Two-level initialization is still in beta testing. Several edge cases are known to fail. Please report problems nevertheless.");
+  Event e("bound-m2n.preConnectSecondaryRanks");
 
   if (isRequesting) {
     PRECICE_DEBUG("Awaiting preliminary secondary connections from {}", remoteName);

--- a/src/m2n/DistributedCommunication.hpp
+++ b/src/m2n/DistributedCommunication.hpp
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <vector>
+#include "com/SerializedConnectionInfo.hpp"
 #include "mesh/Mesh.hpp"
 #include "mesh/SharedPointer.hpp"
 #include "precice/span.hpp"
@@ -77,6 +78,29 @@ public:
       std::string const &requesterName) = 0;
 
   /**
+   * @brief Set up a server, so that another participant, can connect using requestConnection().
+   *        Call finishAcceptConnection() afterward to respond to requestConnection() calls.
+   *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
+   * @return connectionInfo Information on how to connect to the server that has been set up in this function
+   */
+  virtual std::string prepareAcceptPreConnection(
+      const std::string &acceptorName,
+      const std::string &requesterName) = 0;
+
+  /**
+   * @brief Connects to another participant, which has to call requestConnection().
+   *        Must not be called before prepareAcceptConnection
+   *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
+   */
+  virtual void finishAcceptPreConnection(
+      const std::string &acceptorName,
+      const std::string &requesterName) = 0;
+
+  /**
    * @brief Connects to another participant, which has to call acceptPreConnection().
    *        Exchanged vertex list is not included, only connection between ranks
    *        is established.
@@ -87,6 +111,22 @@ public:
   virtual void requestPreConnection(
       std::string const &acceptorName,
       std::string const &requesterName) = 0;
+
+  /**
+   * @brief Connects to another participant, which has to call acceptPreConnection().
+   *        Exchanged vertex list is not included, only connection between ranks
+   *        is established.
+   *        This version of the function takes a connectionInfo string, that tells
+   *        it how to connect to the accepting side.
+   *
+   * @param[in] acceptorName Name of remote participant to connect to.
+   * @param[in] requesterName Name of calling participant.
+   * @param[in] connectionInfoMap Connection info containing information on how to connect to accepting side
+   */
+  virtual void requestPreConnection(
+      std::string const                                                    &acceptorName,
+      std::string const                                                    &requesterName,
+      const com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap) = 0;
 
   /* @brief Completes the secondary connections for both acceptor and requester by updating
    * the vertex list in _mappings.

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -213,9 +213,32 @@ void GatherScatterCommunication::acceptPreConnection(
   PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
 }
 
+std::string GatherScatterCommunication::prepareAcceptPreConnection(
+    std::string const &acceptorName,
+    std::string const &requesterName)
+{
+  PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
+  return nullptr;
+}
+
+void GatherScatterCommunication::finishAcceptPreConnection(
+    std::string const &acceptorName,
+    std::string const &requesterName)
+{
+  PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
+}
+
 void GatherScatterCommunication::requestPreConnection(
     std::string const &acceptorName,
     std::string const &requesterName)
+{
+  PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
+}
+
+void GatherScatterCommunication::requestPreConnection(
+    std::string const                                                    &acceptorName,
+    std::string const                                                    &requesterName,
+    com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfo)
 {
   PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
 }

--- a/src/m2n/GatherScatterCommunication.cpp
+++ b/src/m2n/GatherScatterCommunication.cpp
@@ -218,7 +218,6 @@ std::string GatherScatterCommunication::prepareAcceptPreConnection(
     std::string const &requesterName)
 {
   PRECICE_ASSERT(false, "Not available for GatherScatterCommunication.");
-  return nullptr;
 }
 
 void GatherScatterCommunication::finishAcceptPreConnection(

--- a/src/m2n/GatherScatterCommunication.hpp
+++ b/src/m2n/GatherScatterCommunication.hpp
@@ -63,12 +63,51 @@ public:
       std::string const &requesterName) override;
 
   /**
+   * @brief Set up a server, so that another participant, can connect using requestConnection().
+   *        Call finishAcceptConnection() afterward to respond to requestConnection() calls.
+    *
+     * @param[in] acceptorName Name of calling participant.
+     * @param[in] requesterName Name of remote participant to connect to.
+     * @return connectionInfo Information on how to connect to the server that has been set up in this function
+     */
+    std::string prepareAcceptPreConnection(
+        const std::string &acceptorName,
+        const std::string &requesterName) override;
+
+  /**
+   * @brief Connects to another participant, which has to call requestConnection().
+   *        Must not be called before prepareAcceptConnection
+   *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
+   */
+  void finishAcceptPreConnection(
+      const std::string &acceptorName,
+      const std::string &requesterName) override;
+
+  /**
    *  This method has not been implemented yet.
    *  @todo: Ideally this should not be here
    */
   void requestPreConnection(
       std::string const &acceptorName,
       std::string const &requesterName) override;
+
+  /**
+   * @brief Connects to another participant, which has to call acceptPreConnection().
+   *        Exchanged vertex list is not included, only connection between ranks
+   *        is established.
+   *        This version of the function takes a connectionInfo string, that tells
+   *        it how to connect to the accepting side.
+   *
+   * @param[in] acceptorName Name of remote participant to connect to.
+   * @param[in] requesterName Name of calling participant.
+   * @param[in] connectionInfo Connection info string containing information on how to connect to accepting side
+   */
+  void requestPreConnection(
+      std::string const                                     &acceptorName,
+      std::string const                                     &requesterName,
+      com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfo) override;
 
   /// Completes the secondary connections for both acceptor and requester by updating the vertex list in _mappings
   void completeSecondaryRanksConnection() override;

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -237,6 +237,8 @@ void M2N::finishAcceptSecondaryRanksPreConnection(
     }
 
     _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
+
+    PRECICE_ASSERT(pair.second->isConnected());
     e1.stop();
   }
   PRECICE_ASSERT(_areSecondaryRanksConnected);

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -197,9 +197,49 @@ void M2N::acceptSecondaryRanksPreConnection(
   PRECICE_ASSERT(_areSecondaryRanksConnected);
 }
 
-void M2N::requestSecondaryRanksPreConnection(
+std::string M2N::prepareAcceptSecondaryRanksPreConnection(
     const std::string &acceptorName,
     const std::string &requesterName)
+{
+  PRECICE_TRACE(acceptorName);
+  PRECICE_ASSERT(not _useOnlyPrimaryCom);
+  Event e("m2n.prepareAcceptSecondaryRanksPreConnection");
+
+  for (const auto &pair : _distComs) {
+    Event e1("m2n.prepareAcceptSecondaryRanksPreConnection." + std::to_string(pair.first));
+
+    std::string connectionInfo = pair.second->prepareAcceptPreConnection(acceptorName, requesterName);
+
+    e1.stop();
+
+    // TODO: Make this work with more than one communication pair
+    return connectionInfo;
+  }
+
+  PRECICE_ASSERT(false, "Must have at least one communication pair");
+}
+
+void M2N::finishAcceptSecondaryRanksPreConnection(
+    const std::string &acceptorName,
+    const std::string &requesterName)
+{
+  PRECICE_TRACE(acceptorName, requesterName);
+  PRECICE_ASSERT(not _useOnlyPrimaryCom);
+  Event e("m2n.finishAcceptSecondaryRanksPreConnection");
+
+  // TODO: Assert that prepareAcceptSecondaryRanksPreConnection has been called before
+  for (const auto &pair : _distComs) {
+    Event e1("m2n.finishAcceptSecondaryRanksPreConnection." + std::to_string(pair.first));
+
+    pair.second->finishAcceptPreConnection(acceptorName, requesterName);
+    _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
+
+    e1.stop();
+  }
+  PRECICE_ASSERT(_areSecondaryRanksConnected);
+}
+
+void M2N::requestSecondaryRanksPreConnection(const std::string &acceptorName, const std::string &requesterName)
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not _useOnlyPrimaryCom);
@@ -210,6 +250,27 @@ void M2N::requestSecondaryRanksPreConnection(
     Event e1("m2n.requestSecondaryRanksPreConnection." + std::to_string(pair.first));
 
     pair.second->requestPreConnection(acceptorName, requesterName);
+    _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
+
+    e1.stop();
+  }
+  PRECICE_ASSERT(_areSecondaryRanksConnected);
+}
+
+void M2N::requestSecondaryRanksPreConnection(
+    const std::string                                                    &acceptorName,
+    const std::string                                                    &requesterName,
+    const com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap)
+{
+  PRECICE_TRACE(acceptorName, requesterName);
+  PRECICE_ASSERT(not _useOnlyPrimaryCom);
+  Event e("m2n.requestSecondaryRanksPreConnection", profiling::Synchronize);
+
+  _areSecondaryRanksConnected = true;
+  for (const auto &pair : _distComs) {
+    Event e1("m2n.requestSecondaryRanksPreConnection." + std::to_string(pair.first));
+
+    pair.second->requestPreConnection(acceptorName, requesterName, connectionInfoMap);
     _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
 
     e1.stop();

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -228,6 +228,7 @@ void M2N::finishAcceptSecondaryRanksPreConnection(
   Event e("m2n.finishAcceptSecondaryRanksPreConnection");
 
   // TODO: Assert that prepareAcceptSecondaryRanksPreConnection has been called before
+  _areSecondaryRanksConnected = true;
   for (const auto &pair : _distComs) {
     Event e1("m2n.finishAcceptSecondaryRanksPreConnection." + std::to_string(pair.first));
 
@@ -238,7 +239,6 @@ void M2N::finishAcceptSecondaryRanksPreConnection(
 
     _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
 
-    PRECICE_ASSERT(pair.second->isConnected());
     e1.stop();
   }
   PRECICE_ASSERT(_areSecondaryRanksConnected);

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -234,9 +234,9 @@ void M2N::finishAcceptSecondaryRanksPreConnection(
     // The communication can already be marked as connected (_isConnected == true), if the requesterCommunicatorSize == 0
     if (!pair.second->isConnected()) {
       pair.second->finishAcceptPreConnection(acceptorName, requesterName);
-      _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
     }
 
+    _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
     e1.stop();
   }
   PRECICE_ASSERT(_areSecondaryRanksConnected);

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -183,6 +183,8 @@ void M2N::acceptSecondaryRanksPreConnection(
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not _useOnlyPrimaryCom);
+  Event e("m2n.acceptSecondaryRanksPreConnection", profiling::Synchronize);
+
   _areSecondaryRanksConnected = true;
   for (const auto &pair : _distComs) {
     pair.second->acceptPreConnection(acceptorName, requesterName);
@@ -197,6 +199,8 @@ void M2N::requestSecondaryRanksPreConnection(
 {
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not _useOnlyPrimaryCom);
+  Event e("m2n.requestSecondaryRanksPreConnection", profiling::Synchronize);
+
   _areSecondaryRanksConnected = true;
   for (const auto &pair : _distComs) {
     pair.second->requestPreConnection(acceptorName, requesterName);
@@ -208,6 +212,8 @@ void M2N::requestSecondaryRanksPreConnection(
 void M2N::completeSecondaryRanksConnection()
 {
   PRECICE_ASSERT(not _useOnlyPrimaryCom);
+  Event e("m2n.completeSecondaryRanksConnection", profiling::Synchronize);
+
   for (const auto &pair : _distComs) {
     pair.second->completeSecondaryRanksConnection();
   }

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -231,8 +231,11 @@ void M2N::finishAcceptSecondaryRanksPreConnection(
   for (const auto &pair : _distComs) {
     Event e1("m2n.finishAcceptSecondaryRanksPreConnection." + std::to_string(pair.first));
 
-    pair.second->finishAcceptPreConnection(acceptorName, requesterName);
-    _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
+    // The communication can already be marked as connected (_isConnected == true), if the requesterCommunicatorSize == 0
+    if (!pair.second->isConnected()) {
+      pair.second->finishAcceptPreConnection(acceptorName, requesterName);
+      _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
+    }
 
     e1.stop();
   }

--- a/src/m2n/M2N.cpp
+++ b/src/m2n/M2N.cpp
@@ -187,8 +187,12 @@ void M2N::acceptSecondaryRanksPreConnection(
 
   _areSecondaryRanksConnected = true;
   for (const auto &pair : _distComs) {
+    Event e1("m2n.acceptSecondaryRanksPreConnection." + std::to_string(pair.first));
+
     pair.second->acceptPreConnection(acceptorName, requesterName);
     _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
+
+    e1.stop();
   }
   PRECICE_ASSERT(_areSecondaryRanksConnected);
 }
@@ -203,8 +207,12 @@ void M2N::requestSecondaryRanksPreConnection(
 
   _areSecondaryRanksConnected = true;
   for (const auto &pair : _distComs) {
+    Event e1("m2n.requestSecondaryRanksPreConnection." + std::to_string(pair.first));
+
     pair.second->requestPreConnection(acceptorName, requesterName);
     _areSecondaryRanksConnected = _areSecondaryRanksConnected && pair.second->isConnected();
+
+    e1.stop();
   }
   PRECICE_ASSERT(_areSecondaryRanksConnected);
 }

--- a/src/m2n/M2N.hpp
+++ b/src/m2n/M2N.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include "DistributedComFactory.hpp"
 #include "SharedPointer.hpp"
+#include "com/ConnectionInfoPublisher.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "m2n/DistributedCommunication.hpp"
@@ -86,11 +87,36 @@ public:
                                          const std::string &requesterName);
 
   /**
+   * Sets up accepting a pre-connection for secondary ranks intercommunication.
+   * @return connection info with the information needed for connecting to the server that has been set up.
+   */
+  std::string prepareAcceptSecondaryRanksPreConnection(const std::string &acceptorName,
+                                                       const std::string &requesterName);
+
+  /**
+   *
+   * @param acceptorName
+   * @param requesterName
+   */
+  void finishAcceptSecondaryRanksPreConnection(const std::string &acceptorName,
+                                               const std::string &requesterName);
+
+  /**
    * Same as requestSecondaryRanksConnection except this only creates the channels,
    * no vertex list needed!
    */
   void requestSecondaryRanksPreConnection(const std::string &acceptorName,
                                           const std::string &requesterName);
+
+  /**
+   *
+   * @param acceptorName
+   * @param requesterName
+   * @param connectionInfoMap Info of where to find the accepting side
+   */
+  void requestSecondaryRanksPreConnection(const std::string                                                    &acceptorName,
+                                          const std::string                                                    &requesterName,
+                                          const com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap &connectionInfoMap);
 
   /*
    * @brief After preliminary communication channels were set up and after

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -426,6 +426,8 @@ void PointToPointCommunication::acceptPreConnection(std::string const &acceptorN
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected(), "Already connected.");
 
+  Event e0("m2n.acceptPreConnection.getConnectedRanks");
+
   const std::vector<int> &localConnectedRanks = _mesh->getConnectedRanks();
 
   if (localConnectedRanks.empty()) {
@@ -433,7 +435,13 @@ void PointToPointCommunication::acceptPreConnection(std::string const &acceptorN
     return;
   }
 
+  e0.stop();
+  Event e1("m2n.acceptPreConnection.newCommunication");
+
   _communication = _communicationFactory->newCommunication();
+
+  e1.stop();
+  Event e2("m2n.acceptPreConnection.acceptConnectionAsServer");
 
   _communication->acceptConnectionAsServer(
       acceptorName,
@@ -442,11 +450,16 @@ void PointToPointCommunication::acceptPreConnection(std::string const &acceptorN
       utils::IntraComm::getRank(),
       localConnectedRanks.size());
 
+  e2.stop();
+  Event e3("m2n.acceptPreConnection.buildConnectionDataVector");
+
   _connectionDataVector.reserve(localConnectedRanks.size());
 
   for (int connectedRank : localConnectedRanks) {
     _connectionDataVector.push_back({connectedRank, com::PtrRequest()});
   }
+
+  e3.stop();
 
   _isConnected = true;
 }
@@ -559,6 +572,8 @@ void PointToPointCommunication::requestPreConnection(std::string const &acceptor
   PRECICE_TRACE(acceptorName, requesterName);
   PRECICE_ASSERT(not isConnected(), "Already connected.");
 
+  Event e0("m2n.requestPreConnection.getConnectedRanks");
+
   std::vector<int> localConnectedRanks = _mesh->getConnectedRanks();
 
   if (localConnectedRanks.empty()) {
@@ -566,20 +581,35 @@ void PointToPointCommunication::requestPreConnection(std::string const &acceptor
     return;
   }
 
+  e0.stop();
+  Event e1("m2n.requestPreConnection.reserveVectors");
+
   std::vector<com::PtrRequest> requests;
   requests.reserve(localConnectedRanks.size());
   _connectionDataVector.reserve(localConnectedRanks.size());
 
   std::set<int> acceptingRanks(localConnectedRanks.begin(), localConnectedRanks.end());
 
+  e1.stop();
+
+  Event e2("m2n.requestPreConnection.newCommunication");
   _communication = _communicationFactory->newCommunication();
+  e2.stop();
+
+  Event e3("m2n.requestPreConnection.requestConnectionAsClient");
   _communication->requestConnectionAsClient(acceptorName, requesterName,
                                             _mesh->getName(),
                                             acceptingRanks, utils::IntraComm::getRank());
+  e3.stop();
+
+  Event e4("m2n.requestPreConnection.buildConnectionDataVector");
 
   for (auto &connectedRank : localConnectedRanks) {
     _connectionDataVector.push_back({connectedRank, com::PtrRequest()});
   }
+
+  e4.stop();
+
   _isConnected = true;
 }
 

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -464,6 +464,72 @@ void PointToPointCommunication::acceptPreConnection(std::string const &acceptorN
   _isConnected = true;
 }
 
+std::string PointToPointCommunication::prepareAcceptPreConnection(std::string const &acceptorName,
+                                                                  std::string const &requesterName)
+{
+  PRECICE_TRACE(acceptorName, requesterName);
+  PRECICE_ASSERT(not isConnected(), "Already connected.");
+
+  Event e0("m2n.acceptPreConnection.getConnectedRanks");
+
+  const std::vector<int> &localConnectedRanks = _mesh->getConnectedRanks();
+
+  if (localConnectedRanks.empty()) {
+    _isConnected = true;
+    return nullptr;
+  }
+
+  e0.stop();
+  Event e1("m2n.acceptPreConnection.newCommunication");
+
+  _communication = _communicationFactory->newCommunication();
+
+  e1.stop();
+  Event e2("m2n.acceptPreConnection.prepareAcceptConnectionAsServer");
+
+  const std::string connectionInfo = _communication->prepareAcceptConnectionAsServer(
+      acceptorName,
+      requesterName,
+      _mesh->getName(),
+      utils::IntraComm::getRank(),
+      localConnectedRanks.size());
+
+  e2.stop();
+
+  return connectionInfo;
+}
+
+void PointToPointCommunication::finishAcceptPreConnection(const std::string &acceptorName,
+                                                          const std::string &requesterName)
+{
+  PRECICE_TRACE(acceptorName, requesterName);
+  PRECICE_ASSERT(not isConnected(), "Already connected.");
+
+  Event e0("m2n.acceptPreConnection.finishAcceptConnectionAsServer");
+
+  const std::vector<int> &localConnectedRanks = _mesh->getConnectedRanks();
+
+  _communication->finishAcceptConnectionAsServer(
+      acceptorName,
+      requesterName,
+      _mesh->getName(),
+      utils::IntraComm::getRank(),
+      localConnectedRanks.size());
+
+  e0.stop();
+  Event e1("m2n.acceptPreConnection.buildConnectionDataVector");
+
+  _connectionDataVector.reserve(localConnectedRanks.size());
+
+  for (int connectedRank : localConnectedRanks) {
+    _connectionDataVector.push_back({connectedRank, com::PtrRequest()});
+  }
+
+  e1.stop();
+
+  _isConnected = true;
+}
+
 void PointToPointCommunication::requestConnection(std::string const &acceptorName,
                                                   std::string const &requesterName)
 {
@@ -600,6 +666,54 @@ void PointToPointCommunication::requestPreConnection(std::string const &acceptor
   _communication->requestConnectionAsClient(acceptorName, requesterName,
                                             _mesh->getName(),
                                             acceptingRanks, utils::IntraComm::getRank());
+  e3.stop();
+
+  Event e4("m2n.requestPreConnection.buildConnectionDataVector");
+
+  for (auto &connectedRank : localConnectedRanks) {
+    _connectionDataVector.push_back({connectedRank, com::PtrRequest()});
+  }
+
+  e4.stop();
+
+  _isConnected = true;
+}
+
+void PointToPointCommunication::requestPreConnection(std::string const                                                    &acceptorName,
+                                                     std::string const                                                    &requesterName,
+                                                     com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap)
+{
+  PRECICE_TRACE(acceptorName, requesterName);
+  PRECICE_ASSERT(not isConnected(), "Already connected.");
+
+  Event e0("m2n.requestPreConnection.getConnectedRanks");
+
+  std::vector<int> localConnectedRanks = _mesh->getConnectedRanks();
+
+  if (localConnectedRanks.empty()) {
+    _isConnected = true;
+    return;
+  }
+
+  e0.stop();
+  Event e1("m2n.requestPreConnection.reserveVectors");
+
+  std::vector<com::PtrRequest> requests;
+  requests.reserve(localConnectedRanks.size());
+  _connectionDataVector.reserve(localConnectedRanks.size());
+
+  std::set<int> acceptingRanks(localConnectedRanks.begin(), localConnectedRanks.end());
+
+  e1.stop();
+
+  Event e2("m2n.requestPreConnection.newCommunication");
+  _communication = _communicationFactory->newCommunication();
+  e2.stop();
+
+  Event e3("m2n.requestPreConnection.requestConnectionAsClient");
+  _communication->requestConnectionAsClient(acceptorName, requesterName,
+                                            _mesh->getName(),
+                                            acceptingRanks, utils::IntraComm::getRank(), connectionInfoMap);
   e3.stop();
 
   Event e4("m2n.requestPreConnection.buildConnectionDataVector");

--- a/src/m2n/PointToPointCommunication.cpp
+++ b/src/m2n/PointToPointCommunication.cpp
@@ -476,7 +476,7 @@ std::string PointToPointCommunication::prepareAcceptPreConnection(std::string co
 
   if (localConnectedRanks.empty()) {
     _isConnected = true;
-    return nullptr;
+    return std::string();
   }
 
   e0.stop();

--- a/src/m2n/PointToPointCommunication.hpp
+++ b/src/m2n/PointToPointCommunication.hpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 #include "DistributedCommunication.hpp"
+#include "com/SerializedConnectionInfo.hpp"
 #include "com/SharedPointer.hpp"
 #include "logging/Logger.hpp"
 #include "mesh/Mesh.hpp"
@@ -70,6 +71,29 @@ public:
                            std::string const &requesterName) override;
 
   /**
+   * @brief Set up a server, so that another participant can connect using requestConnection().
+   *        Call finishAcceptConnection() afterward to respond to requestConnection() calls.
+   *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
+   * @return connectionInfo Information on how to connect to the server that has been set up in this function
+   */
+  std::string prepareAcceptPreConnection(
+      const std::string &acceptorName,
+      const std::string &requesterName) override;
+
+  /**
+   * @brief Connects to another participant, which has to call requestConnection().
+   *        Must not be called before prepareAcceptConnection
+   *
+   * @param[in] acceptorName Name of calling participant.
+   * @param[in] requesterName Name of remote participant to connect to.
+   */
+  void finishAcceptPreConnection(
+      const std::string &acceptorName,
+      const std::string &requesterName) override;
+
+  /**
    * @brief Requests connection from participant, which has to call acceptConnection().
    *        Only initial connection is created.
    *
@@ -78,6 +102,22 @@ public:
    */
   void requestPreConnection(std::string const &acceptorName,
                             std::string const &requesterName) override;
+
+  /**
+   * @brief Connects to another participant, which has to call acceptPreConnection().
+   *        Exchanged vertex list is not included, only connection between ranks
+   *        is established.
+   *        This version of the function takes a connectionInfo string, that tells
+   *        it how to connect to the accepting side.
+   *
+   * @param[in] acceptorName Name of remote participant to connect to.
+   * @param[in] requesterName Name of calling participant.
+   * @param[in] connectionInfoMap Connection info containing information on how to connect to accepting side
+   */
+  void requestPreConnection(
+      std::string const                                                    &acceptorName,
+      std::string const                                                    &requesterName,
+      com::serialize::SerializedConnectionInfoMap::ConnectionInfoMap const &connectionInfoMap) override;
 
   /// Completes the secondary connections for both acceptor and requester by updating the vertex list in _mappings
   void completeSecondaryRanksConnection() override;

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -266,6 +266,8 @@ void ProvidedPartition::compareBoundingBoxes()
     PRECICE_ASSERT(utils::IntraComm::getRank() == 0);
     PRECICE_ASSERT(utils::IntraComm::getSize() > 1);
 
+    Event e0("partition.gatherBB." + _mesh->getName(), profiling::Synchronize);
+
     // to store the collection of bounding boxes
     mesh::Mesh::BoundingBoxMap bbm;
     mesh::BoundingBox          bb(_mesh->getDimensions());
@@ -279,9 +281,15 @@ void ProvidedPartition::compareBoundingBoxes()
       com::receiveBoundingBox(*utils::IntraComm::getCommunication(), secondaryRank, bbm.at(secondaryRank));
     }
 
+    e0.stop();
+
+    Event e1("partition.sendBBsSets." + _mesh->getName(), profiling::Synchronize);
+
     // primary rank sends number of ranks and bbm to the other primary rank
     _m2ns[0]->getPrimaryRankCommunication()->send(utils::IntraComm::getSize(), 0);
     com::sendBoundingBoxMap(*_m2ns[0]->getPrimaryRankCommunication(), 0, bbm);
+
+    e1.stop();
   }
 
   // size of the feedbackmap

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -277,9 +277,14 @@ void ProvidedPartition::compareBoundingBoxes()
 
     // primary rank receives bbs from secondary ranks and stores them in bbm
     for (Rank secondaryRank : utils::IntraComm::allSecondaryRanks()) {
+      Event e0_1("partition.receiveBoundingBox" + _mesh->getName());
+      e0_1.addData("rank", secondaryRank);
+
       // initialize bbm
       bbm.emplace(secondaryRank, bb);
       com::receiveBoundingBox(*utils::IntraComm::getCommunication(), secondaryRank, bbm.at(secondaryRank));
+
+      e0_1.stop();
     }
 
     e0.stop();
@@ -297,11 +302,15 @@ void ProvidedPartition::compareBoundingBoxes()
   int remoteConnectionMapSize = 0;
 
   if (utils::IntraComm::isPrimary()) {
+    Event e0("partition.feedback.receiveConnectedRanksList");
 
     // primary rank receives feedback map (map of other participant ranks -> connected ranks at this participant)
     // from other participants primary rank
     std::vector<Rank> connectedRanksList = _m2ns[0]->getPrimaryRankCommunication()->receiveRange(0, com::asVector<Rank>);
     remoteConnectionMapSize              = connectedRanksList.size();
+
+    e0.stop();
+    Event e1("partition.feedback.receiveConnectionMap");
 
     mesh::Mesh::CommunicationMap remoteConnectionMap;
     for (auto &rank : connectedRanksList) {
@@ -311,11 +320,17 @@ void ProvidedPartition::compareBoundingBoxes()
       com::receiveConnectionMap(*_m2ns[0]->getPrimaryRankCommunication(), 0, remoteConnectionMap);
     }
 
+    e1.stop();
+    Event e2("partition.feedback.broadcastSendConnectionMap");
+
     // broadcast the received feedbackMap
     utils::IntraComm::getCommunication()->broadcast(connectedRanksList);
     if (remoteConnectionMapSize != 0) {
       com::broadcastSendConnectionMap(*utils::IntraComm::getCommunication(), remoteConnectionMap);
     }
+
+    e2.stop();
+    Event e3("partition.feedback.checkConnectedRanks");
 
     // primary rank checks which ranks are connected to it
     PRECICE_ASSERT(_mesh->getConnectedRanks().empty());
@@ -331,9 +346,16 @@ void ProvidedPartition::compareBoundingBoxes()
       return ranks;
     }());
 
+    e3.stop();
+
   } else { // Secondary rank
+    Event e0("partition.feedback.broadcastConnectedRanksList");
+
     std::vector<Rank> connectedRanksList;
     utils::IntraComm::getCommunication()->broadcast(connectedRanksList, 0);
+
+    e0.stop();
+    Event e1("partition.feedback.broadcastReceiveConnectionMap");
 
     mesh::Mesh::CommunicationMap remoteConnectionMap;
     if (!connectedRanksList.empty()) {
@@ -342,6 +364,9 @@ void ProvidedPartition::compareBoundingBoxes()
       }
       com::broadcastReceiveConnectionMap(*utils::IntraComm::getCommunication(), remoteConnectionMap);
     }
+
+    e1.stop();
+    Event e2("partition.feedback.checkConnectedRanks");
 
     PRECICE_ASSERT(_mesh->getConnectedRanks().empty());
     _mesh->setConnectedRanks([&] {
@@ -355,6 +380,8 @@ void ProvidedPartition::compareBoundingBoxes()
       }
       return ranks;
     }());
+
+    e2.stop();
   }
 }
 

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -266,7 +266,7 @@ void ProvidedPartition::compareBoundingBoxes()
     PRECICE_ASSERT(utils::IntraComm::getRank() == 0);
     PRECICE_ASSERT(utils::IntraComm::getSize() > 1);
 
-    Event e0("partition.gatherBB." + _mesh->getName(), profiling::Synchronize);
+    Event e0("partition.gatherBB." + _mesh->getName());
 
     // to store the collection of bounding boxes
     mesh::Mesh::BoundingBoxMap bbm;
@@ -283,7 +283,7 @@ void ProvidedPartition::compareBoundingBoxes()
 
     e0.stop();
 
-    Event e1("partition.sendBBsSets." + _mesh->getName(), profiling::Synchronize);
+    Event e1("partition.sendBBsSets." + _mesh->getName());
 
     // primary rank sends number of ranks and bbm to the other primary rank
     _m2ns[0]->getPrimaryRankCommunication()->send(utils::IntraComm::getSize(), 0);

--- a/src/partition/ProvidedPartition.cpp
+++ b/src/partition/ProvidedPartition.cpp
@@ -234,6 +234,7 @@ void ProvidedPartition::compute()
   PRECICE_TRACE();
   for (const auto &m2n : _m2ns) {
     if (m2n->usesTwoLevelInitialization()) {
+	    Event e("computeProvidedPartition.twoLevelInitialization");
       // @todo this will probably not work for more than one m2n
       PRECICE_ASSERT(_m2ns.size() <= 1);
       // receive communication map from all remote connected ranks

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -288,6 +288,7 @@ auto errorMeshFilteredOut(const std::string &meshName, const int rank)
 void ReceivedPartition::filterByBoundingBox()
 {
   PRECICE_TRACE(static_cast<int>(_geometricFilter));
+  Event e("partition.filterByBoundingBox." + _mesh->getName(), profiling::Synchronize);
 
   if (m2n().usesTwoLevelInitialization()) {
     std::string msg = "The received mesh " + _mesh->getName() +
@@ -514,6 +515,7 @@ void ReceivedPartition::compareBoundingBoxes()
 void ReceivedPartition::prepareBoundingBox()
 {
   PRECICE_TRACE(_safetyFactor);
+  Event e("partition.prepareBoundingBox." + _mesh->getName());
 
   if (_boundingBoxPrepared)
     return;
@@ -965,6 +967,8 @@ bool ReceivedPartition::hasAnyMapping() const
 
 void ReceivedPartition::tagMeshFirstRound()
 {
+  Event e("partition.tagMeshFirstRound." + _mesh->getName(), profiling::Synchronize);
+
   // We want to have every vertex within user-definded bounding box if we access the mesh directly
   if (_allowDirectAccess) {
     // _mesh->getBoundingBox is based on the bounding box of the mesh, which is
@@ -992,6 +996,8 @@ void ReceivedPartition::tagMeshFirstRound()
 
 void ReceivedPartition::tagMeshSecondRound()
 {
+  Event e("partition.tagMeshSecondRound." + _mesh->getName(), profiling::Synchronize);
+
   for (const mapping::PtrMapping &fromMapping : _fromMappings) {
     fromMapping->tagMeshSecondRound();
   }

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -383,17 +383,23 @@ void ReceivedPartition::compareBoundingBoxes()
 {
   PRECICE_TRACE();
 
+  Event e0("partition.compareBoundingBoxes.clearing");
+
   _mesh->clear();
   _mesh->clearPartitioning();
   _boundingBoxPrepared = false;
   _remoteMinGlobalVertexIDs.clear();
   _remoteMaxGlobalVertexIDs.clear();
 
+  e0.stop();
+
   // @todo handle coupling mode (i.e. serial participant)
   // @todo treatment of multiple m2ns
   PRECICE_ASSERT(_m2ns.size() == 1);
   if (not m2n().usesTwoLevelInitialization())
     return;
+
+  Event e1("partition.compareBoundingBoxes.rankNumberCommunication");
 
   // receive and broadcast number of remote ranks
   int numberOfRemoteRanks = -1;
@@ -405,6 +411,9 @@ void ReceivedPartition::compareBoundingBoxes()
     utils::IntraComm::getCommunication()->broadcast(numberOfRemoteRanks, 0);
   }
 
+  e1.stop();
+  Event e2("partition.compareBoundingBoxes.initBBMap");
+
   // define and initialize remote bounding box map
   mesh::Mesh::BoundingBoxMap remoteBBMap;
   mesh::BoundingBox          initialBB(_mesh->getDimensions());
@@ -413,7 +422,8 @@ void ReceivedPartition::compareBoundingBoxes()
     remoteBBMap.emplace(remoteRank, initialBB);
   }
 
-  Event e0("partition.receiveBBsSetAndBroadcast." + _mesh->getName(), profiling::Synchronize);
+  e2.stop();
+  Event e3("partition.compareBoundingBoxes.receiveBBMapAndBroadcast." + _mesh->getName(), profiling::Synchronize);
 
   // receive and broadcast remote bounding box map
   if (utils::IntraComm::isPrimary()) {
@@ -424,17 +434,20 @@ void ReceivedPartition::compareBoundingBoxes()
     com::broadcastReceiveBoundingBoxMap(*utils::IntraComm::getCommunication(), remoteBBMap);
   }
 
-  e0.stop();
+  e3.stop();
+  Event e4("partition.compareBoundingBoxes.prepareBoundingBox." + _mesh->getName());
 
   // prepare local bounding box
   prepareBoundingBox();
 
-  Event e1("partition.compareBBs." + _mesh->getName(), profiling::Synchronize);
+  e4.stop();
+  Event e5("partition.compareBoundingBoxes.compare." + _mesh->getName(), profiling::Synchronize);
 
   if (utils::IntraComm::isPrimary()) {               // Primary
     mesh::Mesh::CommunicationMap connectionMap;      // local ranks -> {remote ranks}
     std::vector<Rank>            connectedRanksList; // local ranks with any connection
 
+    Event e6("partition.compareBoundingBoxes.primary.overlappingBBs." + _mesh->getName());
     // connected ranks for primary rank
     std::vector<Rank> connectedRanks;
     for (auto &remoteBB : remoteBBMap) {
@@ -442,12 +455,19 @@ void ReceivedPartition::compareBoundingBoxes()
         connectedRanks.push_back(remoteBB.first); // connected remote ranks for this rank
       }
     }
+
+    e6.stop();
+    Event e7("partition.compareBoundingBoxes.primary.connectedRanks." + _mesh->getName());
+
     PRECICE_ASSERT(_mesh->getConnectedRanks().empty());
     _mesh->setConnectedRanks(connectedRanks);
     if (not connectedRanks.empty()) {
       connectionMap.emplace(0, std::move(connectedRanks));
       connectedRanksList.push_back(0);
     }
+
+    e7.stop();
+    Event e8("partition.compareBoundingBoxes.primary.secondaryConnectedRanks." + _mesh->getName());
 
     // receive connected ranks from secondary ranks and add them to the connection map
     for (int rank : utils::IntraComm::allSecondaryRanks()) {
@@ -458,6 +478,9 @@ void ReceivedPartition::compareBoundingBoxes()
       }
     }
 
+    e8.stop();
+    Event e9("partition.compareBoundingBoxes.primary.sendConnectionMap." + _mesh->getName());
+
     // send connectionMap to other primary rank
     m2n().getPrimaryRankCommunication()->sendRange(connectedRanksList, 0);
     PRECICE_CHECK(not connectionMap.empty(),
@@ -466,6 +489,8 @@ void ReceivedPartition::compareBoundingBoxes()
                   "If you deal with very different mesh resolutions, consider increasing the safety-factor in the <receive-mesh /> tag.",
                   _mesh->getName());
     com::sendConnectionMap(*m2n().getPrimaryRankCommunication(), 0, connectionMap);
+
+    e9.stop();
   } else {
     PRECICE_ASSERT(utils::IntraComm::isSecondary());
 
@@ -482,7 +507,7 @@ void ReceivedPartition::compareBoundingBoxes()
     utils::IntraComm::getCommunication()->sendRange(connectedRanks, 0);
   }
 
-  e1.stop();
+  e5.stop();
 }
 
 void ReceivedPartition::prepareBoundingBox()

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -429,11 +429,23 @@ void ReceivedPartition::compareBoundingBoxes()
 
   // receive and broadcast remote bounding box map
   if (utils::IntraComm::isPrimary()) {
+    Event e3_1("partition.compareBoundingBoxes.receiveBroadcastBBMap." + _mesh->getName());
+
     com::receiveBoundingBoxMap(*m2n().getPrimaryRankCommunication(), 0, remoteBBMap);
+
+    e3_1.stop();
+    Event e3_2("partition.compareBoundingBoxes.broadcastSendBBMap." + _mesh->getName());
+
     com::broadcastSendBoundingBoxMap(*utils::IntraComm::getCommunication(), remoteBBMap);
+
+    e3_2.stop();
   } else {
     PRECICE_ASSERT(utils::IntraComm::isSecondary());
+    Event e3_3("partition.compareBoundingBoxes.broadcastReceiveBBMap." + _mesh->getName());
+
     com::broadcastReceiveBoundingBoxMap(*utils::IntraComm::getCommunication(), remoteBBMap);
+
+    e3_3.stop();
   }
 
   e3.stop();

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -229,7 +229,7 @@ void ReceivedPartition::compute()
   // (7) Compute vertex offsets
   PRECICE_DEBUG("Compute vertex offsets");
   if (utils::IntraComm::isSecondary()) {
-    Event e7("partition.computeVertexOffsets." + _mesh->getName(), profiling::Synchronize);
+    Event e7("partition.computeVertexOffsets." + _mesh->getName());
 
     // send number of vertices
     PRECICE_DEBUG("Send number of vertices: {}", _mesh->nVertices());

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -158,7 +158,7 @@ void ReceivedPartition::compute()
 
   // (5) Filter mesh according to tag
   PRECICE_INFO("Filter mesh {} by mappings", _mesh->getName());
-  Event      e5("partition.filterMeshMappings" + _mesh->getName(), profiling::Synchronize);
+  Event      e5("partition.filterMeshMappings." + _mesh->getName(), profiling::Synchronize);
   mesh::Mesh filteredMesh("FilteredMesh", _dimensions, mesh::Mesh::MESH_ID_UNDEFINED);
   mesh::filterMesh(filteredMesh, *_mesh, [&](const mesh::Vertex &v) { return v.isTagged(); });
   PRECICE_DEBUG("Mapping filter, filtered from {} to {} vertices, {} to {} edges, and {} to {} triangles.",

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -3,6 +3,7 @@
 #include <map>
 #include <memory>
 #include <ostream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -485,7 +486,9 @@ void ReceivedPartition::compareBoundingBoxes()
 
     // receive connected ranks from secondary ranks and add them to the connection map
     for (int rank : utils::IntraComm::allSecondaryRanks()) {
+      Event e("partition.compareBoundingBoxes.receive." + std::to_string(rank));
       std::vector<Rank> secondaryConnectedRanks = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<Rank>);
+      e.stop();
       if (!secondaryConnectedRanks.empty()) {
         connectedRanksList.push_back(rank);
         connectionMap.emplace(rank, std::move(secondaryConnectedRanks));

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -476,19 +476,17 @@ void ReceivedPartition::compareBoundingBoxes()
 
     PRECICE_ASSERT(_mesh->getConnectedRanks().empty());
     _mesh->setConnectedRanks(connectedRanks);
-    if (not connectedRanks.empty()) {
-      connectionMap.emplace(0, std::move(connectedRanks));
-      connectedRanksList.push_back(0);
-    }
 
     e7.stop();
     Event e8("partition.compareBoundingBoxes.primary.secondaryConnectedRanks." + _mesh->getName());
 
     // receive connected ranks from secondary ranks and add them to the connection map
-    for (int rank : utils::IntraComm::allSecondaryRanks()) {
-      Event e("partition.compareBoundingBoxes.receive." + std::to_string(rank));
-      std::vector<Rank> secondaryConnectedRanks = utils::IntraComm::getCommunication()->receiveRange(rank, com::asVector<Rank>);
-      e.stop();
+
+    std::vector<std::vector<Rank>> allSecondaryConnectedRanks = utils::IntraComm::getCommunication()->gatherRanges(connectedRanks, com::asVector<int>);
+
+    for (int rank = 0; rank < allSecondaryConnectedRanks.size(); rank++) {
+      std::vector<Rank> secondaryConnectedRanks = allSecondaryConnectedRanks[rank];
+
       if (!secondaryConnectedRanks.empty()) {
         connectedRanksList.push_back(rank);
         connectionMap.emplace(rank, std::move(secondaryConnectedRanks));
@@ -526,7 +524,7 @@ void ReceivedPartition::compareBoundingBoxes()
     Event e7("partition.compareBoundingBoxes.secondary.sendConnectedRanks." + _mesh->getName());
 
     // send connected ranks to primary rank
-    utils::IntraComm::getCommunication()->sendRange(connectedRanks, 0);
+    utils::IntraComm::getCommunication()->gatherRanges(connectedRanks, com::asVector<int>);
 
     e7.stop();
   }

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -229,6 +229,7 @@ void ReceivedPartition::compute()
   // (7) Compute vertex offsets
   PRECICE_DEBUG("Compute vertex offsets");
   if (utils::IntraComm::isSecondary()) {
+    Event e7("partition.computeVertexOffsets." + _mesh->getName(), profiling::Synchronize);
 
     // send number of vertices
     PRECICE_DEBUG("Send number of vertices: {}", _mesh->nVertices());

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -508,6 +508,8 @@ void ReceivedPartition::compareBoundingBoxes()
   } else {
     PRECICE_ASSERT(utils::IntraComm::isSecondary());
 
+    Event e6("partition.compareBoundingBoxes.secondary.determineOverlappingBBs." + _mesh->getName());
+
     std::vector<Rank> connectedRanks;
     for (const auto &remoteBB : remoteBBMap) {
       if (_bb.overlapping(remoteBB.second)) {
@@ -517,8 +519,13 @@ void ReceivedPartition::compareBoundingBoxes()
     PRECICE_ASSERT(_mesh->getConnectedRanks().empty());
     _mesh->setConnectedRanks(connectedRanks);
 
+    e6.stop();
+    Event e7("partition.compareBoundingBoxes.secondary.sendConnectedRanks." + _mesh->getName());
+
     // send connected ranks to primary rank
     utils::IntraComm::getCommunication()->sendRange(connectedRanks, 0);
+
+    e7.stop();
   }
 
   e5.stop();

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -413,6 +413,8 @@ void ReceivedPartition::compareBoundingBoxes()
     remoteBBMap.emplace(remoteRank, initialBB);
   }
 
+  Event e0("partition.receiveBBsSetAndBroadcast." + _mesh->getName(), profiling::Synchronize);
+
   // receive and broadcast remote bounding box map
   if (utils::IntraComm::isPrimary()) {
     com::receiveBoundingBoxMap(*m2n().getPrimaryRankCommunication(), 0, remoteBBMap);
@@ -422,8 +424,12 @@ void ReceivedPartition::compareBoundingBoxes()
     com::broadcastReceiveBoundingBoxMap(*utils::IntraComm::getCommunication(), remoteBBMap);
   }
 
+  e0.stop();
+
   // prepare local bounding box
   prepareBoundingBox();
+
+  Event e1("partition.compareBBs." + _mesh->getName(), profiling::Synchronize);
 
   if (utils::IntraComm::isPrimary()) {               // Primary
     mesh::Mesh::CommunicationMap connectionMap;      // local ranks -> {remote ranks}
@@ -475,6 +481,8 @@ void ReceivedPartition::compareBoundingBoxes()
     // send connected ranks to primary rank
     utils::IntraComm::getCommunication()->sendRange(connectedRanks, 0);
   }
+
+  e1.stop();
 }
 
 void ReceivedPartition::prepareBoundingBox()

--- a/src/partition/ReceivedPartition.cpp
+++ b/src/partition/ReceivedPartition.cpp
@@ -601,6 +601,7 @@ void ReceivedPartition::createOwnerInformation()
     5- for the remaining vertices: check if we have less vertices -> own it!
     */
 
+    Event e1("partition.createOwnerInformation." + _mesh->getName() + ".1");
     // #1: receive local bb map from primary rank
     // Define and initialize localBBMap to save local bbs
 
@@ -644,6 +645,9 @@ void ReceivedPartition::createOwnerInformation()
       com::broadcastReceiveBoundingBoxMap(*utils::IntraComm::getCommunication(), localBBMap);
     }
 
+    e1.stop();
+    Event e2("partition.createOwnerInformation." + _mesh->getName() + ".2");
+
     // #2: filter bb map to keep the connected ranks
     // remove the own bb from the map since we compare the own bb only with other ranks bb.
     localBBMap.erase(utils::IntraComm::getRank());
@@ -661,6 +665,9 @@ void ReceivedPartition::createOwnerInformation()
     // See also test Integration/Parallel/TestBoundingBoxInitializationEmpty
     for (auto &neighborRank : localConnectedBBMap)
       sharedVerticesSendMap[neighborRank.first] = std::vector<VertexID>();
+
+    e2.stop();
+    Event e3("partition.createOwnerInformation." + _mesh->getName() + ".3");
 
     // #3: check vertices and keep only those that fit into the current rank's bb
     const int numberOfVertices = _mesh->nVertices();
@@ -690,6 +697,9 @@ void ReceivedPartition::createOwnerInformation()
         tags[i] = 0;
       }
     }
+
+    e3.stop();
+    Event e4("partition.createOwnerInformation." + _mesh->getName() + ".4");
 
     // #4: Exchange number of already owned vertices with the neighbors
 
@@ -747,6 +757,9 @@ void ReceivedPartition::createOwnerInformation()
       rqst->wait();
     }
 
+    e4.stop();
+    Event e5("partition.createOwnerInformation." + _mesh->getName() + ".5");
+
     // #5: Second round assignment according to the number of owned vertices
     // In case that a vertex can be shared between two ranks, the rank with lower
     // vertex count will own the vertex.
@@ -775,6 +788,8 @@ void ReceivedPartition::createOwnerInformation()
     setOwnerInformation(tags);
     PRECICE_DEBUG("{} of {} vertices of mesh {} have been filtered out on rank {} since they have no influence on the mapping.",
                   std::count(tags.begin(), tags.end(), 0), tags.size(), _mesh->getName(), utils::IntraComm::getRank());
+
+    e5.stop();
     // end of two-level initialization section
   } else {
     if (utils::IntraComm::isSecondary()) {

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -354,6 +354,8 @@ void ParticipantImpl::setupCommunication()
   PRECICE_INFO("Primary ranks are connected");
 
   Event e3("repartitioning");
+
+  Event e5("compareBoundingBoxesInitial");
   // clears the mappings as well (see clearMappings)
   compareBoundingBoxes();
 
@@ -362,8 +364,12 @@ void ParticipantImpl::setupCommunication()
     auto &bm2n = m2nPair.second;
     bm2n.preConnectSecondaryRanks();
   }
+  e5.stop();
 
+  Event e6("computePartitions");
   computePartitions();
+  e6.stop();
+
   e3.stop();
 
   PRECICE_INFO("Setting up secondary communication to coupling partner/s");
@@ -378,6 +384,7 @@ void ParticipantImpl::setupCommunication()
   for (auto &m2nPair : _m2ns) {
     m2nPair.second.cleanupEstablishment();
   }
+  e4.stop();
 }
 
 void ParticipantImpl::setupWatcher()
@@ -1569,6 +1576,8 @@ void ParticipantImpl::computePartitions()
   // Originally, this was done in one loop. This however gave deadlock if two meshes needed to be communicated cross-wise.
   // Both loops need a different sorting
 
+  Event e1("computePartitions.1");
+
   auto &contexts = _accessor->usedMeshContexts();
 
   std::sort(contexts.begin(), contexts.end(),
@@ -1591,6 +1600,9 @@ void ParticipantImpl::computePartitions()
     }
   }
 
+  e1.stop();
+  Event e2("computePartitions.resort");
+
   if (resort) {
     // pull provided meshes up front, to have them ready for the decomposition of the received meshes (for the mappings)
     std::stable_partition(contexts.begin(), contexts.end(),
@@ -1598,6 +1610,9 @@ void ParticipantImpl::computePartitions()
                             return meshContext->provideMesh;
                           });
   }
+
+  e2.stop();
+  Event e3("computePartitions.2");
 
   for (MeshContext *meshContext : contexts) {
     meshContext->partition->compute();
@@ -1614,6 +1629,8 @@ void ParticipantImpl::computePartitions()
       }
     }
   }
+
+  e3.stop();
 }
 
 void ParticipantImpl::computeMappings(std::vector<MappingContext> &contexts, const std::string &mappingType)

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -341,8 +341,10 @@ void ParticipantImpl::setupCommunication()
     auto &bm2n       = m2nPair.second;
     bool  requesting = bm2n.isRequesting;
     if (bm2n.m2n->isConnected()) {
+      PRECICE_INFO("Primary connection something something already connected.");
       PRECICE_DEBUG("Primary connection {} {} already connected.", (requesting ? "from" : "to"), bm2n.remoteName);
     } else {
+      PRECICE_INFO(requesting ? "Awaiting primary connection from someone" : "Establishing primary connection to someone");
       PRECICE_DEBUG((requesting ? "Awaiting primary connection from {}" : "Establishing primary connection to {}"), bm2n.remoteName);
       bm2n.prepareEstablishment();
       bm2n.connectPrimaryRanks(_configHash);

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1810,10 +1810,18 @@ void ParticipantImpl::initializeIntraCommunication()
   PRECICE_TRACE();
 
   Event e("com.initializeIntraCom", profiling::Fundamental);
+  Event e1("com.initializeIntraCom.connect");
+
   utils::IntraComm::getCommunication()->connectIntraComm(
       _accessorName, "IntraComm",
       _accessorProcessRank, _accessorCommunicatorSize);
+
+  e1.stop();
+  Event e2("com.initializeIntraCom.barrier");
+
   utils::IntraComm::barrier();
+
+  e2.stop();
 }
 
 void ParticipantImpl::syncTimestep(double computedTimeStepSize)

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1615,19 +1615,19 @@ void ParticipantImpl::computePartitions()
   Event e3("computePartitions.2");
 
   for (MeshContext *meshContext : contexts) {
-	Event e4("computeMeshContext." + meshContext->mesh->getName());
-	Event e5("computePartition");
+	  Event e4("computeMeshContext." + meshContext->mesh->getName());
+	  Event e5("computePartition");
 
     meshContext->partition->compute();
 
-	e5.stop();
-	Event e6("computeBoundingBox");
+	  e5.stop();
+	  Event e6("computeBoundingBox");
 
     if (not meshContext->provideMesh) { // received mesh can only compute their bounding boxes here
       meshContext->mesh->computeBoundingBox();
     }
 
-	e6.stop();
+	  e6.stop();
 
     meshContext->mesh->allocateDataValues();
 
@@ -1637,6 +1637,8 @@ void ParticipantImpl::computePartitions()
         context.resizeBufferTo(requiredSize);
       }
     }
+
+    e4.stop();
   }
 
   e3.stop();

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1615,19 +1615,19 @@ void ParticipantImpl::computePartitions()
   Event e3("computePartitions.2");
 
   for (MeshContext *meshContext : contexts) {
-	  Event e4("computeMeshContext." + meshContext->mesh->getName());
-	  Event e5("computePartition");
+    Event e4("computeMeshContext." + meshContext->mesh->getName());
+    Event e5("computePartition");
 
     meshContext->partition->compute();
 
-	  e5.stop();
-	  Event e6("computeBoundingBox");
+    e5.stop();
+    Event e6("computeBoundingBox");
 
     if (not meshContext->provideMesh) { // received mesh can only compute their bounding boxes here
       meshContext->mesh->computeBoundingBox();
     }
 
-	  e6.stop();
+    e6.stop();
 
     meshContext->mesh->allocateDataValues();
 

--- a/src/precice/impl/ParticipantImpl.cpp
+++ b/src/precice/impl/ParticipantImpl.cpp
@@ -1615,10 +1615,19 @@ void ParticipantImpl::computePartitions()
   Event e3("computePartitions.2");
 
   for (MeshContext *meshContext : contexts) {
+	Event e4("computeMeshContext." + meshContext->mesh->getName());
+	Event e5("computePartition");
+
     meshContext->partition->compute();
+
+	e5.stop();
+	Event e6("computeBoundingBox");
+
     if (not meshContext->provideMesh) { // received mesh can only compute their bounding boxes here
       meshContext->mesh->computeBoundingBox();
     }
+
+	e6.stop();
 
     meshContext->mesh->allocateDataValues();
 

--- a/src/sources.cmake
+++ b/src/sources.cmake
@@ -72,6 +72,8 @@ target_sources(preciceCore
     src/com/MPISinglePortsCommunicationFactory.hpp
     src/com/Request.cpp
     src/com/Request.hpp
+    src/com/SerializedConnectionInfo.cpp
+    src/com/SerializedConnectionInfo.hpp
     src/com/SerializedMesh.cpp
     src/com/SerializedMesh.hpp
     src/com/SerializedPartitioning.cpp


### PR DESCRIPTION
## Main changes of this PR

This PR concerns the initialization of preCICE, more specifically the pre-connection of secondary ranks. In a m2n, after the connecting participant's ranks know which ranks to connect to, they need connection information (e.g. IP address, port number for TCP) to know how to connect.

This PR implements the approach recommended in https://doi.org/10.18419/opus-18224 (not yet published). This approach is called "Three-level initialization with `MPI_Gatherv`" in the thesis. This implementation supersedes the naive variant in #2444.

- Introduce an **alternative approach for exchanging connection information**. Currently, connection information is written to files by the ConnectionInfoWriter and read from these files on the connecting side. This PR introduces a different way to exchange this information: We use the primary ranks' connection to exchange a connection information map that maps a rank number to its IP address + port number (assuming TCP). This map is gathered on the acceptor side and sent to the connector side via the primary ranks. On the connector side, we broadcast it to the secondary ranks. Changes to the code:
  1. Accepting side: Split `acceptConnectionAsServer` into `prepareAcceptConnectionAsServer` and `finishAcceptConnectionAsServer`: We insert the gather operation after the accepting rank opens its port, and before it waits for a connection.
  2. Code for serializing and deserializing the connection information map.
  4. Connecting side: Add a `connectionInfoMap` parameter to the `requestConnectionAsClient` function and pass the connection info map received in the broadcast operation.
- **`MPI_Gatherv`** is added to the communication abstraction of preCICE and is used for gathering the feedback map (https://github.com/s3n-w6i/precice/commit/d7b7cedebd3cbc40a3b1ef99c91a9c4a53cf4857) and the new connection information map (https://github.com/s3n-w6i/precice/commit/10a3364c8e318a5f23c2fa84eece2522084df468). Without these changes (#2444), performance is significantly worse, as in slower than the current approach of using the file system for large rank counts.
- Added a lot of **profiling events** in the initialization phase ([cleaner diff of the other two changes without all the profiling events](https://github.com/s3n-w6i/precice/compare/initialization-performance-profiling...s3n-w6i:precice:3li-proper-gather))

## Limitations

There are many. This is more of a proof of concept:
- Like the two-level initialization, this currently only supports a single receiver per mesh.
- No fallback is implemented for non-MPI intra-communication
- No option configure to go back to the current behavior
- This was built on preCICE v3.3.0 (no major merge conflicts so far, #2477 may collide)

## Further reading

https://doi.org/10.18419/opus-18224 (not yet published)
- Section 4.4 (Idea, Implementation)
- Section 5 (comparison to other approaches)
- Section 5.1 (why `MPI_Gatherv`)
- Section 6.1.3 (Discussion of results)
- Section 6.3 (This is the recommended approach)