### PR TITLE
Bump baseline from Ubuntu 22.04 to 24.04 LTS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,37 +57,33 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - IMAGE: 'ubuntu-2204'
+          - IMAGE: 'ubuntu-2404'
             CONFIG: Bare
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-2204'
+          - IMAGE: 'ubuntu-2404'
             CONFIG: MPI
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-2204'
+          - IMAGE: 'ubuntu-2404'
             CONFIG: MPIPETScLZMA
             CXX: 'g++'
             TYPE: Debug
             COVFLAGS: '--coverage'
-          - IMAGE: 'ubuntu-2204'
+          - IMAGE: 'ubuntu-2404'
             CONFIG: Bare
             CXX: 'g++'
             TYPE: Release
-          - IMAGE: 'ubuntu-2204'
+          - IMAGE: 'ubuntu-2404'
             CONFIG: MPI
-            CXX: 'g++'
-            TYPE: Release
-          - IMAGE: 'ubuntu-2204'
-            CONFIG: MPIPETSc
             CXX: 'g++'
             TYPE: Release
           - IMAGE: 'ubuntu-2404'
             CONFIG: MPIPETSc
             CXX: 'g++'
-            TYPE: Debug
+            TYPE: Release
           - IMAGE: 'ubuntu-2604'
             CONFIG: MPIPETSc
             CXX: 'g++'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
       matrix:
         include:
         - distro: ubuntu
-          version: "22.04"
-        - distro: ubuntu
           version: "24.04"
+        - distro: ubuntu
+          version: "26.04"
         - distro: debian
           version: "13"
     uses: ./.github/workflows/request-deb-package.yml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.22.1)
+cmake_minimum_required (VERSION 3.28.3)
 project(preCICE VERSION 3.4.1 LANGUAGES CXX)
 set(preCICE_SOVERSION ${preCICE_VERSION_MAJOR})
 
@@ -220,7 +220,7 @@ if(POLICY CMP0167)
 endif()
 
 option(Boost_USE_STATIC_LIBS "Force BoostConfig.cmake to find static libraries." OFF)
-find_package(Boost 1.74.0 REQUIRED CONFIG
+find_package(Boost 1.83.0 REQUIRED CONFIG
   COMPONENTS log log_setup program_options thread unit_test_framework
   )
 mark_as_advanced(Boost_INCLUDE_DIR Boost_LOG_LIBRARY_RELEASE Boost_LOG_SETUP_LIBRARY_RELEASE Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE Boost_SYSTEM_LIBRARY_RELEASE Boost_THREAD_LIBRARY_RELEASE Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE)
@@ -268,7 +268,7 @@ if (PRECICE_FEATURE_PETSC_MAPPING)
     xsdk_tpl_require(PETSC PETSC_DIR PETSC_ARCH)
     # PETSc detection uses primarily these ENVs
   endif()
-  find_package(PETSc 3.15 REQUIRED)
+  find_package(PETSc 3.19 REQUIRED)
   # No validation required as PETSc does this internally
   message(STATUS "Found PETSc ${PETSc_VERSION}")
 else()

--- a/docs/changelog/2564.md
+++ b/docs/changelog/2564.md
@@ -1,0 +1,1 @@
+- Changed the baseline from Ubuntu 22.04 LTS to Ubuntu 24.04 LTS, which lifts minimum required versions of dependencies to: CMake 3.28.3, GCC/stdlibc++ 13.2.0, Eigen 3.4.0 (remains), Boost 1.83.0, PETSc 3.19, Python 3.12.3, and Numpy 1.26.4.


### PR DESCRIPTION
## Main changes of this PR

With the releases of Ubuntu 26.04 LTS, we bump the baseline version from Ubuntu 22.04 LTS to Ubuntu 24.04 LTS.

This translates to the following version bumps:


Package | 22.04 | **24.04**
--- | --- | ---
CMake | 3.22.1 | 3.28.3
Boost | 1.74.0 | 1.83.0
PETSc | 3.15   | 3.19
GCC   | 11.2   | 13.2
CLANG | 14.0   | 18.0
*Eigen3* | 3.4.0 | 3.4.0
Python | 3.10.6 | 3.12.3
Numpy  | 1.21.5 | 1.26.4.


The vendored libfmt-dev is now available in the baseline version 24.04@9.1.0 and the latest LTS 26.04@10.1.1.
We could think about moving to the system library.

We should also think about increasing the C++ version, definitely to 20 and potentially to 23.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
