### PR TITLE
Modernize TestContext to use smart pointer

### DIFF
--- a/src/testing/TestContext.cpp
+++ b/src/testing/TestContext.cpp
@@ -203,9 +203,9 @@ void TestContext::initializeIntraComm()
     return;
 
 #ifndef PRECICE_NO_MPI
-  precice::com::PtrCommunication intraComm = precice::com::PtrCommunication(new precice::com::MPIDirectCommunication());
+  auto intraComm = std::make_shared<precice::com::MPIDirectCommunication>();
 #else
-  precice::com::PtrCommunication intraComm = precice::com::PtrCommunication(new precice::com::SocketCommunication());
+  auto intraComm = std::make_shared<precice::com::SocketCommunication>();
 #endif
 
   intraComm->connectIntraComm(name, "", rank, size);
@@ -250,7 +250,7 @@ void TestContext::initializeKokkos()
 
 m2n::PtrM2N TestContext::connectPrimaryRanks(const std::string &acceptor, const std::string &connector, const ConnectionOptions &options) const
 {
-  auto participantCom = com::PtrCommunication(new com::SocketCommunication());
+  auto participantCom = std::make_shared<com::SocketCommunication>();
 
   m2n::DistributedComFactory::SharedPointer distrFactory;
   switch (options.type) {


### PR DESCRIPTION
## Description

This PR modernizes the initialization of `shared_ptr`s in `src/testing/TestContext.cpp` by replacing legacy raw `new` usages with `std::make_shared`.

This is a small, non-breaking cleanup that improves memory allocation performance and aligns the code with modern C++ best practices.

## Changes

* Replaced `std::shared_ptr<T>(new T(...))` with `std::make_shared<T>(...)`
* Simplified local variable declarations using `auto`

## Notes

The change is isolated to test initialization code and does not alter runtime logic.

## Testing

* Reviewed resulting type conversions (`shared_ptr<Derived>` → `shared_ptr<Base>`)
* No behavioral changes introduced

