### PR TITLE
Query the spatial index with raw coordinates

### DIFF
--- a/benchmarks/mapping-nn.cpp
+++ b/benchmarks/mapping-nn.cpp
@@ -1,0 +1,52 @@
+#include <benchmark/benchmark.h>
+
+#include "helper.hpp"
+#include "mapping/Mapping.hpp"
+#include "mapping/NearestNeighborMapping.hpp"
+#include "mesh/Mesh.hpp"
+#include "mesh/SharedPointer.hpp"
+
+using namespace precice;
+
+namespace {
+
+/// Two 3d Halton meshes of n vertices, offset so no vertices coincide
+std::pair<mesh::PtrMesh, mesh::PtrMesh> makeMeshPair(int n)
+{
+  mesh::PtrMesh inMesh(new mesh::Mesh("InMesh", 3, 0));
+  auto          inPos = generate3DHalton(n);
+  for (auto row : inPos.rowwise()) {
+    inMesh->createVertex(row);
+  }
+
+  mesh::PtrMesh outMesh(new mesh::Mesh("OutMesh", 3, 1));
+  auto          outPos = generate3DHalton(n);
+  outPos.array() += 1e-3;
+  for (auto row : outPos.rowwise()) {
+    outMesh->createVertex(row);
+  }
+  return {inMesh, outMesh};
+}
+
+} // namespace
+
+/// Benchmarks computeMapping of a consistent nearest-neighbour mapping between two 3d meshes
+static void computeNearestNeighborMapping(benchmark::State &state)
+{
+  int n          = state.range(0);
+  auto [in, out] = makeMeshPair(n);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    mapping::NearestNeighborMapping mapping(mapping::Mapping::CONSISTENT, 3);
+    mapping.setMeshes(in, out);
+    in->index().clear();
+    state.ResumeTiming();
+
+    mapping.computeMapping();
+    benchmark::DoNotOptimize(mapping);
+  }
+  state.SetComplexityN(state.range(0));
+}
+
+BENCHMARK(computeNearestNeighborMapping)->Name("NN computeMapping")->RangeMultiplier(4)->Range(1 << 10, 1 << 18)->Complexity();

