### PR TITLE
Release PR template: Remove tests covered by the system tests

### DIFF
--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -85,7 +85,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 
 | State | Tester | Test |
 | --- | --- | --- |
-| | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-openfoam - solid-dune |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |
 | | | Solverdummy [MATLAB](https://github.com/precice/matlab-bindings/tree/develop/solverdummy) |
 | | | Solverdummy [Julia](https://github.com/precice/PreCICE.jl/tree/develop/solverdummy) |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -87,8 +87,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 | --- | --- | --- |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-openfoam - solid-dune |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-nutils - solid-calculix |
-| | | [flow-over-heated-plate-steady-state](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate-steady-state) fluid-openfoam - solid-codeaster |
-| | | [heat-exchanger](https://github.com/precice/tutorials/tree/master/heat-exchanger) fluid-(inner+outer)-openfoam - solid-calculix |
 | | | [partitioned-elastic-beam](https://github.com/precice/tutorials/tree/master/partitioned-elastic-beam) dirichlet-calculix - neumann-calculix |
 | | | [partitioned-heat-conduction](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction) fenics - nutils |
 | | | [partitioned-heat-conduction-complex](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction-complex) fenics- fenics |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -87,7 +87,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 | --- | --- | --- |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-openfoam - solid-dune |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-nutils - solid-calculix |
-| | | [partitioned-elastic-beam](https://github.com/precice/tutorials/tree/master/partitioned-elastic-beam) dirichlet-calculix - neumann-calculix |
 | | | [partitioned-heat-conduction](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction) fenics - nutils |
 | | | [partitioned-heat-conduction-complex](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction-complex) fenics- fenics |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -85,20 +85,14 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 
 | State | Tester | Test |
 | --- | --- | --- |
-| | | [quickstart](https://github.com/precice/tutorials/tree/master/quickstart) fluid-openfoam - solid-cpp |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-openfoam - solid-dune |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-nutils - solid-calculix |
-| | | [flow-over-heated-plate](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate) fluid-openfoam - solid-openfoam parallel |
-| | | [flow-over-heated-plate](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate) fluid-openfoam - solid-fenics parallel |
-| | | [flow-over-heated-plate](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate) fluid-openfoam - solid-nutils |
-| | | [flow-over-heated-plate-nearest-projection](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate-nearest-projection) fluid-openfoam - solid-openfoam |
 | | | [flow-over-heated-plate-steady-state](https://github.com/precice/tutorials/tree/master/flow-over-heated-plate-steady-state) fluid-openfoam - solid-codeaster |
 | | | [heat-exchanger](https://github.com/precice/tutorials/tree/master/heat-exchanger) fluid-(inner+outer)-openfoam - solid-calculix |
 | | | [partitioned-elastic-beam](https://github.com/precice/tutorials/tree/master/partitioned-elastic-beam) dirichlet-calculix - neumann-calculix |
 | | | [partitioned-heat-conduction](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction) fenics - nutils |
 | | | [partitioned-heat-conduction-complex](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction-complex) fenics- fenics |
 | | | [partitioned-pipe](https://github.com/precice/tutorials/tree/master/partitioned-pipe) fluid1-openfoam-pimplefoam - fluid2-openfoam-sonicliquidfoam |
-| | | [elastic-tube-3d](https://github.com/precice/tutorials/tree/master/elastic-tube-3d) fluid-openfoam - solid-calculix |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |
 | | | Solverdummy [Fortran module](https://github.com/precice/fortran-module/tree/develop/examples/solverdummy) |
 | | | Solverdummy [Python](https://github.com/precice/python-bindings/tree/develop/solverdummy) |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -87,7 +87,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 | --- | --- | --- |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |
 | | | Solverdummy [MATLAB](https://github.com/precice/matlab-bindings/tree/develop/solverdummy) |
-| | | Solverdummy [Julia](https://github.com/precice/PreCICE.jl/tree/develop/solverdummy) |
 | | | Alya |
 | | | SuperMUC |
 

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -86,7 +86,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 | State | Tester | Test |
 | --- | --- | --- |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-openfoam - solid-dune |
-| | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-nutils - solid-calculix |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |
 | | | Solverdummy [Fortran module](https://github.com/precice/fortran-module/tree/develop/examples/solverdummy) |
 | | | Solverdummy [Python](https://github.com/precice/python-bindings/tree/develop/solverdummy) |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -90,7 +90,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 | | | [partitioned-elastic-beam](https://github.com/precice/tutorials/tree/master/partitioned-elastic-beam) dirichlet-calculix - neumann-calculix |
 | | | [partitioned-heat-conduction](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction) fenics - nutils |
 | | | [partitioned-heat-conduction-complex](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction-complex) fenics- fenics |
-| | | [partitioned-pipe](https://github.com/precice/tutorials/tree/master/partitioned-pipe) fluid1-openfoam-pimplefoam - fluid2-openfoam-sonicliquidfoam |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |
 | | | Solverdummy [Fortran module](https://github.com/precice/fortran-module/tree/develop/examples/solverdummy) |
 | | | Solverdummy [Python](https://github.com/precice/python-bindings/tree/develop/solverdummy) |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -87,8 +87,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 | --- | --- | --- |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-openfoam - solid-dune |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-nutils - solid-calculix |
-| | | [partitioned-heat-conduction](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction) fenics - nutils |
-| | | [partitioned-heat-conduction-complex](https://github.com/precice/tutorials/tree/master/partitioned-heat-conduction-complex) fenics- fenics |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |
 | | | Solverdummy [Fortran module](https://github.com/precice/fortran-module/tree/develop/examples/solverdummy) |
 | | | Solverdummy [Python](https://github.com/precice/python-bindings/tree/develop/solverdummy) |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -87,8 +87,6 @@ Tests covered by the system tests: see `release_test` in [`tests.yaml`](https://
 | --- | --- | --- |
 | | | [perpendicular-flap](https://github.com/precice/tutorials/tree/master/perpendicular-flap) fluid-openfoam - solid-dune |
 | | | MATLAB / MATLAB [ODEs](https://github.com/precice/matlab-bindings/tree/develop/tutorial) |
-| | | Solverdummy [Fortran module](https://github.com/precice/fortran-module/tree/develop/examples/solverdummy) |
-| | | Solverdummy [Python](https://github.com/precice/python-bindings/tree/develop/solverdummy) |
 | | | Solverdummy [MATLAB](https://github.com/precice/matlab-bindings/tree/develop/solverdummy) |
 | | | Solverdummy [Julia](https://github.com/precice/PreCICE.jl/tree/develop/solverdummy) |
 | | | Alya |

--- a/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
+++ b/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md
@@ -39,7 +39,7 @@ Only the release manager should update this post (even tickboxes, due to race co
 ## Step by step guide
 
 * Open PR from `release-vX.Y.Z` to `main` (use [this template](https://github.com/precice/precice/blob/develop/tools/releasing/PULL_REQUEST_TEMPLATE/release_pull_request_template.md))
-* [ ] Trigger the system tests using the `trigger-system-tests` label ([`release_test` suite](https://github.com/precice/tutorials/blob/develop/tools/tests/tests.yaml)). After any force-push, remove and add the label again.
+* [ ] [Trigger the system tests](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml) for the `release_test` test suite.
 * [ ] Review the changelog and use review comments with suggestions for feedback (all)
 * [ ] Do any additional regression tests using the release branch (specific revision) _list below :arrow_down:_ (all)
 * [ ] Fix potential problems in develop (all)


### PR DESCRIPTION
## Main changes of this PR

Removes from the release pull request template the cases now covered by the system tests. See recent runs in https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml and https://github.com/precice/tutorials/issues/448

It also removes the code_aster tutorial, since the respective adapter is currently unmaintained.

## Motivation and additional information

See the complete list in the `release_test` in [`tests.yaml`](https://github.com/precice/tutorials/blob/develop/tools/tests/tests.yaml) and https://github.com/precice/tutorials/issues/448

In particular, the OpenFOAM parallel cases that this PR removes are also now executed in parallel by the system tests.

The `perpendicular-flap` with `fluid-nutils` - `solid-calculix` takes a few minutes to even complete the first time window (without converging). I added that to an additional `extra` test suite, which can be triggered manually.

### Solver dummies

To test the bindings dummies, we would need to first have a mechanism to integrate cases from other repositories than the tutorials (https://github.com/precice/tutorials/issues/538). However, we already test the elastic-tube-1d with Python (and C++), and we could add more of these.

- elastic-tube-1d C++ > C++ solverdummy
- elastic-tube-1d Fortran > Fortran solverdummy
- elastic-tube-1d Fortran module > Fortran module solverdummy
- elastic-tube-1d Python > Python solverdummy
- elastic-tube-1d Julia > Julia bindings solverdummy

That's why I remove these solverdummies, which should be covered by the CI of each repository. The above list excludes the:

- MATLAB bindings solverdummy

To test Alya and MATLAB, similarly + licenses.

Testing SuperMUC as part of the system tests will not be in scope any time soon.