### PR TITLE
Migrate to v1 notify action with login

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -51,8 +51,9 @@ jobs:
           EMAIL: ${{ secrets.COVERITY_SUBMITTER_EMAIL }}
       - name: Notification
         if: always()
-        uses: precice/notify-action@v0
+        uses: precice/notify-action@v1
         with:
           homeserver: ${{ vars.MATRIX_BOT_HOMESERVER }}
-          access_token: ${{ secrets.MATRIX_BOT_TOKEN }}
+          login: ${{ vars.MATRIX_BOT_LOGIN }}
+          password: ${{ secrets.MATRIX_BOT_PASSWORD }}
           room_id: ${{ vars.MATRIX_BOT_ROOMID }}

--- a/.github/workflows/performance-regression.yml
+++ b/.github/workflows/performance-regression.yml
@@ -108,8 +108,9 @@ jobs:
             comparison.txt
       - name: Notification
         if: ${{ always() && github.event_name == 'schedule' }}
-        uses: precice/notify-action@v0
+        uses: precice/notify-action@v1
         with:
           homeserver: ${{ vars.MATRIX_BOT_HOMESERVER }}
-          access_token: ${{ secrets.MATRIX_BOT_TOKEN }}
+          login: ${{ vars.MATRIX_BOT_LOGIN }}
+          password: ${{ secrets.MATRIX_BOT_PASSWORD }}
           room_id: ${{ vars.MATRIX_BOT_ROOMID }}

--- a/.github/workflows/publish-docker-nightly.yml
+++ b/.github/workflows/publish-docker-nightly.yml
@@ -14,11 +14,7 @@ on:
     secrets:
       DOCKERHUB_TOKEN:
         required: true
-      MATRIX_BOT_HOMESERVER:
-        required: true
-      MATRIX_BOT_TOKEN:
-        required: true
-      MATRIX_BOT_ROOMID:
+      MATRIX_BOT_PASSWORD:
         required: true
   schedule:
     - cron: '0 3 * * *'
@@ -48,8 +44,9 @@ jobs:
             BRANCH=${{ inputs.branch || 'develop' }}
       - name: Failure Notification
         if: failure()
-        uses: precice/notify-action@v0
+        uses: precice/notify-action@v1
         with:
           homeserver: ${{ vars.MATRIX_BOT_HOMESERVER }}
-          access_token: ${{ secrets.MATRIX_BOT_TOKEN }}
+          login: ${{ vars.MATRIX_BOT_LOGIN }}
+          password: ${{ secrets.MATRIX_BOT_PASSWORD }}
           room_id: ${{ vars.MATRIX_BOT_ROOMID }}


### PR DESCRIPTION
## Main changes of this PR

This PR migrates the notify steps to using the v1 of the notify action which now uses password based login.

## Motivation and additional information

Turns out that the access tokens do expire.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [ ] I stuck to C++17 features.
* [ ] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
