### PR TITLE
Add more website update tasks to the release PR template

### DIFF
--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -115,8 +115,12 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 * [ ] Update `pyprecice` Spack
 * [ ] Update Website:
     * [ ] Bump version in [`_config.yml`](https://github.com/precice/precice.github.io/blob/master/_config.yml)
+       * [ ] In the same file: Also update the citation numbers
     * [ ] Update the [XML reference](https://github.com/precice/precice.github.io/blob/master/_includes/xmlreference.md) using `binprecice md`
-    * [ ] Look over the [Roadmap](https://www.precice.org/fundamentals-roadmap.html) and update entries.
+    * [ ] Look over the [Roadmap](https://www.precice.org/fundamentals-roadmap.html) and update entries
+    * [ ] Update the [dependencies page](https://github.com/precice/precice.github.io/blob/master/content/docs/installation/building-from-source/installation-source-dependencies.md) (supported versions)
+    * [ ] Update the supported [Ubuntu versions](https://github.com/precice/precice.github.io/blob/master/content/docs/installation/installation-packages.md) corresponding to the baseline
+* [ ] Update the versions in the [Quickstart tutorial](https://github.com/precice/tutorials/edit/develop/quickstart/README.md)
 
 ### Release new version for bindings (to ensure compatibility with newest preCICE version)
 


### PR DESCRIPTION
## Main changes of this PR

This PR adds a few reminders in the PR template to:

- Update the citation numbers (related to https://github.com/precice/precice.github.io/issues/522)
- Update the [dependencies page](https://precice.org/installation-source-dependencies.html) and the [system packages page](https://precice.org/installation-packages.html) (for the supported Ubuntu versions) (related to https://github.com/precice/precice.github.io/issues/617)
- Update the versions in the [Quickstart](https://precice.org/quickstart.html)

## Motivation and additional information

These are often forgotten. This is a workaround until a better solution is implemented.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I squashed / am about to squash all commits that should be seen as one.
