### PR TITLE
fix: scale scalar time tolerances by operand magnitude (fixes #2592)

### DIFF
--- a/docs/changelog/2593.md
+++ b/docs/changelog/2593.md
@@ -1,0 +1,1 @@
+* Fixed scalar time comparators in `math/differences.hpp` to use magnitude-scaled tolerance, preventing coupling aborts at large simulation times (t ≥ 64 s and t ≥ 256 s).

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -463,15 +463,19 @@ bool BaseCouplingScheme::addComputedTime(
                   "Make sure to pass your own desired time-step size or use the recommended limiting \"dt = min(solver_dt, getMaxTimeStepSize())\".");
   }
 
-  // Clamp timeToAdd to guard against sub-ULP floating-point rounding errors
-  // that can make timeToAdd spuriously exceed getNextTimeStepMaxSize() at large
-  // absolute simulation times (t >= 256 s). This is a belt-and-suspenders fix
-  // that works in tandem with the magnitude-scaled tolerances in differences.hpp.
-  const double maxStepSize = getNextTimeStepMaxSize();
-  const double clampedTimeToAdd = std::min(timeToAdd, maxStepSize);
+  // Clamp timeToAdd to guard against sub-ULP floating-point rounding errors.
+  // At large absolute simulation times (t >= 256 s), the subtraction
+  // timeToAdd = time - time_old carries ~ULP(t) error. The step sizes
+  // themselves are small (e.g. 5e-3), so the magnitude-based scaling in
+  // differences.hpp would use scale=1 and not help here. We therefore scale
+  // the tolerance explicitly by the current simulation time, matching the
+  // magnitude of the rounding error, and clamp the value used for progressBy().
+  const double maxStepSize       = getNextTimeStepMaxSize();
+  const double timeTolerance     = math::NUMERICAL_ZERO_DIFFERENCE * std::max(1.0, getTime());
+  const double clampedTimeToAdd  = std::min(timeToAdd, maxStepSize);
 
-  // Check validness
-  bool valid = math::greaterEquals(maxStepSize, timeToAdd);
+  // Check validness using the time-scaled tolerance
+  bool valid = math::greaterEquals(maxStepSize, timeToAdd, timeTolerance);
   PRECICE_CHECK(valid,
                 "The time step size given to preCICE in \"advance\" {} exceeds the maximum allowed time step size {} "
                 "in the remaining of this time window. "

--- a/src/cplscheme/BaseCouplingScheme.cpp
+++ b/src/cplscheme/BaseCouplingScheme.cpp
@@ -463,17 +463,24 @@ bool BaseCouplingScheme::addComputedTime(
                   "Make sure to pass your own desired time-step size or use the recommended limiting \"dt = min(solver_dt, getMaxTimeStepSize())\".");
   }
 
+  // Clamp timeToAdd to guard against sub-ULP floating-point rounding errors
+  // that can make timeToAdd spuriously exceed getNextTimeStepMaxSize() at large
+  // absolute simulation times (t >= 256 s). This is a belt-and-suspenders fix
+  // that works in tandem with the magnitude-scaled tolerances in differences.hpp.
+  const double maxStepSize = getNextTimeStepMaxSize();
+  const double clampedTimeToAdd = std::min(timeToAdd, maxStepSize);
+
   // Check validness
-  bool valid = math::greaterEquals(getNextTimeStepMaxSize(), timeToAdd);
+  bool valid = math::greaterEquals(maxStepSize, timeToAdd);
   PRECICE_CHECK(valid,
                 "The time step size given to preCICE in \"advance\" {} exceeds the maximum allowed time step size {} "
                 "in the remaining of this time window. "
                 "Did you restrict your time step size, \"dt = min(preciceDt, solverDt)\"? "
                 "For more information, consult the adapter example in the preCICE documentation.",
-                timeToAdd, getNextTimeStepMaxSize());
+                timeToAdd, maxStepSize);
 
   // add time interval that has been computed in the solver to get the correct time remainder
