### PR TITLE
Rename precicef_set_tetrahedron to precicef_set_tetrahedron_

### DIFF
--- a/docs/changelog/2595.md
+++ b/docs/changelog/2595.md
@@ -1,0 +1,1 @@
+* Fixed the deprecated Fortran function `precicef_set_tetrahedron`, which was missing the trailing underscore that Fortran compilers append and could therefore not be called from Fortran. It is now `precicef_set_tetrahedron_`.

--- a/extras/bindings/fortran/include/precice/preciceFortran.hpp
+++ b/extras/bindings/fortran/include/precice/preciceFortran.hpp
@@ -505,7 +505,7 @@ PRECICE_API void precicef_set_mesh_tetrahedron_(
  * @brief @deprecated Use precicef_set_mesh_tetrahedron_() instead.
  * @see precicef_set_mesh_tetrahedron_
  */
-PRECICE_API void precicef_set_tetrahedron(
+PRECICE_API void precicef_set_tetrahedron_(
     const char *meshName,
     const int  *firstVertexID,
     const int  *secondVertexID,

--- a/extras/bindings/fortran/src/preciceFortran.cpp
+++ b/extras/bindings/fortran/src/preciceFortran.cpp
@@ -616,7 +616,7 @@ void precicef_set_quad_(
   precicef_set_mesh_quad_(meshName, firstVertexID, secondVertexID, thirdVertexID, fourthVertexID, meshNameLength);
 }
 
-void precicef_set_tetrahedron(
+void precicef_set_tetrahedron_(
     const char *meshName,
     const int  *firstVertexID,
     const int  *secondVertexID,


### PR DESCRIPTION
## Main changes of this PR

Adds the Fortran function `precicef_set_tetrahedron_`.

The problem:

- Fortran compilers append a trailing underscore to symbol names.
- Five of the six deprecated `precicef_set_*` aliases have that underscore. `precicef_set_tetrahedron` does not.

| symbol | trailing `_` |
| --- | --- |
| `precicef_set_vertex_` | yes |
| `precicef_set_vertices_` | yes |
| `precicef_set_edge_` | yes |
| `precicef_set_triangle_` | yes |
| `precicef_set_quad_` | yes |
| `precicef_set_tetrahedron` | **no** |

- So `call precicef_set_tetrahedron(...)` looks for `precicef_set_tetrahedron_`, which is not in the library, and the link fails.
- The other five deprecated aliases work fine.

## Motivation and additional information

- I found this while looking at #1540, running the `tools/building/checkSymbols` logic against a build. `precicef_set_tetrahedron` showed up expecting a C++ counterpart called `setTetrahedron` instead of `setMeshTetrahedron`, which is what made me look at the name.
- The name has been wrong since the binding was added in #1382, and CHANGELOG.md records it under that name, so no Fortran code can be relying on it today.
- I did not simply rename it. `preCICE_SOVERSION` is the major version, so `libprecice.so.3` promises a stable ABI, and renaming would drop an exported symbol from it.
- So this PR keeps the old symbol and adds the correctly named one next to it, with a note that the old one can be removed in the next major release.
- If you would rather rename it outright, or want a different deprecation note, tell me and I will change it.

On tests:

- The deprecated Fortran aliases have no test coverage today. The only Fortran tests are `precice.solverdummy.build.fortran` and `precice.solverdummy.run.*`, and they use the current API.
- Catching this kind of bug is really a symbol-level check rather than a functional test, which is what #1540 is about. So I did not add Fortran test infrastructure inside a bugfix PR.
- Happy to add either if you want it.

Checked locally on macOS 26.5, arm64, Clang 21, Boost 1.92, Eigen 5.0.1:

- both `precicef_set_tetrahedron` and `precicef_set_tetrahedron_` are exported
- full test suite passes, 1273/1273, including the six `solverdummy` Fortran tests

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [x] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite. (see above)
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html). (not breaking, this only adds a symbol)
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)
