### PR TITLE
Switch the Debian package libxml2 dependency to libxml2-dev

### DIFF
--- a/cmake/CPackConfig.cmake
+++ b/cmake/CPackConfig.cmake
@@ -61,7 +61,7 @@ set(CPACK_SOURCE_IGNORE_FILES
 
 # Build dependency set
 unset(CPACK_DEBIAN_PACKAGE_DEPENDS)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libboost-dev (>= 1.65), libboost-log-dev (>= 1.65), libboost-thread-dev (>= 1.65), libboost-system-dev (>= 1.65), libboost-program-options-dev (>= 1.65), libboost-test-dev (>= 1.65), libxml2")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6, libboost-dev (>= 1.65), libboost-log-dev (>= 1.65), libboost-thread-dev (>= 1.65), libboost-system-dev (>= 1.65), libboost-program-options-dev (>= 1.65), libboost-test-dev (>= 1.65), libxml2-dev")
 if(PRECICE_FEATURE_PYTHON_ACTIONS)
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, python3-dev, python3-numpy")
 endif()

--- a/docs/changelog/2560.md
+++ b/docs/changelog/2560.md
@@ -1,0 +1,1 @@
+- Fix the libxml2 dependency specification in the Debian package for Ubuntu 25.10 and newer


### PR DESCRIPTION
## Main changes of this PR

In `CPackConfig.cmake`, switches the Debian package `libxml2` dependency to `libxml2-dev`.

closes #2559

Verified in a container, it works. Package: [libprecice3_3.4.1_Linux.zip](https://github.com/user-attachments/files/27323618/libprecice3_3.4.1_Linux.zip) (@BenjaminRodenberg you could already try if this works for you)

## Motivation and additional information

The `libxml2` package does not exist anymore in Ubuntu 25.10 and 26.04, and that would require additional conditions to install the right package on each system. Fortunately, the `-dev` package is still consistent in all the systems we support.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
