### PR TITLE
Fix Boost linking of unit_test_framework and disallow static

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,9 +220,12 @@ if(POLICY CMP0167)
 endif()
 
 option(Boost_USE_STATIC_LIBS "Force BoostConfig.cmake to find static libraries." OFF)
-find_package(Boost 1.83.0 REQUIRED CONFIG
-  COMPONENTS log log_setup program_options thread unit_test_framework
-  )
+set(_precice_boost_components log log_setup program_options thread)
+if(BUILD_TESTING)
+  list(APPEND _precice_boost_components unit_test_framework)
+endif()
+find_package(Boost 1.83.0 REQUIRED CONFIG COMPONENTS ${_precice_boost_components})
+unset(_precice_boost_components)
 mark_as_advanced(Boost_INCLUDE_DIR Boost_LOG_LIBRARY_RELEASE Boost_LOG_SETUP_LIBRARY_RELEASE Boost_PROGRAM_OPTIONS_LIBRARY_RELEASE Boost_SYSTEM_LIBRARY_RELEASE Boost_THREAD_LIBRARY_RELEASE Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE)
 mark_as_advanced(Boost_INCLUDE_DIR Boost_LOG_LIBRARY_DEBUG Boost_LOG_SETUP_LIBRARY_DEBUG Boost_PROGRAM_OPTIONS_LIBRARY_DEBUG Boost_SYSTEM_LIBRARY_DEBUG Boost_THREAD_LIBRARY_DEBUG Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG)
 message(STATUS "Found Boost ${Boost_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,14 +427,16 @@ endif()
 
 
 # Setup Boost
-target_compile_definitions(preciceCore PUBLIC BOOST_ALL_DYN_LINK BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
+target_compile_definitions(preciceCore PUBLIC BOOST_ASIO_ENABLE_OLD_SERVICES BOOST_GEOMETRY_DISABLE_DEPRECATED_03_WARNING)
+if(NOT Boost_USE_STATIC_LIBS)
+  target_compile_definitions(preciceCore PUBLIC BOOST_ALL_DYN_LINK)
+endif()
 target_link_libraries(preciceCore PUBLIC
   Boost::boost
   Boost::log
   Boost::log_setup
   Boost::program_options
   Boost::thread
-  Boost::unit_test_framework
   )
 if(UNIX OR APPLE OR MINGW)
   target_compile_definitions(preciceCore PUBLIC _GNU_SOURCE)
@@ -680,6 +682,7 @@ IF (BUILD_TESTING)
   target_link_libraries(testprecice
     PRIVATE
     preciceCore
+    Boost::unit_test_framework
     )
   set_target_properties(testprecice PROPERTIES
     CXX_STANDARD ${PRECICE_CXX_STANDARD}


### PR DESCRIPTION
…nking unit_test_framework to testprecice

## Main changes of this PR

1. Raise error when Boost_USE_STATIC_LIBS is ON.
2. Link Boost::unit_test_framework into testprecice target, not into preciceCore.

## Motivation and additional information
closes #2596

## Author's checklist

* [x] I used the [`pre-commit` hook](https://precice.org/dev-docs-dev-tooling.html#setting-up-pre-commit) to prevent dirty commits and used `pre-commit run --all` to format old commits.
* [ ] I added a changelog file with `make changelog` if there are user-observable changes since the last release.
* [ ] I added a test to cover the proposed changes in our test suite.
* [ ] For breaking changes: I documented the changes in the appropriate [porting guide](https://precice.org/couple-your-code-porting-overview.html).
* [x] I stuck to C++17 features.
* [x] I stuck to CMake version 3.22.1.
* [x] I squashed / am about to squash all commits that should be seen as one.
* [ ] I ran the systemtests by adding the label `trigger-system-tests` (may be skipped if minor change)

## Reviewers' checklist

<!-- Tag people next to each point and add points for specific questions -->

* [ ] Does the changelog entry make sense? Is it formatted correctly?
* [ ] Do you understand the code changes?

<!-- add more questions/tasks if necessary -->