--- a/benchmarks/sources.cmake
+++ b/benchmarks/sources.cmake
@@ -7,6 +7,7 @@ target_sources(precice-bench
     benchmarks/bb.cpp
     benchmarks/helper.hpp
     benchmarks/main.cpp
+    benchmarks/mapping-nn.cpp
     benchmarks/mesh-index.cpp
     benchmarks/mesh-tagging.cpp
     benchmarks/rbf-assembly-kernels.cpp

--- a/docs/changelog/2594.md
+++ b/docs/changelog/2594.md
@@ -1,0 +1,1 @@
+- Improved the speed of nearest-neighbour and enclosing-tetrahedron index queries by converting the query point to raw coordinates once per query.

--- a/src/mapping/NearestNeighborBaseMapping.cpp
+++ b/src/mapping/NearestNeighborBaseMapping.cpp
@@ -1,6 +1,7 @@
 #include "NearestNeighborBaseMapping.hpp"
 
 #include <boost/container/flat_set.hpp>
+#include <cmath>
 #include <functional>
 #include <iostream>
 #include "logging/LogMacros.hpp"
@@ -59,14 +60,16 @@ void NearestNeighborBaseMapping::computeMapping()
 
   auto &index = searchSpace->index();
   for (size_t i = 0; i < verticesSize; ++i) {
-    const auto &sourceCoords  = sourceVertices[i].getCoords();
+    const auto &sourceCoords  = sourceVertices[i].rawCoords();
     const auto  matchedVertex = index.getClosestVertex(sourceCoords);
     _vertexIndices[i]         = matchedVertex.index;
 
     // Compute distance between input and output vertiex for the stats
-    const auto &matchCoords = searchSpace->vertex(matchedVertex.index).getCoords();
-    auto        distance    = (sourceCoords - matchCoords).norm();
-    distanceStatistics(distance);
+    const auto &matchCoords = searchSpace->vertex(matchedVertex.index).rawCoords();
+    const auto  d0          = sourceCoords[0] - matchCoords[0];
+    const auto  d1          = sourceCoords[1] - matchCoords[1];
+    const auto  d2          = sourceCoords[2] - matchCoords[2];
+    distanceStatistics(std::sqrt(d0 * d0 + d1 * d1 + d2 * d2));
   }
 
   // For gradient mapping, the calculation of offsets between source and matched vertex necessary

--- a/src/mapping/impl/CreateClustering.hpp
+++ b/src/mapping/impl/CreateClustering.hpp
@@ -151,7 +151,7 @@ void projectClusterCentersToinputMesh(Vertices &clusterCenters, mesh::PtrMesh me
 {
   std::transform(clusterCenters.begin(), clusterCenters.end(), clusterCenters.begin(), [&](auto &v) {
     if (!v.isTagged()) {
-      auto closestCenter = mesh->index().getClosestVertex(v.getCoords()).index;
+      auto closestCenter = mesh->index().getClosestVertex(v.rawCoords()).index;
       return mesh::Vertex{mesh->vertex(closestCenter).getCoords(), v.getID()};
     } else {
       return v;
@@ -256,7 +256,7 @@ inline double estimateClusterRadius(unsigned int verticesPerCluster, mesh::PtrMe
   std::vector<double> sampledClusterRadii;
   for (auto s : randomSamples) {
     // ask the index tree for the k-nearest neighbors  in order to estimate the point density
-    auto kNearestVertexIDs = inMesh->index().getClosestVertices(inMesh->vertex(s).getCoords(), verticesPerCluster);
+    auto kNearestVertexIDs = inMesh->index().getClosestVertices(inMesh->vertex(s).rawCoords(), verticesPerCluster);
     // compute the distance of each point to the center
     std::vector<double> squaredRadius(kNearestVertexIDs.size());
     std::transform(kNearestVertexIDs.begin(), kNearestVertexIDs.end(), squaredRadius.begin(), [&inMesh, s](auto i) {

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -168,30 +168,40 @@ Index::Index(mesh::Mesh &mesh)
 // Required for the pimpl idiom to work with std::unique_ptr
 Index::~Index() = default;
 
-VertexMatch Index::getClosestVertex(const Eigen::VectorXd &sourceCoord)
+VertexMatch Index::getClosestVertex(const mesh::Vertex::RawCoords &sourceCoord)
 {
   PRECICE_TRACE();
 
   PRECICE_ASSERT(not _mesh->empty(), _mesh->getName());
   VertexMatch match;
   const auto &rtree = _pimpl->getVertexRTree(*_mesh);
-  rtree->query(bgi::nearest(eigenToRaw(sourceCoord), 1), boost::make_function_output_iterator([&](size_t matchID) {
+  rtree->query(bgi::nearest(sourceCoord, 1), boost::make_function_output_iterator([&](size_t matchID) {
                  match = VertexMatch(matchID);
                }));
   return match;
 }
 
-std::vector<VertexID> Index::getClosestVertices(const Eigen::VectorXd &sourceCoord, int n)
+VertexMatch Index::getClosestVertex(const Eigen::VectorXd &sourceCoord)
+{
+  return getClosestVertex(eigenToRaw(sourceCoord));
+}
+
+std::vector<VertexID> Index::getClosestVertices(const mesh::Vertex::RawCoords &sourceCoord, int n)
 {
   PRECICE_TRACE();
   PRECICE_ASSERT(!(_mesh->empty()), _mesh->getName());
   std::vector<VertexID> matches;
   const auto           &rtree = _pimpl->getVertexRTree(*_mesh);
 
-  rtree->query(bgi::nearest(eigenToRaw(sourceCoord), n), boost::make_function_output_iterator([&](size_t matchID) {
+  rtree->query(bgi::nearest(sourceCoord, n), boost::make_function_output_iterator([&](size_t matchID) {
                  matches.emplace_back(matchID);
                }));
   return matches;
+}
+
+std::vector<VertexID> Index::getClosestVertices(const Eigen::VectorXd &sourceCoord, int n)
+{
+  return getClosestVertices(eigenToRaw(sourceCoord), n);
 }
 
 std::vector<EdgeMatch> Index::getClosestEdges(const Eigen::VectorXd &sourceCoord, int n)

--- a/src/query/Index.cpp
+++ b/src/query/Index.cpp
@@ -175,7 +175,7 @@ VertexMatch Index::getClosestVertex(const Eigen::VectorXd &sourceCoord)
   PRECICE_ASSERT(not _mesh->empty(), _mesh->getName());
   VertexMatch match;
   const auto &rtree = _pimpl->getVertexRTree(*_mesh);
-  rtree->query(bgi::nearest(sourceCoord, 1), boost::make_function_output_iterator([&](size_t matchID) {
+  rtree->query(bgi::nearest(eigenToRaw(sourceCoord), 1), boost::make_function_output_iterator([&](size_t matchID) {
                  match = VertexMatch(matchID);
                }));
   return match;
@@ -188,7 +188,7 @@ std::vector<VertexID> Index::getClosestVertices(const Eigen::VectorXd &sourceCoo
   std::vector<VertexID> matches;
   const auto           &rtree = _pimpl->getVertexRTree(*_mesh);
 
-  rtree->query(bgi::nearest(sourceCoord, n), boost::make_function_output_iterator([&](size_t matchID) {
+  rtree->query(bgi::nearest(eigenToRaw(sourceCoord), n), boost::make_function_output_iterator([&](size_t matchID) {
                  matches.emplace_back(matchID);
                }));
   return matches;
@@ -202,7 +202,7 @@ std::vector<EdgeMatch> Index::getClosestEdges(const Eigen::VectorXd &sourceCoord
 
   std::vector<EdgeMatch> matches;
   matches.reserve(n);
-  rtree->query(bgi::nearest(sourceCoord, n), boost::make_function_output_iterator([&](size_t matchID) {
+  rtree->query(bgi::nearest(eigenToRaw(sourceCoord), n), boost::make_function_output_iterator([&](size_t matchID) {
                  matches.emplace_back(matchID);
                }));
   return matches;
@@ -215,7 +215,7 @@ std::vector<TriangleMatch> Index::getClosestTriangles(const Eigen::VectorXd &sou
 
   std::vector<TriangleMatch> matches;
   matches.reserve(n);
-  rtree->query(bgi::nearest(sourceCoord, n),
+  rtree->query(bgi::nearest(eigenToRaw(sourceCoord), n),
                boost::make_function_output_iterator([&](TriangleTraits::IndexType const &match) {
                  matches.emplace_back(match.second);
                }));
@@ -268,7 +268,7 @@ std::vector<TetrahedronID> Index::getEnclosingTetrahedra(const Eigen::VectorXd &
   const auto &rtree = _pimpl->getTetraRTree(*_mesh);
 
   std::vector<TetrahedronID> matches;
-  rtree->query(bgi::covers(location), boost::make_function_output_iterator([&](TetrahedronTraits::IndexType const &match) {
+  rtree->query(bgi::covers(eigenToRaw(location)), boost::make_function_output_iterator([&](TetrahedronTraits::IndexType const &match) {
                  matches.emplace_back(match.second);
                }));
   return matches;

--- a/src/query/Index.hpp
+++ b/src/query/Index.hpp
@@ -68,8 +68,14 @@ public:
   Index(mesh::Mesh &mesh);
   ~Index();
 
+  /// Get the closest vertex to the given coordinates
+  VertexMatch getClosestVertex(const mesh::Vertex::RawCoords &sourceCoord);
+
   /// Get the closest vertex to the given vertex
   VertexMatch getClosestVertex(const Eigen::VectorXd &sourceCoord);
+
+  /// Get n number of closest vertices to the given coordinates
+  std::vector<VertexID> getClosestVertices(const mesh::Vertex::RawCoords &sourceCoord, int n);
 
   /// Get n number of closest vertices to the given vertex
   std::vector<VertexID> getClosestVertices(const Eigen::VectorXd &sourceCoord, int n);

--- a/src/query/impl/RTreeAdapter.hpp
+++ b/src/query/impl/RTreeAdapter.hpp
@@ -188,6 +188,12 @@ inline RTreeBox makeBox(const pm::Vertex::RawCoords &min, const pm::Vertex::RawC
   return {min, max};
 }
 
+/** Converts an Eigen vector to raw coordinates.
+ *
+ * Prefer raw coordinates when querying an rtree. Adapting an Eigen::VectorXd to
+ * boost.geometry requires a runtime dimension check on every coordinate access,
+ * which a single query repeats for every primitive it visits.
+ */
 inline pm::Vertex::RawCoords eigenToRaw(const Eigen::VectorXd &v)
 {
   const auto size = v.size();


### PR DESCRIPTION
## Main changes of this PR

The rtree queries in `query::Index` now take raw coordinates instead of an `Eigen::VectorXd`.

Why the old way costs something:

- boost.geometry reads an `Eigen::VectorXd` through this accessor:

```cpp
static double get(Eigen::VectorXd const &p)
{
  if (Dimension >= static_cast<size_t>(p.rows())) {
    return 0;
  } else {
    return p(Dimension);
  }
}
```

- So every coordinate read does a bounds check and goes through the vector's heap pointer.
- A query repeats that for every primitive it visits, so the cost grows with the size of the search space rather than with the number of queries.
- `eigenToRaw` already exists and pads to three dimensions the same way, so converting the query point once per query gives the same results.

Affected calls: `getClosestVertex`, `getClosestVertices`, `getClosestEdges`, `getClosestTriangles`, `getEnclosingTetrahedra`.

## Motivation and additional information

- Found while looking into #2408, which lists "minimizing indirection by directly using 3D `Vertex::rawCoords()` instead of adapting `mesh::Vertex` and `Eigen::VectorXd`" as one direction.
- This only moves the conversion out of the per-primitive adapter and into the query boundary. As @fsimonis points out below, the Index API itself still takes `Eigen::VectorXd`, so the conversions aren't gone, just cheaper. Discussion on that is in the comments.

Measurements, using the existing `benchmarks/mesh-index.cpp`:

- Redone with @fsimonis's settings: AC adapter connected, macOS Low Power Mode off, `--benchmark_repetitions=11 --benchmark_report_aggregates_only=true` on a filtered subset.
- Low Power Mode was the main source of noise in my first attempt, so please ignore the numbers I posted earlier. These are lower.
- Four independent runs. `Index vertices` isn't touched by this PR, so it's in as a control.

| benchmark | median of 4 runs | per-run |
|---|---|---|
| Closest vertex to center/65536 | -7.3% | -6.5, -7.3, -7.3, -8.7 |
| Closest vertex to center/1048576 | -6.6% | -6.0, -7.1, -6.8, -6.3 |
| 10 closest vertices to center/65536 | -5.7% | -6.1, -5.3, -5.1, -6.9 |
| Index vertices/65536 (control) | -0.6% | +3.4, -0.2, -1.1, -1.2 |

Within-run CV is under 1.2% now, against 20% and worse before.

Rebased onto current `develop`, so the recent mesh changes are in both sides.

**Disclosure per CONTRIBUTING.md:** the code and benchmark scripts in this PR were prepared with an AI assistant.

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

On the test checkbox: this doesn't change behaviour, and the existing query and mapping tests already cover the affected calls. Can add something specific if you'd like.
