### PR TITLE
Specific mesh filtering and use LUT

### DIFF
--- a/docs/changelog/2591.md
+++ b/docs/changelog/2591.md
@@ -1,0 +1,1 @@
+- Improved mesh filtering and merging speeds and memory consumption.

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -32,8 +32,7 @@ void filterMeshWithConnectivity(Mesh &destination, const Mesh &source, UnaryPred
     if (p(vertex)) {
       Vertex &v = destination.createVertex(vertex.getCoords());
       v.setGlobalIndex(vertex.getGlobalIndex());
-      if (vertex.isTagged())
-        v.tag();
+      v.setTagged(vertex.isTagged());
       v.setOwner(vertex.isOwner());
       vertexMap[vertex.getID()] = &v;
     }
@@ -91,8 +90,7 @@ void filterMeshWithoutConnectivity(Mesh &destination, const Mesh &source, UnaryP
     if (p(vertex)) {
       Vertex &v = destination.createVertex(vertex.getCoords());
       v.setGlobalIndex(vertex.getGlobalIndex());
-      if (vertex.isTagged())
-        v.tag();
+      v.setTagged(vertex.isTagged());
       v.setOwner(vertex.isOwner());
     }
   }

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -13,7 +13,17 @@ namespace precice::mesh {
  * @param[in] p the filter as a UnaryPredicate on mesh::Vertex
  */
 template <typename UnaryPredicate>
-void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
+void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate &&p)
+{
+  if (source.hasConnectivity()) {
+    filterMeshWithConnectivity(destination, source, std::forward<UnaryPredicate>(p));
+  } else {
+    filterMeshWithoutConnectivity(destination, source, std::forward<UnaryPredicate>(p));
+  }
+}
+
+template <typename UnaryPredicate>
+void filterMeshWithConnectivity(Mesh &destination, const Mesh &source, UnaryPredicate p)
 {
   // Create a flat_map which can contain all vertices of the original mesh.
   // This prevents resizes during the map build-up.
@@ -64,6 +74,20 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate p)
         vertexMap.count(vertexIndex3) == 1 &&
         vertexMap.count(vertexIndex4) == 1) {
       destination.createTetrahedron(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3], *vertexMap[vertexIndex4]);
+    }
+  }
+}
+
+template <typename UnaryPredicate>
+void filterMeshWithoutConnectivity(Mesh &destination, const Mesh &source, UnaryPredicate p)
+{
+  for (const Vertex &vertex : source.vertices()) {
+    if (p(vertex)) {
+      Vertex &v = destination.createVertex(vertex.getCoords());
+      v.setGlobalIndex(vertex.getGlobalIndex());
+      if (vertex.isTagged())
+        v.tag();
+      v.setOwner(vertex.isOwner());
     }
   }
 }

