### PR TITLE
Upgrade the linting workflow to Ubuntu 26.04

### DIFF
--- a/.github/workflows/code-linting.yml
+++ b/.github/workflows/code-linting.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   clang-tidy:
     runs-on: ubuntu-latest
-    container: 'precice/ci-ubuntu-2204:latest'
+    container: 'precice/ci-ubuntu-2604:latest'
     steps:
       - uses: actions/checkout@v6
       - name: fetch clang

--- a/.github/workflows/code-linting.yml
+++ b/.github/workflows/code-linting.yml
@@ -27,7 +27,7 @@ jobs:
       - name: fetch clang
         run: apt update && apt install -y clang && apt install -y clang-tidy
       - name: run clang-tidy
-        run: tools/linting/run_clang_tidy.sh
+        run: tools/linting/run_clang_tidy.sh .
       - uses: actions/upload-artifact@v7
         if: failure()
         with:


### PR DESCRIPTION
## Main changes of this PR

This PR bumps the linting workflow to ubuntu 26.04


## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
