### PR TITLE
Update README with new system test badges

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,8 @@
 [![Coverity](https://scan.coverity.com/projects/19312/badge.svg)](https://scan.coverity.com/projects/precice-precice)
 
 **Downstream Components**  
-[![System tests (latest components)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-latest-components.yml)
+[![System tests (nightly)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-nightly.yml)
+[![System tests (weekly - extra)](https://github.com/precice/tutorials/actions/workflows/system-tests-weekly.yml/badge.svg)](https://github.com/precice/tutorials/actions/workflows/system-tests-weekly.yml)
 [![preCICE distribution](https://img.shields.io/badge/preCICE_Distribution-10.18419%2Fdarus--4167-d45815.svg)](https://doi.org/10.18419/darus-4167)
 [![preCICE website status](https://img.shields.io/website-up-down-green-red/https/precice.org.svg?label=website)](https://precice.org/)
 


### PR DESCRIPTION
## Main changes of this PR

This replaces the `System tests (latest components)` badge with two badges: one for the nightly tests, and one for the weekly (extra) tests.

## Motivation and additional information

Follow-up of https://github.com/precice/tutorials/pull/875, which skipped the manual and the scheduled runs, for clearer reporting.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I squashed / am about to squash all commits that should be seen as one.