--- a/src/mesh/Filter.hpp
+++ b/src/mesh/Filter.hpp
@@ -25,10 +25,8 @@ void filterMesh(Mesh &destination, const Mesh &source, UnaryPredicate &&p)
 template <typename UnaryPredicate>
 void filterMeshWithConnectivity(Mesh &destination, const Mesh &source, UnaryPredicate p)
 {
-  // Create a flat_map which can contain all vertices of the original mesh.
-  // This prevents resizes during the map build-up.
-  boost::container::flat_map<VertexID, Vertex *> vertexMap;
-  vertexMap.reserve(source.nVertices());
+  // Create a lookup table which can contain all vertices of the original mesh.
+  std::vector<Vertex *> vertexMap(source.nVertices(), nullptr);
 
   for (const Vertex &vertex : source.vertices()) {
     if (p(vertex)) {
@@ -41,39 +39,47 @@ void filterMeshWithConnectivity(Mesh &destination, const Mesh &source, UnaryPred
     }
   }
 
+  auto fetch = [&vertexMap](int vid) -> Vertex * {
+#ifndef NDEBUG
+    return vertexMap.at(vid);
+#else
+    return vertexMap[vid];
+#endif
+  };
+
   // Add all edges formed by the contributing vertices
   for (const Edge &edge : source.edges()) {
-    VertexID vertexIndex1 = edge.vertex(0).getID();
-    VertexID vertexIndex2 = edge.vertex(1).getID();
-    if (vertexMap.count(vertexIndex1) == 1 &&
-        vertexMap.count(vertexIndex2) == 1) {
-      destination.createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
+    auto vertex1 = fetch(edge.vertex(0).getID());
+    auto vertex2 = fetch(edge.vertex(1).getID());
+    if (vertex1 &&
+        vertex2) {
+      destination.createEdge(*vertex1, *vertex2);
     }
   }
 
   // Add all triangles formed by the contributing vertices
   for (const Triangle &triangle : source.triangles()) {
-    VertexID vertexIndex1 = triangle.vertex(0).getID();
-    VertexID vertexIndex2 = triangle.vertex(1).getID();
-    VertexID vertexIndex3 = triangle.vertex(2).getID();
-    if (vertexMap.count(vertexIndex1) == 1 &&
-        vertexMap.count(vertexIndex2) == 1 &&
-        vertexMap.count(vertexIndex3) == 1) {
-      destination.createTriangle(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3]);
+    auto vertex1 = fetch(triangle.vertex(0).getID());
+    auto vertex2 = fetch(triangle.vertex(1).getID());
+    auto vertex3 = fetch(triangle.vertex(2).getID());
+    if (vertex1 &&
+        vertex2 &&
+        vertex3) {
+      destination.createTriangle(*vertex1, *vertex2, *vertex3);
     }
   }
 
   // Add all tetrahedra formed by the contributing vertices
   for (const Tetrahedron &tetra : source.tetrahedra()) {
-    VertexID vertexIndex1 = tetra.vertex(0).getID();
-    VertexID vertexIndex2 = tetra.vertex(1).getID();
-    VertexID vertexIndex3 = tetra.vertex(2).getID();
-    VertexID vertexIndex4 = tetra.vertex(3).getID();
-    if (vertexMap.count(vertexIndex1) == 1 &&
-        vertexMap.count(vertexIndex2) == 1 &&
-        vertexMap.count(vertexIndex3) == 1 &&
-        vertexMap.count(vertexIndex4) == 1) {
-      destination.createTetrahedron(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3], *vertexMap[vertexIndex4]);
+    auto vertex1 = fetch(tetra.vertex(0).getID());
+    auto vertex2 = fetch(tetra.vertex(1).getID());
+    auto vertex3 = fetch(tetra.vertex(2).getID());
+    auto vertex4 = fetch(tetra.vertex(3).getID());
+    if (vertex1 &&
+        vertex2 &&
+        vertex3 &&
+        vertex4) {
+      destination.createTetrahedron(*vertex1, *vertex2, *vertex3, *vertex4);
     }
   }
 }

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -353,7 +353,7 @@ void Mesh::tagAll()
 }
 
 void Mesh::addMesh(
-    Mesh &deltaMesh)
+    const Mesh &deltaMesh)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(_dimensions == deltaMesh.getDimensions());

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -364,8 +364,7 @@ void Mesh::addMesh(
     coords    = vertex.getCoords();
     Vertex &v = createVertex(coords);
     v.setGlobalIndex(vertex.getGlobalIndex());
-    if (vertex.isTagged())
-      v.tag();
+    v.setTagged(vertex.isTagged());
     v.setOwner(vertex.isOwner());
     PRECICE_ASSERT(vertex.getID() >= 0, vertex.getID());
     vertexMap[vertex.getID()] = &v;

--- a/src/mesh/Mesh.cpp
+++ b/src/mesh/Mesh.cpp
@@ -16,6 +16,7 @@
 #include "logging/LogMacros.hpp"
 #include "math/geometry.hpp"
 #include "mesh/Data.hpp"
+#include "mesh/Filter.hpp"
 #include "mesh/Vertex.hpp"
 #include "precice/impl/Types.hpp"
 #include "query/Index.hpp"
@@ -357,52 +358,9 @@ void Mesh::addMesh(
   PRECICE_TRACE();
   PRECICE_ASSERT(_dimensions == deltaMesh.getDimensions());
 
-  boost::container::flat_map<VertexID, Vertex *> vertexMap;
-  vertexMap.reserve(deltaMesh.nVertices());
-  Eigen::VectorXd coords(_dimensions);
-  for (const Vertex &vertex : deltaMesh.vertices()) {
-    coords    = vertex.getCoords();
-    Vertex &v = createVertex(coords);
-    v.setGlobalIndex(vertex.getGlobalIndex());
-    v.setTagged(vertex.isTagged());
-    v.setOwner(vertex.isOwner());
-    PRECICE_ASSERT(vertex.getID() >= 0, vertex.getID());
-    vertexMap[vertex.getID()] = &v;
-  }
+  // Filter by selecting all vertices in the delta mesh
+  filterMesh(*this, deltaMesh, [](const Vertex &) { return true; });
 
-  // you cannot just take the vertices from the edge and add them,
-  // since you need the vertices from the new mesh
-  // (which may differ in IDs)
-  for (const Edge &edge : deltaMesh.edges()) {
-    VertexID vertexIndex1 = edge.vertex(0).getID();
-    VertexID vertexIndex2 = edge.vertex(1).getID();
-    PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
-                   (vertexMap.count(vertexIndex2) == 1));
-    createEdge(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2]);
-  }
-
-  for (const Triangle &triangle : deltaMesh.triangles()) {
-    VertexID vertexIndex1 = triangle.vertex(0).getID();
-    VertexID vertexIndex2 = triangle.vertex(1).getID();
-    VertexID vertexIndex3 = triangle.vertex(2).getID();
-    PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
-                   (vertexMap.count(vertexIndex2) == 1) &&
-                   (vertexMap.count(vertexIndex3) == 1));
-    createTriangle(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3]);
-  }
-
-  for (const Tetrahedron &tetra : deltaMesh.tetrahedra()) {
-    VertexID vertexIndex1 = tetra.vertex(0).getID();
-    VertexID vertexIndex2 = tetra.vertex(1).getID();
-    VertexID vertexIndex3 = tetra.vertex(2).getID();
-    VertexID vertexIndex4 = tetra.vertex(3).getID();
-
-    PRECICE_ASSERT((vertexMap.count(vertexIndex1) == 1) &&
-                   (vertexMap.count(vertexIndex2) == 1) &&
-                   (vertexMap.count(vertexIndex3) == 1) &&
-                   (vertexMap.count(vertexIndex4) == 1));
-    createTetrahedron(*vertexMap[vertexIndex1], *vertexMap[vertexIndex2], *vertexMap[vertexIndex3], *vertexMap[vertexIndex4]);
-  }
   _index.clear();
 }
 