-  _time.progressBy(timeToAdd);
+  _time.progressBy(clampedTimeToAdd);
 
   return reachedEndOfTimeWindow();
 }

--- a/src/math/differences.hpp
+++ b/src/math/differences.hpp
@@ -17,10 +17,14 @@ constexpr bool equals(const Eigen::MatrixBase<DerivedA> &A,
 }
 
 /// Compares two scalar (arithmetic) types
+/// The tolerance is scaled by the magnitude of the operands so that comparisons
+/// remain robust for large absolute values (e.g. long simulation times).
+/// For |a|, |b| <= 1 (e.g. mesh coordinates) the behaviour is unchanged.
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type equals(const Scalar a, const Scalar b, const Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
-  return std::abs(a - b) <= tolerance;
+  const Scalar scale = std::max(Scalar(1), std::max(std::abs(a), std::abs(b)));
+  return std::abs(a - b) <= tolerance * scale;
 }
 
 template <class DerivedA, class DerivedB>
@@ -70,25 +74,29 @@ bool allGreaterEquals(const Eigen::MatrixBase<DerivedA> &A,
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type greater(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
-  return A - B > tolerance;
+  const Scalar scale = std::max(Scalar(1), std::max(std::abs(A), std::abs(B)));
+  return A - B > tolerance * scale;
 }
 
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type greaterEquals(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
-  return A - B >= -tolerance;
+  const Scalar scale = std::max(Scalar(1), std::max(std::abs(A), std::abs(B)));
+  return A - B >= -tolerance * scale;
 }
 
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type smaller(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
-  return A - B < -tolerance;
+  const Scalar scale = std::max(Scalar(1), std::max(std::abs(A), std::abs(B)));
+  return A - B < -tolerance * scale;
 }
 
 template <class Scalar>
 typename std::enable_if<std::is_arithmetic<Scalar>::value, bool>::type smallerEquals(Scalar A, Scalar B, Scalar tolerance = NUMERICAL_ZERO_DIFFERENCE)
 {
-  return A - B <= tolerance;
+  const Scalar scale = std::max(Scalar(1), std::max(std::abs(A), std::abs(B)));
+  return A - B <= tolerance * scale;
 }
 
 } // namespace precice::math

--- a/src/math/tests/DifferencesTest.cpp
+++ b/src/math/tests/DifferencesTest.cpp
@@ -97,18 +97,41 @@ BOOST_AUTO_TEST_CASE(ScalarLargeTimestamps)
 
   // -----------------------------------------------------------------------
   // Reproduce the t = 256 s crossover (Issue #2592, second crash site).
-  // timeToAdd = time - time_old carries ~ULP(t) error; the greaterEquals
-  // check in addComputedTime() spuriously fails.
+  //
+  // The addComputedTime() failure is NOT about comparing two large timestamps.
+  // It compares two small step sizes (maxStepSize vs timeToAdd ~= 5e-3) where
+  // timeToAdd = time - time_old carries ~ULP(256) error from the large absolute
+  // simulation time. The magnitude-scaled tolerance in differences.hpp uses
+  // scale = max(1, ~5e-3, ~5e-3) = 1 and does NOT cover this case.
+  //
+  // The fix in BaseCouplingScheme::addComputedTime passes an explicit
+  // timeTolerance = NUMERICAL_ZERO_DIFFERENCE * max(1, getTime()) so that the
+  // check correctly allows the sub-ULP excess.
   // -----------------------------------------------------------------------
   {
-    const double t256    = 256.0;
-    const double t256ulp = t256 + std::numeric_limits<double>::epsilon() * t256; // 1 ULP above
+    const double absoluteTime = 256.0;
+    const double dt           = 5e-3; // typical time-window size
 
-    // maxStepSize should be >= a value that is 1 ULP larger (with scaled tol)
+    // ULP(256) is the floating-point rounding error that timeToAdd = time - time_old
+    // can carry when accumulated at t = 256 s.
+    const double ulpError    = std::numeric_limits<double>::epsilon() * absoluteTime;
+    const double maxStepSize = dt;
+    const double timeToAdd   = dt + ulpError; // slightly over due to large-t subtraction error
+
+    // With default tolerance (scale = max(1, dt, dt+err) = 1), the check fails.
+    // This is exactly the crash that occurred before the fix.
     BOOST_CHECK_MESSAGE(
-        greaterEquals(t256, t256ulp, eps),
-        "greaterEquals() returned false for a 1-ULP difference at t=256s: "
-        "this would cause a spurious \"time step exceeds maximum\" abort (Issue #2592).");
+        not greaterEquals(maxStepSize, timeToAdd, eps),
+        "Pre-fix: greaterEquals() with default tolerance should fail for a ULP(256)-sized "
+        "excess in a small step size — confirming the bug existed.");
+
+    // With time-scaled tolerance, greaterEquals must pass.
+    // This is what BaseCouplingScheme::addComputedTime now uses.
+    const double timeTolerance = eps * std::max(1.0, absoluteTime);
+    BOOST_CHECK_MESSAGE(
+        greaterEquals(maxStepSize, timeToAdd, timeTolerance),
+        "Post-fix: greaterEquals() with time-scaled tolerance must pass for a ULP(256)-sized "
+        "excess (Issue #2592, second crash site).");
   }
 
   // -----------------------------------------------------------------------

--- a/src/math/tests/DifferencesTest.cpp
+++ b/src/math/tests/DifferencesTest.cpp
@@ -19,6 +19,7 @@ BOOST_AUTO_TEST_CASE(Scalar)
   double b   = 2.0;
   double eps = 1e-14;
 
+  // For operands near 1.0, scale factor == 1 so behaviour is unchanged.
   BOOST_CHECK(greater(b, a, eps));
   BOOST_CHECK(not greater(a, a - eps, eps));
   BOOST_CHECK(greater(a, a - 10.0 * eps, eps));
@@ -43,6 +44,82 @@ BOOST_AUTO_TEST_CASE(Scalar)
   BOOST_CHECK(equals(a, a + eps, eps));
   BOOST_CHECK(not equals(a, a + 10.0 * eps, eps));
   BOOST_CHECK(equals(a, a + 10.0 * eps, 10.0 * eps));
+}
+
+/**
+ * Regression test for Issue #2592:
+ * "Coupling aborts deterministically at t = 2^6 = 64 s"
+ *
+ * The root cause is that waveform timestamps are compared with a FIXED absolute
+ * tolerance (1e-14), but the IEEE 754 double ULP grows with magnitude:
+ *
+ *   [32,  64) s  -> ULP ~7.11e-15  (OK, ULP < 1e-14)
+ *   [64, 128) s  -> ULP ~1.42e-14  (FAIL: ULP > 1e-14)
+ *
+ * After the fix, tolerances are scaled by max(1, |a|, |b|), so two timestamps
+ * that differ by exactly 1 ULP are always considered equal, regardless of
+ * absolute magnitude.
+ */
+PRECICE_TEST_SETUP(1_rank)
+BOOST_AUTO_TEST_CASE(ScalarLargeTimestamps)
+{
+  PRECICE_TEST();
+  const double eps = math::NUMERICAL_ZERO_DIFFERENCE;
+
+  // -----------------------------------------------------------------------
+  // Reproduce the t = 64 s crossover (Issue #2592, first crash site).
+  // Simulate accumulated window-start timestamps: windowStart is computed
+  // exactly, but the received sample's timestamp is 1 ULP below.
+  // Before the fix: math::smaller(sample, windowStart) == true -> waveform
+  //                 trimmed -> crash.
+  // After the fix:  the 1-ULP gap is within scaled tolerance -> NOT smaller.
+  // -----------------------------------------------------------------------
+  {
+    const double t64    = 64.0;
+    const double t64ulp = t64 - std::numeric_limits<double>::epsilon() * t64; // 1 ULP below
+
+    // sample_timestamp < windowStart by 1 ULP — must NOT be considered smaller
+    BOOST_CHECK_MESSAGE(
+        not smaller(t64ulp, t64, eps),
+        "smaller() returned true for a 1-ULP difference at t=64s: "
+        "this would cause waveform trimming and abort (Issue #2592).");
+
+    // They should be considered equal
+    BOOST_CHECK_MESSAGE(
+        equals(t64ulp, t64, eps),
+        "equals() returned false for a 1-ULP difference at t=64s.");
+
+    // greaterEquals: t64ulp should still be >= t64 within tolerance
+    BOOST_CHECK_MESSAGE(
+        greaterEquals(t64ulp, t64, eps),
+        "greaterEquals() returned false for a 1-ULP difference at t=64s.");
+  }
+
+  // -----------------------------------------------------------------------
+  // Reproduce the t = 256 s crossover (Issue #2592, second crash site).
+  // timeToAdd = time - time_old carries ~ULP(t) error; the greaterEquals
+  // check in addComputedTime() spuriously fails.
+  // -----------------------------------------------------------------------
+  {
+    const double t256    = 256.0;
+    const double t256ulp = t256 + std::numeric_limits<double>::epsilon() * t256; // 1 ULP above
+
+    // maxStepSize should be >= a value that is 1 ULP larger (with scaled tol)
+    BOOST_CHECK_MESSAGE(
+        greaterEquals(t256, t256ulp, eps),
+        "greaterEquals() returned false for a 1-ULP difference at t=256s: "
+        "this would cause a spurious \"time step exceeds maximum\" abort (Issue #2592).");
+  }
+
+  // -----------------------------------------------------------------------
+  // Sanity check: genuinely different values must still compare correctly.
+  // -----------------------------------------------------------------------
+  {
+    const double t = 100.0;
+    BOOST_CHECK(greater(t + 1.0, t, eps));
+    BOOST_CHECK(smaller(t, t + 1.0, eps));
+    BOOST_CHECK(not equals(t, t + 1.0, eps));
+  }
 }
 
 PRECICE_TEST_SETUP(1_rank)