--- a/src/mesh/Mesh.hpp
+++ b/src/mesh/Mesh.hpp
@@ -304,7 +304,7 @@ public:
     return _communicationMap;
   }
 
-  void addMesh(Mesh &deltaMesh);
+  void addMesh(const Mesh &deltaMesh);
 
   /**
    * @brief Returns the bounding box of the mesh.

--- a/src/mesh/Vertex.cpp
+++ b/src/mesh/Vertex.cpp
@@ -34,6 +34,11 @@ bool Vertex::isTagged() const
   return _tagged;
 }
 
+void Vertex::setTagged(bool tagged)
+{
+  _tagged = tagged;
+}
+
 void Vertex::tag()
 {
   _tagged = true;

--- a/src/mesh/Vertex.hpp
+++ b/src/mesh/Vertex.hpp
@@ -51,6 +51,8 @@ public:
 
   bool isTagged() const;
 
+  void setTagged(bool tagged);
+
   void tag();
 
   /// Returns a coordinate of a vertex


### PR DESCRIPTION
## Main changes of this PR

This PR changes the implementation of mesh filtering, used in the repartitioning in two ways:

1. Meshes without connectivity now copy filtered vertices without building the vertex map as it is only needed for filtering connectivity.
2. Instead of a pre-sizes flat-map, changed to using a LUT. This is possible as vertex ids are always mesh-local and in between 0 and size-1. This LUT not only has a constant access time, but is filled sequentially. It even reduces memory footprint as the indices are not saved anymore.
3. Copying tags is now branchless using a getter and setter, which leads to a significant speed-up, especially in the non-connectivity variant.

## Motivation and additional information

Improve filtering in terms of efficacy and efficiency.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [x] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