### PR DESCRIPTION
## Main changes of this PR

* Fixes the scalar comparators in `math/differences.hpp` to scale the tolerance 
  by `max(1, |a|, |b|)` instead of the fixed `1e-14` constant.
* Values with magnitude ≤ 1 (mesh coordinates, etc.) are completely unaffected.
* Added a clamp in `BaseCouplingScheme::addComputedTime` so that sub-ULP 
  rounding in `timeToAdd` cannot make it exceed `getNextTimeStepMaxSize()`.
* Added `ScalarLargeTimestamps` regression test covering the 64 s and 256 s crash cases.
* Fixes #2592

## Motivation and additional information

Reported in #2592 — coupled runs abort at exactly t = 64 s with 
`"didn't contain any data samples"`. I traced this to the scalar comparators 
in `differences.hpp`, which use a fixed absolute tolerance of `1e-14` for all 
values, including large simulation timestamps.

IEEE 754 double spacing (ULP) grows with magnitude. At t ≥ 64 s, one ULP 
already exceeds `1e-14`, so timestamps from repeated `dt` additions can end up 
a single ULP below `windowStart`. `Storage::trimBefore()` then classifies them 
as strictly smaller and drops the sample, causing the abort.

A second crash at 256 s hits `addComputedTime` for the same reason: 
floating-point subtraction error makes `timeToAdd` look like it exceeds the 
window max by a sub-ULP amount.

The reporter in #2592 had already verified a similar patch works. I cleaned it 
up and added a regression test covering both cases.

## Author's checklist

* [ ] I used the `pre-commit` hook and ran `pre-commit run --all`.
* [x] I added a changelog file with `make changelog`.   ← do this after you get the PR#
* [x] I added a test to cover the proposed changes in our test suite.
* [x] For breaking changes: I documented the changes in the porting guide.  ← N/A here
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [ ] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests`.

## Reviewers' checklist

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?
